### PR TITLE
runner: on_sample_scored callback

### DIFF
--- a/sgl_eval/runner.py
+++ b/sgl_eval/runner.py
@@ -35,6 +35,9 @@ from sgl_eval.types import Example, ExampleResult, RunResult, Sample
 TickFn = Callable[[int, float], None]
 SampleFn = Callable[..., Sample]
 ScoreOneFn = Callable[[Example, Sample], Tuple[float, Optional[str]]]
+# Called once per (example, repeat) immediately after scoring, on whatever
+# thread completed the future. Implementations must be thread-safe.
+OnSampleScoredFn = Callable[[Example, int, Sample, float, Optional[str]], None]
 
 
 def run_examples(
@@ -46,6 +49,7 @@ def run_examples(
     n_repeats: int = 1,
     aggregate_fn: Optional[Callable[[List[ExampleResult]], Dict[str, float]]] = None,
     progress: bool = True,
+    on_sample_scored: Optional[OnSampleScoredFn] = None,
 ) -> RunResult:
     debug_serial = os.getenv("SGL_EVAL_DEBUG") == "1"
     total_samples = len(examples) * max(n_repeats, 1)
@@ -75,6 +79,7 @@ def run_examples(
             ex_by_id=ex_by_id,
             workers=workers,
             tick=tick,
+            on_sample_scored=on_sample_scored,
         )
         results = _assemble_results(examples, samples_by_ex, scores_by_ex, extracted_by_ex)
     finally:
@@ -120,6 +125,7 @@ def _run_sample_score_phase(
     ex_by_id: Dict[str, Example],
     workers: int,
     tick: TickFn,
+    on_sample_scored: Optional[OnSampleScoredFn],
 ) -> None:
     if workers == 1:
         for ex, rep in tasks:
@@ -128,6 +134,8 @@ def _run_sample_score_phase(
             score, extracted = score_one_fn(ex, sample)
             scores_by_ex[ex.id][rep] = score
             extracted_by_ex[ex.id][rep] = extracted
+            if on_sample_scored is not None:
+                on_sample_scored(ex, rep, sample, score, extracted)
             tick(rep, score)
         return
     with ThreadPoolExecutor(max_workers=workers) as pool:
@@ -140,6 +148,8 @@ def _run_sample_score_phase(
             score, extracted = score_one_fn(ex, sample)
             scores_by_ex[ex_id][rep] = score
             extracted_by_ex[ex_id][rep] = extracted
+            if on_sample_scored is not None:
+                on_sample_scored(ex, rep, sample, score, extracted)
             tick(rep, score)
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,10 +2,12 @@
 
 Verifies the runner: parallel sample_fn, inline per-sample score_one_fn,
 default mean aggregator, completion-token tally, n_repeats * num_examples
-parallelism.
+parallelism, on_sample_scored callback contract.
 """
 
 from __future__ import annotations
+
+import threading
 
 from sgl_eval.runner import run_examples
 from sgl_eval.types import Example, Sample
@@ -79,3 +81,35 @@ def test_runner_n_repeats_flat_concurrency():
     assert result.n_repeats == 8
     assert len(submitted) == 4 * 8
     assert result.total_completion_tokens == 4 * 8
+
+
+def test_runner_invokes_on_sample_scored():
+    """Callback fires once per ``(example, repeat)`` with the scored
+    sample, score, and extracted answer -- this is the streaming-dump hook."""
+    examples = [Example(id=str(i), inputs={}, target=str(i)) for i in range(3)]
+
+    received = []
+    lock = threading.Lock()
+
+    def cb(ex, rep, sample, score, extracted):
+        with lock:
+            received.append((ex.id, rep, sample.text, score, extracted))
+
+    result = run_examples(
+        "dummy",
+        examples,
+        _fake_sample_fn,
+        _all_correct_score_one_fn,
+        num_threads=4,
+        n_repeats=2,
+        progress=False,
+        on_sample_scored=cb,
+    )
+
+    assert len(received) == 3 * 2
+    assert {(eid, rep) for eid, rep, _, _, _ in received} == {
+        (str(i), r) for i in range(3) for r in range(2)
+    }
+    assert all(s == 1.0 for _, _, _, s, _ in received)
+    assert all(extracted == str(eid) for eid, _, _, _, extracted in received)
+    assert result.aggregate["score"] == 1.0


### PR DESCRIPTION
Per-sample hook fired right after scoring; backbone for streaming prediction dump.