### PR TITLE
lint CI; block direct commits to main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: no-commit-to-branch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: detect-private-key
       - id: debug-statements
+      - id: no-commit-to-branch
 
   - repo: https://github.com/PyCQA/isort
     rev: 7.0.0


### PR DESCRIPTION
Adds GitHub Actions lint job (runs pre-commit on PRs + main pushes) and a no-commit-to-branch hook locally.