### PR TITLE
predictions: streaming JSONL writer

### DIFF
--- a/sgl_eval/evals/_predictions.py
+++ b/sgl_eval/evals/_predictions.py
@@ -4,11 +4,19 @@ Both ``MathEvaluator.eval_single`` (during sampling) and ``MathMetrics.update``
 (during aggregation) consume dicts with the same field set. We mint that dict
 once here and reuse it on both sides so the data we feed into vendored code
 matches the contract upstream's own ``inference/generate.py`` would produce.
+
+``PredictionsWriter`` is the streaming on-disk counterpart: it sits behind
+``runner.run_examples``' ``on_sample_scored`` hook and appends one NS-shape
+JSON line per scored sample to ``output-rs{rep}.jsonl``, flushing after every
+write so a Ctrl-C / crash leaves all already-scored samples on disk.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import json
+import threading
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 from sgl_eval.types import Example, Sample
 
@@ -30,3 +38,52 @@ def sample_to_pred(sample: Sample, example: Example) -> Dict[str, Any]:
     if sample.generation_end_time is not None:
         pred["generation_end_time"] = sample.generation_end_time
     return pred
+
+
+class PredictionsWriter:
+    """Streaming JSONL writer for NS-shape prediction records.
+
+    Opens ``output-rs{i}.jsonl`` for each repeat under ``out_dir``, appends
+    one JSON line per scored sample (in thread-pool completion order, not
+    dataset order), and flushes after every line. Thread-safe across the
+    runner's parallel workers via a single lock -- contention is negligible
+    because writing a few hundred bytes is cheap relative to LLM round-trip.
+    """
+
+    def __init__(self, out_dir: Path, n_repeats: int) -> None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        self._files = [
+            (out_dir / f"output-rs{i}.jsonl").open("w", encoding="utf-8") for i in range(n_repeats)
+        ]
+        self._lock = threading.Lock()
+
+    def __call__(
+        self,
+        ex: Example,
+        rep: int,
+        sample: Sample,
+        score: float,
+        extracted: Optional[str],
+    ) -> None:
+        pred: Dict[str, Any] = {
+            "generation": sample.text,
+            **sample_to_pred(sample, ex),
+            "predicted_answer": extracted,
+            "symbolic_correct": bool(score),
+        }
+        line = json.dumps(pred, ensure_ascii=False) + "\n"
+        with self._lock:
+            f = self._files[rep]
+            f.write(line)
+            f.flush()
+
+    def close(self) -> None:
+        for f in self._files:
+            if not f.closed:
+                f.close()
+
+    def __enter__(self) -> "PredictionsWriter":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()

--- a/sgl_eval/evals/_predictions.py
+++ b/sgl_eval/evals/_predictions.py
@@ -24,7 +24,11 @@ from sgl_eval.types import Example, Sample
 def sample_to_pred(sample: Sample, example: Example) -> Dict[str, Any]:
     completion = sample.completion_tokens or 0
     reasoning = sample.reasoning_tokens or 0
+    # ``id`` mirrors NS upstream's native row shape (e.g. aime24/test.txt
+    # ships ``{"id": "aime24-0", ...}``) and keeps a stable per-problem
+    # key for partial-resume / sub-sampling on top of the JSONL dumps.
     pred: Dict[str, Any] = {
+        "id": example.id,
         "expected_answer": str(example.target),
         "num_generated_tokens": completion,
         "num_reasoning_tokens": reasoning,

--- a/sgl_eval/runner.py
+++ b/sgl_eval/runner.py
@@ -35,6 +35,9 @@ from sgl_eval.types import Example, ExampleResult, RunResult, Sample
 TickFn = Callable[[int, float], None]
 SampleFn = Callable[..., Sample]
 ScoreOneFn = Callable[[Example, Sample], Tuple[float, Optional[str]]]
+# Called once per (example, repeat) immediately after scoring, on whatever
+# thread completed the future. Implementations must be thread-safe.
+OnSampleScoredFn = Callable[[Example, int, Sample, float, Optional[str]], None]
 
 
 def run_examples(
@@ -46,6 +49,7 @@ def run_examples(
     n_repeats: int = 1,
     aggregate_fn: Optional[Callable[[List[ExampleResult]], Dict[str, float]]] = None,
     progress: bool = True,
+    on_sample_scored: Optional[OnSampleScoredFn] = None,
 ) -> RunResult:
     debug_serial = os.getenv("SGL_EVAL_DEBUG") == "1"
     total_samples = len(examples) * max(n_repeats, 1)
@@ -75,6 +79,7 @@ def run_examples(
             ex_by_id=ex_by_id,
             workers=workers,
             tick=tick,
+            on_sample_scored=on_sample_scored,
         )
         results = _assemble_results(examples, samples_by_ex, scores_by_ex, extracted_by_ex)
     finally:
@@ -120,6 +125,7 @@ def _run_sample_score_phase(
     ex_by_id: Dict[str, Example],
     workers: int,
     tick: TickFn,
+    on_sample_scored: Optional[OnSampleScoredFn],
 ) -> None:
     if workers == 1:
         for ex, rep in tasks:
@@ -128,6 +134,8 @@ def _run_sample_score_phase(
             score, extracted = score_one_fn(ex, sample)
             scores_by_ex[ex.id][rep] = score
             extracted_by_ex[ex.id][rep] = extracted
+            if on_sample_scored is not None:
+                on_sample_scored(ex, rep, sample, score, extracted)
             tick(rep, score)
         return
     with ThreadPoolExecutor(max_workers=workers) as pool:
@@ -140,6 +148,8 @@ def _run_sample_score_phase(
             score, extracted = score_one_fn(ex, sample)
             scores_by_ex[ex_id][rep] = score
             extracted_by_ex[ex_id][rep] = extracted
+            if on_sample_scored is not None:
+                on_sample_scored(ex, rep, sample, score, extracted)
             tick(rep, score)
 
 

--- a/tests/test_predictions_writer.py
+++ b/tests/test_predictions_writer.py
@@ -1,0 +1,152 @@
+"""Streaming prediction-writer tests.
+
+Covers the three behaviors the runner depends on:
+  - per-repeat routing into ``output-rs{i}.jsonl``
+  - NS wire-shape fields on every line + every-line flush (crash recovery)
+  - thread safety: concurrent writes from the runner's worker pool don't
+    interleave bytes within a line and don't drop lines
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+from sgl_eval.evals._predictions import PredictionsWriter
+from sgl_eval.types import Example, Sample
+
+
+def _ex(i: int) -> Example:
+    return Example(id=str(i), inputs={"problem": f"q{i}"}, target=str(i))
+
+
+def _sample(text: str = "ans", completion: int = 10) -> Sample:
+    return Sample(text=text, completion_tokens=completion, prompt_tokens=5, finish_reason="stop")
+
+
+def test_writes_ns_shape_record(tmp_path: Path) -> None:
+    with PredictionsWriter(tmp_path, n_repeats=2) as w:
+        w(_ex(0), 0, _sample("response-A"), 1.0, "42")
+
+    rows = [json.loads(line) for line in (tmp_path / "output-rs0.jsonl").read_text().splitlines()]
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["generation"] == "response-A"
+    assert r["expected_answer"] == "0"
+    assert r["problem"] == "q0"
+    assert r["predicted_answer"] == "42"
+    assert r["symbolic_correct"] is True
+    assert r["num_generated_tokens"] == 10
+    assert r["num_answer_tokens"] == 10
+    assert r["num_reasoning_tokens"] == 0
+
+    # The other repeat file is created but stays empty.
+    assert (tmp_path / "output-rs1.jsonl").exists()
+    assert (tmp_path / "output-rs1.jsonl").read_text() == ""
+
+
+def test_routes_per_repeat(tmp_path: Path) -> None:
+    with PredictionsWriter(tmp_path, n_repeats=3) as w:
+        w(_ex(0), 1, _sample("rep1"), 0.0, None)
+        w(_ex(0), 2, _sample("rep2"), 1.0, "ans2")
+        w(_ex(1), 0, _sample("rep0"), 1.0, "ans0")
+
+    files = {r: (tmp_path / f"output-rs{r}.jsonl").read_text().splitlines() for r in range(3)}
+
+    assert len(files[0]) == 1 and json.loads(files[0][0])["generation"] == "rep0"
+    assert len(files[1]) == 1 and json.loads(files[1][0])["generation"] == "rep1"
+    assert len(files[2]) == 1 and json.loads(files[2][0])["generation"] == "rep2"
+
+    # ``predicted_answer=None`` and ``symbolic_correct=False`` survive serialization.
+    rep1 = json.loads(files[1][0])
+    assert rep1["predicted_answer"] is None
+    assert rep1["symbolic_correct"] is False
+
+
+def test_every_line_flush_visible_before_close(tmp_path: Path) -> None:
+    """Mid-run readers must see already-scored samples on disk -- this is
+    the whole point of the streaming write (Ctrl-C / crash recovery)."""
+    w = PredictionsWriter(tmp_path, n_repeats=1)
+    try:
+        w(_ex(0), 0, _sample("first"), 1.0, "a")
+        # Read while writer is still open.
+        content = (tmp_path / "output-rs0.jsonl").read_text()
+        assert content.endswith("\n")
+        rows = [json.loads(line) for line in content.splitlines()]
+        assert len(rows) == 1 and rows[0]["generation"] == "first"
+
+        w(_ex(1), 0, _sample("second"), 0.0, None)
+        rows = [
+            json.loads(line) for line in (tmp_path / "output-rs0.jsonl").read_text().splitlines()
+        ]
+        assert [r["generation"] for r in rows] == ["first", "second"]
+    finally:
+        w.close()
+
+
+def test_close_is_idempotent(tmp_path: Path) -> None:
+    w = PredictionsWriter(tmp_path, n_repeats=2)
+    w.close()
+    w.close()  # second close must not raise
+
+
+def test_thread_safety_no_interleaving_no_drops(tmp_path: Path) -> None:
+    """Concurrent writes from many threads: every line stays a valid JSON
+    object (no byte-level interleaving) and the total line count matches."""
+    n_repeats = 4
+    n_threads = 16
+    n_writes_per_thread = 64
+
+    with PredictionsWriter(tmp_path, n_repeats=n_repeats) as w:
+
+        def worker(tid: int) -> None:
+            for i in range(n_writes_per_thread):
+                rep = (tid + i) % n_repeats
+                ex = _ex(tid * 1000 + i)
+                w(ex, rep, _sample(f"t{tid}-{i}"), 1.0, "x")
+
+        threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    total_lines = 0
+    seen_generations: set[str] = set()
+    for r in range(n_repeats):
+        lines = (tmp_path / f"output-rs{r}.jsonl").read_text().splitlines()
+        for line in lines:
+            obj = json.loads(line)  # interleaving would corrupt JSON -> raise
+            seen_generations.add(obj["generation"])
+        total_lines += len(lines)
+
+    expected_total = n_threads * n_writes_per_thread
+    assert total_lines == expected_total
+    assert len(seen_generations) == expected_total  # no duplicates, no drops
+
+
+def test_no_writer_path_runner_still_works() -> None:
+    """``on_sample_scored=None`` -- the path the CLI takes when
+    ``--no-dump-predictions`` is set. Runner must complete normally."""
+    from sgl_eval.runner import run_examples
+
+    examples = [Example(id=str(i), inputs={}, target=str(i)) for i in range(4)]
+
+    def sample_fn(ex: Example, _rep: int) -> Sample:
+        return Sample(text="x", completion_tokens=1, finish_reason="stop")
+
+    def score_one(ex: Example, _sample: Sample):
+        return 1.0, "ok"
+
+    result = run_examples(
+        "dummy",
+        examples,
+        sample_fn,
+        score_one,
+        num_threads=2,
+        n_repeats=1,
+        progress=False,
+        on_sample_scored=None,
+    )
+    assert result.aggregate["score"] == 1.0

--- a/tests/test_predictions_writer.py
+++ b/tests/test_predictions_writer.py
@@ -32,6 +32,7 @@ def test_writes_ns_shape_record(tmp_path: Path) -> None:
     rows = [json.loads(line) for line in (tmp_path / "output-rs0.jsonl").read_text().splitlines()]
     assert len(rows) == 1
     r = rows[0]
+    assert r["id"] == "0"
     assert r["generation"] == "response-A"
     assert r["expected_answer"] == "0"
     assert r["problem"] == "q0"
@@ -83,6 +84,17 @@ def test_every_line_flush_visible_before_close(tmp_path: Path) -> None:
         assert [r["generation"] for r in rows] == ["first", "second"]
     finally:
         w.close()
+
+
+def test_id_preserves_dataset_native_value(tmp_path: Path) -> None:
+    """``Example.id`` is set by the loader from the dataset row's native
+    ``id`` field (e.g. ``aime24-0``). It must round-trip into the JSONL
+    so partial-resume / sub-sampling can dedupe on it."""
+    native = Example(id="aime24-7", inputs={"problem": "P"}, target="42")
+    with PredictionsWriter(tmp_path, n_repeats=1) as w:
+        w(native, 0, _sample("ans"), 1.0, "42")
+    row = json.loads((tmp_path / "output-rs0.jsonl").read_text().splitlines()[0])
+    assert row["id"] == "aime24-7"
 
 
 def test_close_is_idempotent(tmp_path: Path) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,10 +2,12 @@
 
 Verifies the runner: parallel sample_fn, inline per-sample score_one_fn,
 default mean aggregator, completion-token tally, n_repeats * num_examples
-parallelism.
+parallelism, on_sample_scored callback contract.
 """
 
 from __future__ import annotations
+
+import threading
 
 from sgl_eval.runner import run_examples
 from sgl_eval.types import Example, Sample
@@ -79,3 +81,35 @@ def test_runner_n_repeats_flat_concurrency():
     assert result.n_repeats == 8
     assert len(submitted) == 4 * 8
     assert result.total_completion_tokens == 4 * 8
+
+
+def test_runner_invokes_on_sample_scored():
+    """Callback fires once per ``(example, repeat)`` with the scored
+    sample, score, and extracted answer -- this is the streaming-dump hook."""
+    examples = [Example(id=str(i), inputs={}, target=str(i)) for i in range(3)]
+
+    received = []
+    lock = threading.Lock()
+
+    def cb(ex, rep, sample, score, extracted):
+        with lock:
+            received.append((ex.id, rep, sample.text, score, extracted))
+
+    result = run_examples(
+        "dummy",
+        examples,
+        _fake_sample_fn,
+        _all_correct_score_one_fn,
+        num_threads=4,
+        n_repeats=2,
+        progress=False,
+        on_sample_scored=cb,
+    )
+
+    assert len(received) == 3 * 2
+    assert {(eid, rep) for eid, rep, _, _, _ in received} == {
+        (str(i), r) for i in range(3) for r in range(2)
+    }
+    assert all(s == 1.0 for _, _, _, s, _ in received)
+    assert all(extracted == str(eid) for eid, _, _, _, extracted in received)
+    assert result.aggregate["score"] == 1.0


### PR DESCRIPTION
Per-repeat `output-rs{i}.jsonl`, per-line flush, thread-safe. Stacked on #4.