### PR TITLE
Ctrl-C kills in-flight requests; dump partial metrics

### DIFF
--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -14,7 +14,6 @@ import dataclasses
 import os
 import signal
 import sys
-import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -151,12 +150,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     inputs = resolve_run_inputs(args, get)
     spec = get(inputs.benchmark)
 
-    aborted = threading.Event()
     sampler = ChatCompletionSampler(
-        base_url=inputs.base_url,
-        model=inputs.model,
-        api_key=args.api_key,
-        abort_event=aborted,
+        base_url=inputs.base_url, model=inputs.model, api_key=args.api_key
     )
     _warn_if_greedy_repeats(inputs.n_repeats, inputs.gen)
 
@@ -166,7 +161,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     print(f"Run directory: {run_dir}")
 
     writer = PredictionsWriter(run_dir, inputs.n_repeats) if args.dump_predictions else None
-    prev_sigint = signal.signal(signal.SIGINT, _make_sigint_handler(sampler, aborted))
+    prev_sigint = signal.signal(signal.SIGINT, _make_sigint_handler(sampler))
     try:
         result = spec.run(
             sampler=sampler,
@@ -181,12 +176,11 @@ def cmd_run(args: argparse.Namespace) -> int:
             writer.close()
         signal.signal(signal.SIGINT, prev_sigint)
 
-    is_partial = aborted.is_set()
     print(format_summary(result))
     run_meta = _build_run_meta(
         args=args, sampler=sampler, gen=inputs.gen, stamp=stamp, base_url=inputs.base_url
     )
-    if is_partial:
+    if result.partial:
         run_meta["partial"] = True
         run_meta["completed_examples"] = len(result.per_example)
     preset_block = make_run_meta_block(args, inputs.preset)
@@ -196,18 +190,21 @@ def cmd_run(args: argparse.Namespace) -> int:
     print(f"\nMetrics: {metrics_path}")
     if writer is not None:
         print(f"Predictions: {run_dir}  ({inputs.n_repeats} jsonl file(s))")
-    if is_partial:
+    if result.partial:
         print(
             f"\n[partial] aborted after {len(result.per_example)} example(s); "
             "expected_vs_actual skipped (partial runs aren't comparable to baselines).",
             file=sys.stderr,
         )
-        return 130
-    print_expected_vs_actual(result, inputs.preset)
-    return 0
+    else:
+        print_expected_vs_actual(result, inputs.preset)
+    # Exit code 130 if the user pressed Ctrl-C, even when every example
+    # happened to finish before the abort propagated -- their intent was
+    # to bail, so respect it.
+    return 130 if sampler.aborted else 0
 
 
-def _make_sigint_handler(sampler: ChatCompletionSampler, aborted: threading.Event) -> Any:
+def _make_sigint_handler(sampler: ChatCompletionSampler) -> Any:
     """First Ctrl-C: kill in-flight requests and flag for partial dump.
     Second Ctrl-C: hard-exit (escape hatch if partial cleanup hangs)."""
     state = {"count": 0}
@@ -223,7 +220,6 @@ def _make_sigint_handler(sampler: ChatCompletionSampler, aborted: threading.Even
             file=sys.stderr,
         )
         sampler.abort()
-        aborted.set()
 
     return _handler
 

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -193,6 +193,11 @@ def cmd_run(args: argparse.Namespace) -> int:
         # user how much the partial run is worth.
         run_meta["score_lower_bound"] = worst
         run_meta["score_upper_bound"] = best
+        if result.n_repeats > 1:
+            full, part, dropped = _example_breakdown(result)
+            run_meta["examples_full"] = full
+            run_meta["examples_partial"] = part
+            run_meta["examples_dropped"] = dropped
     preset_block = make_run_meta_block(args, inputs.preset)
     if preset_block:
         run_meta["preset"] = preset_block
@@ -208,6 +213,21 @@ def cmd_run(args: argparse.Namespace) -> int:
     # happened to finish before the abort propagated -- their intent was
     # to bail, so respect it.
     return 130 if sampler.aborted else 0
+
+
+def _example_breakdown(result: Any) -> tuple[int, int, int]:
+    """Bucket examples into (full, partial, dropped) for n_repeats > 1.
+
+    full     = every rep completed (clean signal)
+    partial  = some reps completed; aggregator pads them with the last
+               sample, so these examples actively distort metrics
+    dropped  = no reps completed; not in per_example, just absent
+    """
+    n_repeats = result.n_repeats
+    full = sum(1 for r in result.per_example if len(r.samples) == n_repeats)
+    part = sum(1 for r in result.per_example if 0 < len(r.samples) < n_repeats)
+    dropped = result.planned_examples - len(result.per_example)
+    return full, part, dropped
 
 
 def _score_bounds(
@@ -231,31 +251,43 @@ def _format_partial_summary(result: Any) -> str:
 
     Progress line uses sample-level counts when ``n_repeats > 1`` (per-
     example pad-with-last makes pure example counts misleading there);
-    example-level otherwise (equivalent). Score bounds are always sample-
-    level so they're comparable across n_repeats settings.
+    example-level otherwise (equivalent). For ``n_repeats > 1`` we also
+    surface the full / partial / dropped example breakdown -- ``partial``
+    examples are the ones whose pad-with-last actively skews metrics,
+    so the count matters for trusting the score bounds.
+
+    Score bounds are always sample-level so they're comparable across
+    n_repeats settings.
     """
     completed_samples = sum(len(r.samples) for r in result.per_example)
     planned_samples = result.planned_examples * result.n_repeats
     unfinished = planned_samples - completed_samples
     n_correct = sum(score for r in result.per_example for score in r.scores)
     worst, best = _score_bounds(n_correct, completed_samples, planned_samples)
+    lines = []
     if result.n_repeats > 1:
-        progress = (
-            f"{completed_samples} / {planned_samples} samples completed "
+        full, part, dropped = _example_breakdown(result)
+        lines.append(
+            f"[partial] {completed_samples} / {planned_samples} samples completed "
             f"({unfinished} unfinished, n_repeats={result.n_repeats})"
         )
+        lines.append(
+            f"[partial] examples: {full} full / {part} partial / {dropped} dropped "
+            f"({result.planned_examples} planned)"
+        )
     else:
-        progress = (
-            f"{len(result.per_example)} / {result.planned_examples} "
+        lines.append(
+            f"[partial] {len(result.per_example)} / {result.planned_examples} "
             f"examples completed ({unfinished} unfinished)"
         )
-    return (
-        f"\n[partial] {progress}\n"
+    lines.append(
         f"[partial] score range: [{worst:.2%}, {best:.2%}] "
-        "(missing samples assumed all-wrong / all-correct)\n"
-        "[partial] expected_vs_actual skipped (partial runs aren't "
-        "comparable to baselines)."
+        "(missing samples assumed all-wrong / all-correct)"
     )
+    lines.append(
+        "[partial] expected_vs_actual skipped (partial runs aren't " "comparable to baselines)."
+    )
+    return "\n" + "\n".join(lines)
 
 
 def _make_sigint_handler(sampler: ChatCompletionSampler) -> Any:

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -181,8 +181,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         args=args, sampler=sampler, gen=inputs.gen, stamp=stamp, base_url=inputs.base_url
     )
     if result.partial:
+        completed_samples = sum(len(r.samples) for r in result.per_example)
         run_meta["partial"] = True
-        run_meta["completed_examples"] = len(result.per_example)
+        run_meta["planned_examples"] = result.planned_examples
+        run_meta["completed_samples"] = completed_samples
     preset_block = make_run_meta_block(args, inputs.preset)
     if preset_block:
         run_meta["preset"] = preset_block
@@ -191,17 +193,32 @@ def cmd_run(args: argparse.Namespace) -> int:
     if writer is not None:
         print(f"Predictions: {run_dir}  ({inputs.n_repeats} jsonl file(s))")
     if result.partial:
-        print(
-            f"\n[partial] aborted after {len(result.per_example)} example(s); "
-            "expected_vs_actual skipped (partial runs aren't comparable to baselines).",
-            file=sys.stderr,
-        )
+        print(_format_partial_summary(result), file=sys.stderr)
     else:
         print_expected_vs_actual(result, inputs.preset)
     # Exit code 130 if the user pressed Ctrl-C, even when every example
     # happened to finish before the abort propagated -- their intent was
     # to bail, so respect it.
     return 130 if sampler.aborted else 0
+
+
+def _format_partial_summary(result: Any) -> str:
+    """``[partial]`` footer surfacing how much got done. Uses sample-level
+    counts when ``n_repeats > 1`` (per-example pad-with-last makes pure
+    example counts misleading there); example-level otherwise (equivalent)."""
+    completed_samples = sum(len(r.samples) for r in result.per_example)
+    planned_samples = result.planned_examples * result.n_repeats
+    unfinished = planned_samples - completed_samples
+    skipped = "expected_vs_actual skipped (partial runs aren't comparable to baselines)."
+    if result.n_repeats > 1:
+        return (
+            f"\n[partial] {completed_samples} / {planned_samples} samples completed "
+            f"({unfinished} unfinished, n_repeats={result.n_repeats}); {skipped}"
+        )
+    return (
+        f"\n[partial] {len(result.per_example)} / {result.planned_examples} "
+        f"examples completed ({unfinished} unfinished); {skipped}"
+    )
 
 
 def _make_sigint_handler(sampler: ChatCompletionSampler) -> Any:

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -182,9 +182,17 @@ def cmd_run(args: argparse.Namespace) -> int:
     )
     if result.partial:
         completed_samples = sum(len(r.samples) for r in result.per_example)
+        planned_samples = result.planned_examples * result.n_repeats
+        n_correct = sum(score for r in result.per_example for score in r.scores)
+        worst, best = _score_bounds(n_correct, completed_samples, planned_samples)
         run_meta["partial"] = True
         run_meta["planned_examples"] = result.planned_examples
         run_meta["completed_samples"] = completed_samples
+        # Sample-level accuracy bounds: missing samples treated as all-wrong
+        # (worst) or all-correct (best). Metric-agnostic and tight; tells the
+        # user how much the partial run is worth.
+        run_meta["score_lower_bound"] = worst
+        run_meta["score_upper_bound"] = best
     preset_block = make_run_meta_block(args, inputs.preset)
     if preset_block:
         run_meta["preset"] = preset_block
@@ -202,22 +210,51 @@ def cmd_run(args: argparse.Namespace) -> int:
     return 130 if sampler.aborted else 0
 
 
+def _score_bounds(
+    n_correct: float, completed_samples: int, planned_samples: int
+) -> tuple[float, float]:
+    """Sample-level accuracy bounds for a partial run.
+
+    Lower bound: missing samples are all wrong. Upper bound: missing
+    samples are all correct. Metric-agnostic -- whatever the aggregator
+    does, accuracy must fall in [worst, best]. Returns (worst, best) in
+    [0.0, 1.0].
+    """
+    if planned_samples <= 0:
+        return 0.0, 0.0
+    n_missing = planned_samples - completed_samples
+    return n_correct / planned_samples, (n_correct + n_missing) / planned_samples
+
+
 def _format_partial_summary(result: Any) -> str:
-    """``[partial]`` footer surfacing how much got done. Uses sample-level
-    counts when ``n_repeats > 1`` (per-example pad-with-last makes pure
-    example counts misleading there); example-level otherwise (equivalent)."""
+    """``[partial]`` footer: how much got done + worst/best score bounds.
+
+    Progress line uses sample-level counts when ``n_repeats > 1`` (per-
+    example pad-with-last makes pure example counts misleading there);
+    example-level otherwise (equivalent). Score bounds are always sample-
+    level so they're comparable across n_repeats settings.
+    """
     completed_samples = sum(len(r.samples) for r in result.per_example)
     planned_samples = result.planned_examples * result.n_repeats
     unfinished = planned_samples - completed_samples
-    skipped = "expected_vs_actual skipped (partial runs aren't comparable to baselines)."
+    n_correct = sum(score for r in result.per_example for score in r.scores)
+    worst, best = _score_bounds(n_correct, completed_samples, planned_samples)
     if result.n_repeats > 1:
-        return (
-            f"\n[partial] {completed_samples} / {planned_samples} samples completed "
-            f"({unfinished} unfinished, n_repeats={result.n_repeats}); {skipped}"
+        progress = (
+            f"{completed_samples} / {planned_samples} samples completed "
+            f"({unfinished} unfinished, n_repeats={result.n_repeats})"
+        )
+    else:
+        progress = (
+            f"{len(result.per_example)} / {result.planned_examples} "
+            f"examples completed ({unfinished} unfinished)"
         )
     return (
-        f"\n[partial] {len(result.per_example)} / {result.planned_examples} "
-        f"examples completed ({unfinished} unfinished); {skipped}"
+        f"\n[partial] {progress}\n"
+        f"[partial] score range: [{worst:.2%}, {best:.2%}] "
+        "(missing samples assumed all-wrong / all-correct)\n"
+        "[partial] expected_vs_actual skipped (partial runs aren't "
+        "comparable to baselines)."
     )
 
 

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -180,24 +180,20 @@ def cmd_run(args: argparse.Namespace) -> int:
     run_meta = _build_run_meta(
         args=args, sampler=sampler, gen=inputs.gen, stamp=stamp, base_url=inputs.base_url
     )
-    if result.partial:
-        completed_samples = sum(len(r.samples) for r in result.per_example)
-        planned_samples = result.planned_examples * result.n_repeats
-        n_correct = sum(score for r in result.per_example for score in r.scores)
-        worst, best = _score_bounds(n_correct, completed_samples, planned_samples)
+    stats = _partial_stats(result) if result.partial else None
+    if stats is not None:
         run_meta["partial"] = True
         run_meta["planned_examples"] = result.planned_examples
-        run_meta["completed_samples"] = completed_samples
+        run_meta["completed_samples"] = stats.completed_samples
         # Sample-level accuracy bounds: missing samples treated as all-wrong
         # (worst) or all-correct (best). Metric-agnostic and tight; tells the
         # user how much the partial run is worth.
-        run_meta["score_lower_bound"] = worst
-        run_meta["score_upper_bound"] = best
+        run_meta["score_lower_bound"] = stats.worst
+        run_meta["score_upper_bound"] = stats.best
         if result.n_repeats > 1:
-            full, part, dropped = _example_breakdown(result)
-            run_meta["examples_full"] = full
-            run_meta["examples_partial"] = part
-            run_meta["examples_dropped"] = dropped
+            run_meta["examples_full"] = stats.full
+            run_meta["examples_partial"] = stats.part
+            run_meta["examples_dropped"] = stats.dropped
     preset_block = make_run_meta_block(args, inputs.preset)
     if preset_block:
         run_meta["preset"] = preset_block
@@ -205,8 +201,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     print(f"\nMetrics: {metrics_path}")
     if writer is not None:
         print(f"Predictions: {run_dir}  ({inputs.n_repeats} jsonl file(s))")
-    if result.partial:
-        print(_format_partial_summary(result), file=sys.stderr)
+    if stats is not None:
+        print(_format_partial_summary(result, stats), file=sys.stderr)
     else:
         print_expected_vs_actual(result, inputs.preset)
     # Exit code 130 if the user pressed Ctrl-C, even when every example
@@ -215,19 +211,53 @@ def cmd_run(args: argparse.Namespace) -> int:
     return 130 if sampler.aborted else 0
 
 
-def _example_breakdown(result: Any) -> tuple[int, int, int]:
-    """Bucket examples into (full, partial, dropped) for n_repeats > 1.
+@dataclasses.dataclass(frozen=True)
+class _PartialStats:
+    """Single-walk snapshot of ``per_example`` for partial-run reporting.
 
-    full     = every rep completed (clean signal)
-    partial  = some reps completed; aggregator pads them with the last
-               sample, so these examples actively distort metrics
-    dropped  = no reps completed; not in per_example, just absent
+    ``full / part / dropped`` partition examples into clean signal
+    (every rep done), pad-distorted (some reps done -- aggregator's
+    pad-with-last fabricates the rest), and absent (no reps done,
+    not in ``per_example`` at all).
     """
+
+    completed_samples: int
+    planned_samples: int
+    unfinished_samples: int
+    worst: float
+    best: float
+    full: int
+    part: int
+    dropped: int
+
+
+def _partial_stats(result: Any) -> _PartialStats:
+    """Walk ``result.per_example`` once and bundle every count we need
+    to populate ``run_meta`` and the ``[partial]`` footer."""
     n_repeats = result.n_repeats
-    full = sum(1 for r in result.per_example if len(r.samples) == n_repeats)
-    part = sum(1 for r in result.per_example if 0 < len(r.samples) < n_repeats)
-    dropped = result.planned_examples - len(result.per_example)
-    return full, part, dropped
+    completed = 0
+    n_correct = 0.0
+    full = part = 0
+    for r in result.per_example:
+        k = len(r.samples)
+        completed += k
+        n_correct += sum(r.scores)
+        if k == n_repeats:
+            full += 1
+        elif k > 0:
+            part += 1
+    planned = result.planned_examples * n_repeats
+    worst, best = _score_bounds(n_correct, completed, planned)
+    return _PartialStats(
+        completed_samples=completed,
+        planned_samples=planned,
+        unfinished_samples=planned - completed,
+        worst=worst,
+        best=best,
+        full=full,
+        part=part,
+        dropped=result.planned_examples - len(result.per_example),
+    )
 
 
 def _score_bounds(
@@ -246,7 +276,7 @@ def _score_bounds(
     return n_correct / planned_samples, (n_correct + n_missing) / planned_samples
 
 
-def _format_partial_summary(result: Any) -> str:
+def _format_partial_summary(result: Any, stats: _PartialStats) -> str:
     """``[partial]`` footer: how much got done + worst/best score bounds.
 
     Progress line uses sample-level counts when ``n_repeats > 1`` (per-
@@ -259,33 +289,28 @@ def _format_partial_summary(result: Any) -> str:
     Score bounds are always sample-level so they're comparable across
     n_repeats settings.
     """
-    completed_samples = sum(len(r.samples) for r in result.per_example)
-    planned_samples = result.planned_examples * result.n_repeats
-    unfinished = planned_samples - completed_samples
-    n_correct = sum(score for r in result.per_example for score in r.scores)
-    worst, best = _score_bounds(n_correct, completed_samples, planned_samples)
     lines = []
     if result.n_repeats > 1:
-        full, part, dropped = _example_breakdown(result)
         lines.append(
-            f"[partial] {completed_samples} / {planned_samples} samples completed "
-            f"({unfinished} unfinished, n_repeats={result.n_repeats})"
+            f"[partial] {stats.completed_samples} / {stats.planned_samples} "
+            f"samples completed ({stats.unfinished_samples} unfinished, "
+            f"n_repeats={result.n_repeats})"
         )
         lines.append(
-            f"[partial] examples: {full} full / {part} partial / {dropped} dropped "
-            f"({result.planned_examples} planned)"
+            f"[partial] examples: {stats.full} full / {stats.part} partial / "
+            f"{stats.dropped} dropped ({result.planned_examples} planned)"
         )
     else:
         lines.append(
-            f"[partial] {len(result.per_example)} / {result.planned_examples} "
-            f"examples completed ({unfinished} unfinished)"
+            f"[partial] {stats.full + stats.part} / {result.planned_examples} "
+            f"examples completed ({stats.unfinished_samples} unfinished)"
         )
     lines.append(
-        f"[partial] score range: [{worst:.2%}, {best:.2%}] "
+        f"[partial] score range: [{stats.worst:.2%}, {stats.best:.2%}] "
         "(missing samples assumed all-wrong / all-correct)"
     )
     lines.append(
-        "[partial] expected_vs_actual skipped (partial runs aren't " "comparable to baselines)."
+        "[partial] expected_vs_actual skipped (partial runs aren't comparable to baselines)."
     )
     return "\n" + "\n".join(lines)
 
@@ -293,11 +318,12 @@ def _format_partial_summary(result: Any) -> str:
 def _make_sigint_handler(sampler: ChatCompletionSampler) -> Any:
     """First Ctrl-C: kill in-flight requests and flag for partial dump.
     Second Ctrl-C: hard-exit (escape hatch if partial cleanup hangs)."""
-    state = {"count": 0}
+    count = 0
 
     def _handler(_signum: int, _frame: Any) -> None:
-        state["count"] += 1
-        if state["count"] >= 2:
+        nonlocal count
+        count += 1
+        if count >= 2:
             print("\nSecond Ctrl-C; exiting hard.", file=sys.stderr)
             os._exit(130)
         print(

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import os
+import signal
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -148,8 +151,12 @@ def cmd_run(args: argparse.Namespace) -> int:
     inputs = resolve_run_inputs(args, get)
     spec = get(inputs.benchmark)
 
+    aborted = threading.Event()
     sampler = ChatCompletionSampler(
-        base_url=inputs.base_url, model=inputs.model, api_key=args.api_key
+        base_url=inputs.base_url,
+        model=inputs.model,
+        api_key=args.api_key,
+        abort_event=aborted,
     )
     _warn_if_greedy_repeats(inputs.n_repeats, inputs.gen)
 
@@ -159,6 +166,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     print(f"Run directory: {run_dir}")
 
     writer = PredictionsWriter(run_dir, inputs.n_repeats) if args.dump_predictions else None
+    prev_sigint = signal.signal(signal.SIGINT, _make_sigint_handler(sampler, aborted))
     try:
         result = spec.run(
             sampler=sampler,
@@ -171,11 +179,16 @@ def cmd_run(args: argparse.Namespace) -> int:
     finally:
         if writer is not None:
             writer.close()
+        signal.signal(signal.SIGINT, prev_sigint)
 
+    is_partial = aborted.is_set()
     print(format_summary(result))
     run_meta = _build_run_meta(
         args=args, sampler=sampler, gen=inputs.gen, stamp=stamp, base_url=inputs.base_url
     )
+    if is_partial:
+        run_meta["partial"] = True
+        run_meta["completed_examples"] = len(result.per_example)
     preset_block = make_run_meta_block(args, inputs.preset)
     if preset_block:
         run_meta["preset"] = preset_block
@@ -183,8 +196,36 @@ def cmd_run(args: argparse.Namespace) -> int:
     print(f"\nMetrics: {metrics_path}")
     if writer is not None:
         print(f"Predictions: {run_dir}  ({inputs.n_repeats} jsonl file(s))")
+    if is_partial:
+        print(
+            f"\n[partial] aborted after {len(result.per_example)} example(s); "
+            "expected_vs_actual skipped (partial runs aren't comparable to baselines).",
+            file=sys.stderr,
+        )
+        return 130
     print_expected_vs_actual(result, inputs.preset)
     return 0
+
+
+def _make_sigint_handler(sampler: ChatCompletionSampler, aborted: threading.Event) -> Any:
+    """First Ctrl-C: kill in-flight requests and flag for partial dump.
+    Second Ctrl-C: hard-exit (escape hatch if partial cleanup hangs)."""
+    state = {"count": 0}
+
+    def _handler(_signum: int, _frame: Any) -> None:
+        state["count"] += 1
+        if state["count"] >= 2:
+            print("\nSecond Ctrl-C; exiting hard.", file=sys.stderr)
+            os._exit(130)
+        print(
+            "\nAborting; killing in-flight requests, dumping partial results "
+            "(press Ctrl-C again to force-exit)...",
+            file=sys.stderr,
+        )
+        sampler.abort()
+        aborted.set()
+
+    return _handler
 
 
 def _build_run_meta(

--- a/sgl_eval/runner.py
+++ b/sgl_eval/runner.py
@@ -30,8 +30,17 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from tqdm import tqdm
 
-from sgl_eval.sampler import SamplerAborted
 from sgl_eval.types import Example, ExampleResult, RunResult, Sample
+
+
+class WorkerAborted(Exception):
+    """Raised by ``sample_fn`` to tell the runner this ``(example, repeat)``
+    pair was abandoned mid-flight (e.g. CLI Ctrl-C closed the underlying
+    transport). The runner skips the pair, drops examples with no completed
+    repeats, and reports ``RunResult.partial = True``. Any sampler /
+    transport that wants to participate in cooperative cancellation should
+    raise this (or a subclass) from inside ``sample_fn``."""
+
 
 TickFn = Callable[[int, float], None]
 SampleFn = Callable[..., Sample]
@@ -112,6 +121,7 @@ def run_examples(
         n_repeats=n_repeats,
         total_completion_tokens=total_completion,
         total_prompt_tokens=total_prompt,
+        partial=len(results) < len(examples),
     )
 
 
@@ -132,7 +142,7 @@ def _run_sample_score_phase(
         for ex, rep in tasks:
             try:
                 sample = sample_fn(ex, rep)
-            except SamplerAborted:
+            except WorkerAborted:
                 return
             samples_by_ex[ex.id][rep] = sample
             score, extracted = score_one_fn(ex, sample)
@@ -149,10 +159,10 @@ def _run_sample_score_phase(
                 ex_id, rep = futures[fut]
                 try:
                     sample = fut.result()
-                except SamplerAborted:
-                    # In-flight request was killed by sampler.abort(); drop
-                    # this (ex, rep) pair. Other pending workers will short-
-                    # circuit on the same abort flag and end up here too.
+                except WorkerAborted:
+                    # Cooperative cancellation: sample_fn signaled this pair
+                    # was abandoned (e.g. CLI Ctrl-C closed the transport).
+                    # Sibling workers will end up here too.
                     continue
                 samples_by_ex[ex_id][rep] = sample
                 ex = ex_by_id[ex_id]
@@ -164,7 +174,7 @@ def _run_sample_score_phase(
                 tick(rep, score)
         finally:
             # Cancel any pending submissions; in-flight workers will surface
-            # SamplerAborted on their next abort_event check and finish fast.
+            # WorkerAborted on their next abort_event check and finish fast.
             pool.shutdown(wait=False, cancel_futures=True)
 
 

--- a/sgl_eval/runner.py
+++ b/sgl_eval/runner.py
@@ -141,19 +141,22 @@ def _run_sample_score_phase(
     tick: TickFn,
     on_sample_scored: Optional[OnSampleScoredFn],
 ) -> None:
+    def record(ex: Example, rep: int, sample: Sample) -> None:
+        samples_by_ex[ex.id][rep] = sample
+        score, extracted = score_one_fn(ex, sample)
+        scores_by_ex[ex.id][rep] = score
+        extracted_by_ex[ex.id][rep] = extracted
+        if on_sample_scored is not None:
+            on_sample_scored(ex, rep, sample, score, extracted)
+        tick(rep, score)
+
     if workers == 1:
         for ex, rep in tasks:
             try:
                 sample = sample_fn(ex, rep)
             except WorkerAborted:
                 return
-            samples_by_ex[ex.id][rep] = sample
-            score, extracted = score_one_fn(ex, sample)
-            scores_by_ex[ex.id][rep] = score
-            extracted_by_ex[ex.id][rep] = extracted
-            if on_sample_scored is not None:
-                on_sample_scored(ex, rep, sample, score, extracted)
-            tick(rep, score)
+            record(ex, rep, sample)
         return
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {pool.submit(sample_fn, ex, rep): (ex.id, rep) for ex, rep in tasks}
@@ -162,19 +165,10 @@ def _run_sample_score_phase(
             try:
                 sample = fut.result()
             except WorkerAborted:
-                # Cooperative cancellation: sample_fn signaled this pair
-                # was abandoned (e.g. CLI Ctrl-C closed the transport).
-                # Sibling workers will end up here too -- queued ones get
-                # picked up and short-circuit at the sampler's entry check.
+                # Cooperative cancellation: queued sibling workers will hit
+                # this path too -- they short-circuit at the sampler entry.
                 continue
-            samples_by_ex[ex_id][rep] = sample
-            ex = ex_by_id[ex_id]
-            score, extracted = score_one_fn(ex, sample)
-            scores_by_ex[ex_id][rep] = score
-            extracted_by_ex[ex_id][rep] = extracted
-            if on_sample_scored is not None:
-                on_sample_scored(ex, rep, sample, score, extracted)
-            tick(rep, score)
+            record(ex_by_id[ex_id], rep, sample)
 
 
 def _assemble_results(

--- a/sgl_eval/runner.py
+++ b/sgl_eval/runner.py
@@ -30,6 +30,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from tqdm import tqdm
 
+from sgl_eval.sampler import SamplerAborted
 from sgl_eval.types import Example, ExampleResult, RunResult, Sample
 
 TickFn = Callable[[int, float], None]
@@ -129,7 +130,10 @@ def _run_sample_score_phase(
 ) -> None:
     if workers == 1:
         for ex, rep in tasks:
-            sample = sample_fn(ex, rep)
+            try:
+                sample = sample_fn(ex, rep)
+            except SamplerAborted:
+                return
             samples_by_ex[ex.id][rep] = sample
             score, extracted = score_one_fn(ex, sample)
             scores_by_ex[ex.id][rep] = score
@@ -140,17 +144,28 @@ def _run_sample_score_phase(
         return
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {pool.submit(sample_fn, ex, rep): (ex.id, rep) for ex, rep in tasks}
-        for fut in as_completed(futures):
-            ex_id, rep = futures[fut]
-            sample = fut.result()
-            samples_by_ex[ex_id][rep] = sample
-            ex = ex_by_id[ex_id]
-            score, extracted = score_one_fn(ex, sample)
-            scores_by_ex[ex_id][rep] = score
-            extracted_by_ex[ex_id][rep] = extracted
-            if on_sample_scored is not None:
-                on_sample_scored(ex, rep, sample, score, extracted)
-            tick(rep, score)
+        try:
+            for fut in as_completed(futures):
+                ex_id, rep = futures[fut]
+                try:
+                    sample = fut.result()
+                except SamplerAborted:
+                    # In-flight request was killed by sampler.abort(); drop
+                    # this (ex, rep) pair. Other pending workers will short-
+                    # circuit on the same abort flag and end up here too.
+                    continue
+                samples_by_ex[ex_id][rep] = sample
+                ex = ex_by_id[ex_id]
+                score, extracted = score_one_fn(ex, sample)
+                scores_by_ex[ex_id][rep] = score
+                extracted_by_ex[ex_id][rep] = extracted
+                if on_sample_scored is not None:
+                    on_sample_scored(ex, rep, sample, score, extracted)
+                tick(rep, score)
+        finally:
+            # Cancel any pending submissions; in-flight workers will surface
+            # SamplerAborted on their next abort_event check and finish fast.
+            pool.shutdown(wait=False, cancel_futures=True)
 
 
 def _assemble_results(
@@ -159,16 +174,25 @@ def _assemble_results(
     scores_by_ex: Dict[str, List[float]],
     extracted_by_ex: Dict[str, List[Optional[str]]],
 ) -> List[ExampleResult]:
+    """Filter out repeats whose sample never completed (partial-run case
+    where the runner was aborted mid-flight). Keeps samples / scores /
+    extracted aligned in length so downstream aggregators see consistent
+    triples. Examples with zero completed repeats are dropped entirely."""
     results: List[ExampleResult] = []
     for ex in examples:
-        samples = [s for s in samples_by_ex[ex.id] if s is not None]
+        samples: List[Sample] = []
+        scores: List[float] = []
+        extracted: List[Optional[str]] = []
+        for s, sc, e in zip(samples_by_ex[ex.id], scores_by_ex[ex.id], extracted_by_ex[ex.id]):
+            if s is None:
+                continue
+            samples.append(s)
+            scores.append(sc)
+            extracted.append(e)
+        if not samples:
+            continue
         results.append(
-            ExampleResult(
-                example=ex,
-                samples=samples,
-                scores=list(scores_by_ex[ex.id]),
-                extracted=list(extracted_by_ex[ex.id]),
-            )
+            ExampleResult(example=ex, samples=samples, scores=scores, extracted=extracted)
         )
     return results
 

--- a/sgl_eval/runner.py
+++ b/sgl_eval/runner.py
@@ -154,28 +154,24 @@ def _run_sample_score_phase(
         return
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {pool.submit(sample_fn, ex, rep): (ex.id, rep) for ex, rep in tasks}
-        try:
-            for fut in as_completed(futures):
-                ex_id, rep = futures[fut]
-                try:
-                    sample = fut.result()
-                except WorkerAborted:
-                    # Cooperative cancellation: sample_fn signaled this pair
-                    # was abandoned (e.g. CLI Ctrl-C closed the transport).
-                    # Sibling workers will end up here too.
-                    continue
-                samples_by_ex[ex_id][rep] = sample
-                ex = ex_by_id[ex_id]
-                score, extracted = score_one_fn(ex, sample)
-                scores_by_ex[ex_id][rep] = score
-                extracted_by_ex[ex_id][rep] = extracted
-                if on_sample_scored is not None:
-                    on_sample_scored(ex, rep, sample, score, extracted)
-                tick(rep, score)
-        finally:
-            # Cancel any pending submissions; in-flight workers will surface
-            # WorkerAborted on their next abort_event check and finish fast.
-            pool.shutdown(wait=False, cancel_futures=True)
+        for fut in as_completed(futures):
+            ex_id, rep = futures[fut]
+            try:
+                sample = fut.result()
+            except WorkerAborted:
+                # Cooperative cancellation: sample_fn signaled this pair
+                # was abandoned (e.g. CLI Ctrl-C closed the transport).
+                # Sibling workers will end up here too -- queued ones get
+                # picked up and short-circuit at the sampler's entry check.
+                continue
+            samples_by_ex[ex_id][rep] = sample
+            ex = ex_by_id[ex_id]
+            score, extracted = score_one_fn(ex, sample)
+            scores_by_ex[ex_id][rep] = score
+            extracted_by_ex[ex_id][rep] = extracted
+            if on_sample_scored is not None:
+                on_sample_scored(ex, rep, sample, score, extracted)
+            tick(rep, score)
 
 
 def _assemble_results(

--- a/sgl_eval/runner.py
+++ b/sgl_eval/runner.py
@@ -112,6 +112,8 @@ def run_examples(
 
     aggregate = aggregate_fn(results) if aggregate_fn else _default_aggregate(results)
 
+    planned_samples = len(examples) * n_repeats
+    completed_samples = sum(len(r.samples) for r in results)
     return RunResult(
         name=name,
         per_example=results,
@@ -121,7 +123,8 @@ def run_examples(
         n_repeats=n_repeats,
         total_completion_tokens=total_completion,
         total_prompt_tokens=total_prompt,
-        partial=len(results) < len(examples),
+        partial=completed_samples < planned_samples,
+        planned_examples=len(examples),
     )
 
 

--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -23,13 +23,6 @@ from sgl_eval.types import GenConfig, MessageList, Sample
 LOG = logging.getLogger(__name__)
 
 
-class SamplerAborted(WorkerAborted):
-    """Sampler-side specialization of ``WorkerAborted``: ``abort()`` was
-    called mid-flight. Bypasses the retry loop and propagates out of the
-    worker; the runner catches it as ``WorkerAborted`` without knowing the
-    sampler exists."""
-
-
 class _LargeHttpxClient(httpx.Client):
     """httpx client tuned for long-running reasoning generations."""
 
@@ -68,7 +61,7 @@ class ChatCompletionSampler:
 
         In-flight ``chat.completions.create(...)`` calls raise immediately;
         the retry loop short-circuits on the abort flag and re-raises
-        ``SamplerAborted``. Idempotent.
+        ``WorkerAborted``. Idempotent.
         """
         self._abort_event.set()
         try:
@@ -95,7 +88,7 @@ class ChatCompletionSampler:
 
         for trial in range(self.max_retries):
             if self._abort_event.is_set():
-                raise SamplerAborted()
+                raise WorkerAborted()
             try:
                 start = time.time()
                 response = self.client.chat.completions.create(**kwargs)
@@ -106,7 +99,7 @@ class ChatCompletionSampler:
                 return Sample(text="", finish_reason="error", raw=e)
             except Exception as e:
                 if self._abort_event.is_set():
-                    raise SamplerAborted() from e
+                    raise WorkerAborted() from e
                 backoff = 2**trial
                 LOG.warning(
                     "Sampler exception (trial %d/%d), backing off %ds: %s",
@@ -117,7 +110,7 @@ class ChatCompletionSampler:
                 )
                 # Wake immediately if abort fires during the backoff sleep.
                 if self._abort_event.wait(backoff):
-                    raise SamplerAborted() from e
+                    raise WorkerAborted() from e
 
         LOG.error("Sampler exhausted retries; returning empty sample.")
         return Sample(text="", finish_reason="error")

--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -9,6 +9,7 @@ side-channel list).
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from typing import Any, Dict, Optional
 
@@ -19,6 +20,15 @@ from openai import OpenAI
 from sgl_eval.types import GenConfig, MessageList, Sample
 
 LOG = logging.getLogger(__name__)
+
+
+class SamplerAborted(Exception):
+    """Raised when the sampler was aborted mid-flight via ``abort()``.
+
+    Bypasses the retry loop and propagates out of the worker so the runner
+    can drop the in-flight sample instead of recording it. Used by the CLI's
+    Ctrl-C handler to kill in-flight requests immediately.
+    """
 
 
 class _LargeHttpxClient(httpx.Client):
@@ -39,10 +49,25 @@ class ChatCompletionSampler:
         model: Optional[str] = None,
         api_key: str = "EMPTY",
         max_retries: int = 6,
+        abort_event: Optional[threading.Event] = None,
     ) -> None:
         self.client = OpenAI(base_url=base_url, api_key=api_key, http_client=_LargeHttpxClient())
         self.model = model or self._resolve_default_model()
         self.max_retries = max_retries
+        self._abort_event = abort_event or threading.Event()
+
+    def abort(self) -> None:
+        """Set the abort flag and close the underlying httpx client.
+
+        In-flight ``chat.completions.create(...)`` calls raise ``ConnectError``
+        / ``RemoteProtocolError`` immediately; the retry loop short-circuits
+        on the abort flag and re-raises ``SamplerAborted``. Idempotent.
+        """
+        self._abort_event.set()
+        try:
+            self.client._client.close()
+        except Exception:
+            pass
 
     def _resolve_default_model(self) -> str:
         models = self.client.models.list().data
@@ -62,6 +87,8 @@ class ChatCompletionSampler:
         kwargs = self._build_kwargs(messages, gen)
 
         for trial in range(self.max_retries):
+            if self._abort_event.is_set():
+                raise SamplerAborted()
             try:
                 start = time.time()
                 response = self.client.chat.completions.create(**kwargs)
@@ -71,6 +98,8 @@ class ChatCompletionSampler:
                 LOG.warning("BadRequestError, returning empty sample: %s", e)
                 return Sample(text="", finish_reason="error", raw=e)
             except Exception as e:
+                if self._abort_event.is_set():
+                    raise SamplerAborted() from e
                 backoff = 2**trial
                 LOG.warning(
                     "Sampler exception (trial %d/%d), backing off %ds: %s",
@@ -79,7 +108,9 @@ class ChatCompletionSampler:
                     backoff,
                     e,
                 )
-                time.sleep(backoff)
+                # Wake immediately if abort fires during the backoff sleep.
+                if self._abort_event.wait(backoff):
+                    raise SamplerAborted() from e
 
         LOG.error("Sampler exhausted retries; returning empty sample.")
         return Sample(text="", finish_reason="error")

--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -17,18 +17,17 @@ import httpx
 import openai
 from openai import OpenAI
 
+from sgl_eval.runner import WorkerAborted
 from sgl_eval.types import GenConfig, MessageList, Sample
 
 LOG = logging.getLogger(__name__)
 
 
-class SamplerAborted(Exception):
-    """Raised when the sampler was aborted mid-flight via ``abort()``.
-
-    Bypasses the retry loop and propagates out of the worker so the runner
-    can drop the in-flight sample instead of recording it. Used by the CLI's
-    Ctrl-C handler to kill in-flight requests immediately.
-    """
+class SamplerAborted(WorkerAborted):
+    """Sampler-side specialization of ``WorkerAborted``: ``abort()`` was
+    called mid-flight. Bypasses the retry loop and propagates out of the
+    worker; the runner catches it as ``WorkerAborted`` without knowing the
+    sampler exists."""
 
 
 class _LargeHttpxClient(httpx.Client):
@@ -49,23 +48,31 @@ class ChatCompletionSampler:
         model: Optional[str] = None,
         api_key: str = "EMPTY",
         max_retries: int = 6,
-        abort_event: Optional[threading.Event] = None,
     ) -> None:
-        self.client = OpenAI(base_url=base_url, api_key=api_key, http_client=_LargeHttpxClient())
+        # Hold the httpx client directly so ``abort()`` can close it without
+        # reaching into ``OpenAI``'s private ``_client`` attribute.
+        self._http = _LargeHttpxClient()
+        self.client = OpenAI(base_url=base_url, api_key=api_key, http_client=self._http)
         self.model = model or self._resolve_default_model()
         self.max_retries = max_retries
-        self._abort_event = abort_event or threading.Event()
+        self._abort_event = threading.Event()
+
+    @property
+    def aborted(self) -> bool:
+        """True if ``abort()`` was called. CLI uses this to decide exit code
+        without needing to share a ``threading.Event`` directly."""
+        return self._abort_event.is_set()
 
     def abort(self) -> None:
         """Set the abort flag and close the underlying httpx client.
 
-        In-flight ``chat.completions.create(...)`` calls raise ``ConnectError``
-        / ``RemoteProtocolError`` immediately; the retry loop short-circuits
-        on the abort flag and re-raises ``SamplerAborted``. Idempotent.
+        In-flight ``chat.completions.create(...)`` calls raise immediately;
+        the retry loop short-circuits on the abort flag and re-raises
+        ``SamplerAborted``. Idempotent.
         """
         self._abort_event.set()
         try:
-            self.client._client.close()
+            self._http.close()
         except Exception:
             pass
 

--- a/sgl_eval/types.py
+++ b/sgl_eval/types.py
@@ -69,7 +69,13 @@ class ExampleResult:
 
 @dataclass
 class RunResult:
-    """Top-level eval result. Aggregator metrics live in ``aggregate``."""
+    """Top-level eval result. Aggregator metrics live in ``aggregate``.
+
+    ``partial`` is True when one or more examples were dropped because no
+    repeat completed (e.g. the runner was aborted mid-flight). Downstream
+    consumers (metrics writer, baseline comparator) should treat partial
+    results as not directly comparable to full runs.
+    """
 
     name: str
     per_example: List[ExampleResult]
@@ -79,6 +85,7 @@ class RunResult:
     n_repeats: int
     total_completion_tokens: int = 0
     total_prompt_tokens: int = 0
+    partial: bool = False
 
     @property
     def output_throughput(self) -> float:

--- a/sgl_eval/types.py
+++ b/sgl_eval/types.py
@@ -71,10 +71,16 @@ class ExampleResult:
 class RunResult:
     """Top-level eval result. Aggregator metrics live in ``aggregate``.
 
-    ``partial`` is True when one or more examples were dropped because no
-    repeat completed (e.g. the runner was aborted mid-flight). Downstream
-    consumers (metrics writer, baseline comparator) should treat partial
-    results as not directly comparable to full runs.
+    ``partial`` is True when at least one ``(example, repeat)`` sample
+    didn't make it into ``per_example`` (e.g. the runner was aborted
+    mid-flight). Defined at the sample level so an example whose 1/3 reps
+    completed -- which the aggregator pads up to 3 by repeating the last
+    sample -- still surfaces as partial.
+
+    ``planned_examples`` is what the runner was asked to score; multiply
+    by ``n_repeats`` for planned samples. ``num_examples`` is what
+    survived (>=1 rep completed); ``sum(len(r.samples) for r in per_example)``
+    gives completed samples.
     """
 
     name: str
@@ -86,6 +92,7 @@ class RunResult:
     total_completion_tokens: int = 0
     total_prompt_tokens: int = 0
     partial: bool = False
+    planned_examples: int = 0
 
     @property
     def output_throughput(self) -> float:

--- a/tests/test_cli_partial.py
+++ b/tests/test_cli_partial.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sgl_eval.cli import _format_partial_summary, _score_bounds
+from sgl_eval.cli import _example_breakdown, _format_partial_summary, _score_bounds
 from sgl_eval.types import Example, ExampleResult, RunResult, Sample
 
 
@@ -70,12 +70,37 @@ def test_partial_summary_n_repeats_1():
 
 
 def test_partial_summary_n_repeats_gt_1():
-    """n_repeats>1 path uses sample-level progress; bounds still sample-level."""
-    # ex0 done all 3 reps (1 correct), ex1 done 1/3 reps (correct).
-    # 4/12 samples completed, 2 correct -> worst 16.67%, best 83.33%.
+    """n_repeats>1 path uses sample-level progress + example full/partial/
+    dropped breakdown; score bounds still sample-level."""
+    # planned_examples=4, n_repeats=3 -> 12 planned samples
+    # ex0: 3 reps done (full, 1 correct)
+    # ex1: 1 rep done (partial, 1 correct)
+    # ex2, ex3: missing from per_example -> dropped
     per_example = [_ex_result("0", [1.0, 0.0, 0.0]), _ex_result("1", [1.0])]
     result = _make_result(per_example, planned_examples=4, n_repeats=3)
     out = _format_partial_summary(result)
     assert "4 / 12 samples completed" in out
     assert "(8 unfinished, n_repeats=3)" in out
+    assert "examples: 1 full / 1 partial / 2 dropped (4 planned)" in out
     assert "score range: [16.67%, 83.33%]" in out
+
+
+def test_example_breakdown_buckets():
+    """full = all reps done, partial = some reps done, dropped = none done."""
+    per_example = [
+        _ex_result("a", [1.0, 1.0, 1.0]),  # full
+        _ex_result("b", [1.0, 1.0]),  # partial
+        _ex_result("c", [1.0]),  # partial
+    ]
+    # planned 5, only 3 in per_example -> 2 dropped
+    result = _make_result(per_example, planned_examples=5, n_repeats=3)
+    full, part, dropped = _example_breakdown(result)
+    assert (full, part, dropped) == (1, 2, 2)
+
+
+def test_example_breakdown_all_full():
+    """No partial, no dropped -- but partial=True flag could still fire if
+    e.g. another tracking field said so. Helper just buckets."""
+    per_example = [_ex_result("a", [1.0, 1.0]), _ex_result("b", [0.0, 1.0])]
+    result = _make_result(per_example, planned_examples=2, n_repeats=2)
+    assert _example_breakdown(result) == (2, 0, 0)

--- a/tests/test_cli_partial.py
+++ b/tests/test_cli_partial.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sgl_eval.cli import _example_breakdown, _format_partial_summary, _score_bounds
+from sgl_eval.cli import _format_partial_summary, _partial_stats, _score_bounds
 from sgl_eval.types import Example, ExampleResult, RunResult, Sample
 
 
@@ -58,11 +58,41 @@ def _ex_result(ex_id, scores):
     )
 
 
+def test_partial_stats_single_walk():
+    """One pass over ``per_example`` covers samples, scores, and the
+    full/partial/dropped buckets in one go."""
+    per_example = [
+        _ex_result("a", [1.0, 1.0, 1.0]),  # full, 3 correct
+        _ex_result("b", [1.0, 1.0]),  # part (2/3), 2 correct
+        _ex_result("c", [0.0]),  # part (1/3), 0 correct
+    ]
+    # planned 5, only 3 in per_example -> 2 dropped, planned_samples=15
+    result = _make_result(per_example, planned_examples=5, n_repeats=3)
+    stats = _partial_stats(result)
+    assert stats.completed_samples == 6
+    assert stats.planned_samples == 15
+    assert stats.unfinished_samples == 9
+    assert (stats.full, stats.part, stats.dropped) == (1, 2, 2)
+    # n_correct = 5; worst = 5/15, best = (5+9)/15
+    assert stats.worst == 5 / 15
+    assert stats.best == 14 / 15
+
+
+def test_partial_stats_all_full_no_dropped():
+    """Edge case: every rep done for every example -- partial flag may
+    still fire from elsewhere, but the buckets all collapse correctly."""
+    per_example = [_ex_result("a", [1.0, 1.0]), _ex_result("b", [0.0, 1.0])]
+    result = _make_result(per_example, planned_examples=2, n_repeats=2)
+    stats = _partial_stats(result)
+    assert (stats.full, stats.part, stats.dropped) == (2, 0, 0)
+    assert stats.unfinished_samples == 0
+
+
 def test_partial_summary_n_repeats_1():
     """n_repeats=1 path uses example-level progress and shows [worst, best]."""
     per_example = [_ex_result(str(i), [1.0]) for i in range(3)]  # 3/10 examples, all correct
     result = _make_result(per_example, planned_examples=10, n_repeats=1)
-    out = _format_partial_summary(result)
+    out = _format_partial_summary(result, _partial_stats(result))
     assert "3 / 10 examples completed" in out
     assert "(7 unfinished)" in out
     assert "score range: [30.00%, 100.00%]" in out
@@ -78,29 +108,8 @@ def test_partial_summary_n_repeats_gt_1():
     # ex2, ex3: missing from per_example -> dropped
     per_example = [_ex_result("0", [1.0, 0.0, 0.0]), _ex_result("1", [1.0])]
     result = _make_result(per_example, planned_examples=4, n_repeats=3)
-    out = _format_partial_summary(result)
+    out = _format_partial_summary(result, _partial_stats(result))
     assert "4 / 12 samples completed" in out
     assert "(8 unfinished, n_repeats=3)" in out
     assert "examples: 1 full / 1 partial / 2 dropped (4 planned)" in out
     assert "score range: [16.67%, 83.33%]" in out
-
-
-def test_example_breakdown_buckets():
-    """full = all reps done, partial = some reps done, dropped = none done."""
-    per_example = [
-        _ex_result("a", [1.0, 1.0, 1.0]),  # full
-        _ex_result("b", [1.0, 1.0]),  # partial
-        _ex_result("c", [1.0]),  # partial
-    ]
-    # planned 5, only 3 in per_example -> 2 dropped
-    result = _make_result(per_example, planned_examples=5, n_repeats=3)
-    full, part, dropped = _example_breakdown(result)
-    assert (full, part, dropped) == (1, 2, 2)
-
-
-def test_example_breakdown_all_full():
-    """No partial, no dropped -- but partial=True flag could still fire if
-    e.g. another tracking field said so. Helper just buckets."""
-    per_example = [_ex_result("a", [1.0, 1.0]), _ex_result("b", [0.0, 1.0])]
-    result = _make_result(per_example, planned_examples=2, n_repeats=2)
-    assert _example_breakdown(result) == (2, 0, 0)

--- a/tests/test_cli_partial.py
+++ b/tests/test_cli_partial.py
@@ -1,0 +1,81 @@
+"""Unit tests for cli partial-run helpers (score bounds + summary line)."""
+
+from __future__ import annotations
+
+from sgl_eval.cli import _format_partial_summary, _score_bounds
+from sgl_eval.types import Example, ExampleResult, RunResult, Sample
+
+
+def _make_result(per_example, planned_examples, n_repeats):
+    return RunResult(
+        name="dummy",
+        per_example=per_example,
+        aggregate={"score": 0.0},
+        latency=0.0,
+        num_examples=len(per_example),
+        n_repeats=n_repeats,
+        partial=True,
+        planned_examples=planned_examples,
+    )
+
+
+def test_score_bounds_basic():
+    """3/10 done, all correct -> worst 30% (missing all wrong),
+    best 100% (missing all right)."""
+    worst, best = _score_bounds(n_correct=3.0, completed_samples=3, planned_samples=10)
+    assert worst == 0.3
+    assert best == 1.0
+
+
+def test_score_bounds_zero_correct():
+    """3/10 done, none correct -> worst 0%, best 70%."""
+    worst, best = _score_bounds(n_correct=0.0, completed_samples=3, planned_samples=10)
+    assert worst == 0.0
+    assert best == 0.7
+
+
+def test_score_bounds_all_done():
+    """When nothing is missing, worst == best == actual rate (sanity check
+    -- partial runs typically don't hit this branch but the math should
+    still collapse correctly)."""
+    worst, best = _score_bounds(n_correct=7.0, completed_samples=10, planned_samples=10)
+    assert worst == 0.7
+    assert best == 0.7
+
+
+def test_score_bounds_zero_planned():
+    """Empty dataset -> bounds are zero, no division by zero."""
+    worst, best = _score_bounds(n_correct=0.0, completed_samples=0, planned_samples=0)
+    assert worst == 0.0
+    assert best == 0.0
+
+
+def _ex_result(ex_id, scores):
+    ex = Example(id=ex_id, inputs={}, target="x")
+    samples = [Sample(text="x", completion_tokens=1, finish_reason="stop") for _ in scores]
+    return ExampleResult(
+        example=ex, samples=samples, scores=list(scores), extracted=["x"] * len(scores)
+    )
+
+
+def test_partial_summary_n_repeats_1():
+    """n_repeats=1 path uses example-level progress and shows [worst, best]."""
+    per_example = [_ex_result(str(i), [1.0]) for i in range(3)]  # 3/10 examples, all correct
+    result = _make_result(per_example, planned_examples=10, n_repeats=1)
+    out = _format_partial_summary(result)
+    assert "3 / 10 examples completed" in out
+    assert "(7 unfinished)" in out
+    assert "score range: [30.00%, 100.00%]" in out
+    assert "expected_vs_actual skipped" in out
+
+
+def test_partial_summary_n_repeats_gt_1():
+    """n_repeats>1 path uses sample-level progress; bounds still sample-level."""
+    # ex0 done all 3 reps (1 correct), ex1 done 1/3 reps (correct).
+    # 4/12 samples completed, 2 correct -> worst 16.67%, best 83.33%.
+    per_example = [_ex_result("0", [1.0, 0.0, 0.0]), _ex_result("1", [1.0])]
+    result = _make_result(per_example, planned_examples=4, n_repeats=3)
+    out = _format_partial_summary(result)
+    assert "4 / 12 samples completed" in out
+    assert "(8 unfinished, n_repeats=3)" in out
+    assert "score range: [16.67%, 83.33%]" in out

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import threading
 
-from sgl_eval.runner import run_examples
-from sgl_eval.sampler import SamplerAborted
+from sgl_eval.runner import WorkerAborted, run_examples
 from sgl_eval.types import Example, Sample
 
 
@@ -39,6 +38,7 @@ def test_runner_basic():
         progress=False,
     )
     assert result.num_examples == 4
+    assert result.partial is False
     assert result.aggregate["score"] == 1.0
     assert result.total_completion_tokens == 4 * 5
     assert result.output_throughput > 0
@@ -85,7 +85,7 @@ def test_runner_n_repeats_flat_concurrency():
 
 
 def test_runner_drops_aborted_samples_serial():
-    """When ``sample_fn`` raises ``SamplerAborted`` (i.e. CLI Ctrl-C closed
+    """When ``sample_fn`` raises ``WorkerAborted`` (i.e. CLI Ctrl-C closed
     the httpx client), the serial runner stops, drops examples with no
     completed repeats, and aligns samples / scores / extracted so partial
     aggregation works."""
@@ -96,7 +96,7 @@ def test_runner_drops_aborted_samples_serial():
     def flaky_sample_fn(ex, _rep_idx):
         counter["n"] += 1
         if counter["n"] > 2:
-            raise SamplerAborted()
+            raise WorkerAborted()
         return Sample(text="x", completion_tokens=1, finish_reason="stop")
 
     result = run_examples(
@@ -110,6 +110,7 @@ def test_runner_drops_aborted_samples_serial():
     )
 
     assert result.num_examples == 2
+    assert result.partial is True
     for r in result.per_example:
         assert len(r.samples) == len(r.scores) == len(r.extracted) == 1
         assert r.samples[0].text == "x"
@@ -117,7 +118,7 @@ def test_runner_drops_aborted_samples_serial():
 
 
 def test_runner_drops_aborted_samples_parallel():
-    """Parallel path: an ``as_completed`` worker raising ``SamplerAborted``
+    """Parallel path: an ``as_completed`` worker raising ``WorkerAborted``
     is skipped without poisoning sibling workers' results. We can't
     guarantee which ones complete (thread interleaving), but the invariant
     holds: every returned ExampleResult has aligned, non-empty triples."""
@@ -133,7 +134,7 @@ def test_runner_drops_aborted_samples_parallel():
             if completed["n"] >= 3:
                 abort_event.set()
         if abort_event.is_set() and completed["n"] >= 3:
-            raise SamplerAborted()
+            raise WorkerAborted()
         return Sample(text="x", completion_tokens=1, finish_reason="stop")
 
     result = run_examples(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import threading
 
 from sgl_eval.runner import run_examples
+from sgl_eval.sampler import SamplerAborted
 from sgl_eval.types import Example, Sample
 
 
@@ -81,6 +82,73 @@ def test_runner_n_repeats_flat_concurrency():
     assert result.n_repeats == 8
     assert len(submitted) == 4 * 8
     assert result.total_completion_tokens == 4 * 8
+
+
+def test_runner_drops_aborted_samples_serial():
+    """When ``sample_fn`` raises ``SamplerAborted`` (i.e. CLI Ctrl-C closed
+    the httpx client), the serial runner stops, drops examples with no
+    completed repeats, and aligns samples / scores / extracted so partial
+    aggregation works."""
+    examples = [Example(id=str(i), inputs={}, target="x") for i in range(4)]
+
+    counter = {"n": 0}
+
+    def flaky_sample_fn(ex, _rep_idx):
+        counter["n"] += 1
+        if counter["n"] > 2:
+            raise SamplerAborted()
+        return Sample(text="x", completion_tokens=1, finish_reason="stop")
+
+    result = run_examples(
+        "dummy",
+        examples,
+        flaky_sample_fn,
+        _all_correct_score_one_fn,
+        num_threads=1,
+        n_repeats=1,
+        progress=False,
+    )
+
+    assert result.num_examples == 2
+    for r in result.per_example:
+        assert len(r.samples) == len(r.scores) == len(r.extracted) == 1
+        assert r.samples[0].text == "x"
+    assert result.aggregate["score"] == 1.0
+
+
+def test_runner_drops_aborted_samples_parallel():
+    """Parallel path: an ``as_completed`` worker raising ``SamplerAborted``
+    is skipped without poisoning sibling workers' results. We can't
+    guarantee which ones complete (thread interleaving), but the invariant
+    holds: every returned ExampleResult has aligned, non-empty triples."""
+    examples = [Example(id=str(i), inputs={}, target="x") for i in range(8)]
+
+    abort_event = threading.Event()
+    completed = {"n": 0}
+    lock = threading.Lock()
+
+    def flaky_sample_fn(_ex, _rep_idx):
+        with lock:
+            completed["n"] += 1
+            if completed["n"] >= 3:
+                abort_event.set()
+        if abort_event.is_set() and completed["n"] >= 3:
+            raise SamplerAborted()
+        return Sample(text="x", completion_tokens=1, finish_reason="stop")
+
+    result = run_examples(
+        "dummy",
+        examples,
+        flaky_sample_fn,
+        _all_correct_score_one_fn,
+        num_threads=4,
+        n_repeats=1,
+        progress=False,
+    )
+
+    assert 0 < result.num_examples <= len(examples)
+    for r in result.per_example:
+        assert len(r.samples) == len(r.scores) == len(r.extracted) >= 1
 
 
 def test_runner_invokes_on_sample_scored():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -39,6 +39,7 @@ def test_runner_basic():
     )
     assert result.num_examples == 4
     assert result.partial is False
+    assert result.planned_examples == 4
     assert result.aggregate["score"] == 1.0
     assert result.total_completion_tokens == 4 * 5
     assert result.output_throughput > 0
@@ -111,10 +112,47 @@ def test_runner_drops_aborted_samples_serial():
 
     assert result.num_examples == 2
     assert result.partial is True
+    assert result.planned_examples == 4
     for r in result.per_example:
         assert len(r.samples) == len(r.scores) == len(r.extracted) == 1
         assert r.samples[0].text == "x"
     assert result.aggregate["score"] == 1.0
+
+
+def test_runner_partial_at_sample_level_when_n_repeats_gt_1():
+    """An example that completed only some of its reps is partial too --
+    even though it survives in ``per_example``, the missing reps mean
+    the aggregator's pad-with-last would silently fabricate data, so
+    ``partial`` must surface."""
+    examples = [Example(id=str(i), inputs={}, target="x") for i in range(2)]
+    counter = {"n": 0}
+
+    def flaky_sample_fn(_ex, _rep_idx):
+        counter["n"] += 1
+        # Serial order is (ex0,0), (ex0,1), (ex0,2), (ex1,0), ...
+        # Abort after 2 calls -> ex0 keeps 2/3 reps, ex1 gets nothing.
+        if counter["n"] > 2:
+            raise WorkerAborted()
+        return Sample(text="x", completion_tokens=1, finish_reason="stop")
+
+    result = run_examples(
+        "dummy",
+        examples,
+        flaky_sample_fn,
+        _all_correct_score_one_fn,
+        num_threads=1,
+        n_repeats=3,
+        progress=False,
+    )
+
+    completed = sum(len(r.samples) for r in result.per_example)
+    assert result.planned_examples == 2
+    assert result.num_examples == 1  # ex1 dropped (zero reps)
+    assert completed == 2  # ex0 kept 2/3 reps
+    # 2 < 6 planned -> partial fires. Critically, ex0 lives in
+    # per_example with only 2 samples; without sample-level partial
+    # this case would slip through as "complete".
+    assert result.partial is True
 
 
 def test_runner_drops_aborted_samples_parallel():

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -14,7 +14,7 @@ from types import SimpleNamespace
 import pytest
 
 from sgl_eval.runner import WorkerAborted
-from sgl_eval.sampler import ChatCompletionSampler, SamplerAborted
+from sgl_eval.sampler import ChatCompletionSampler
 from sgl_eval.types import GenConfig
 
 
@@ -120,12 +120,6 @@ def test_reasoning_tokens_absent(sampler):
     assert out.reasoning_tokens is None
 
 
-def test_sampler_aborted_subclasses_worker_aborted():
-    """Runner only knows ``WorkerAborted``; sampler-side ``SamplerAborted``
-    must propagate through the runner's ``except WorkerAborted`` clause."""
-    assert issubclass(SamplerAborted, WorkerAborted)
-
-
 def test_aborted_property_reflects_event(sampler):
     """``sampler.aborted`` mirrors the internal event so callers (e.g. the
     CLI) don't need to share the ``threading.Event`` directly."""
@@ -145,14 +139,14 @@ def test_abort_before_call_raises(sampler):
         return _stub_response("hi")
 
     sampler.client.chat.completions.create = fake_create
-    with pytest.raises(SamplerAborted):
+    with pytest.raises(WorkerAborted):
         sampler([{"role": "user", "content": "hi"}])
     assert called["n"] == 0
 
 
 def test_abort_short_circuits_retry(sampler):
     """If a request fails AND abort fires before the next retry, the sampler
-    bails with ``SamplerAborted`` instead of looping through ``max_retries``."""
+    bails with ``WorkerAborted`` instead of looping through ``max_retries``."""
     sampler.max_retries = 5
     calls = {"n": 0}
 
@@ -163,7 +157,7 @@ def test_abort_short_circuits_retry(sampler):
         raise RuntimeError("boom")
 
     sampler.client.chat.completions.create = failing_create
-    with pytest.raises(SamplerAborted):
+    with pytest.raises(WorkerAborted):
         sampler([{"role": "user", "content": "hi"}])
     assert calls["n"] == 1  # no retries after abort
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -8,11 +8,12 @@ the sampler builds the right request kwargs and unpacks responses into a
 
 from __future__ import annotations
 
+import threading
 from types import SimpleNamespace
 
 import pytest
 
-from sgl_eval.sampler import ChatCompletionSampler
+from sgl_eval.sampler import ChatCompletionSampler, SamplerAborted
 from sgl_eval.types import GenConfig
 
 
@@ -45,6 +46,7 @@ def sampler(monkeypatch):
     )
     s.model = "stub-model"
     s.max_retries = 1
+    s._abort_event = threading.Event()
     s._captured = captured
     return s
 
@@ -115,6 +117,40 @@ def test_reasoning_tokens_absent(sampler):
     NeMo-Skills' fallback in BaseMetrics.update treats it as zero."""
     out = sampler([{"role": "user", "content": "hi"}])
     assert out.reasoning_tokens is None
+
+
+def test_abort_before_call_raises(sampler):
+    """If ``abort_event`` is already set when ``__call__`` enters, the
+    sampler raises immediately without hitting the network."""
+    sampler._abort_event.set()
+    called = {"n": 0}
+
+    def fake_create(**_kwargs):
+        called["n"] += 1
+        return _stub_response("hi")
+
+    sampler.client.chat.completions.create = fake_create
+    with pytest.raises(SamplerAborted):
+        sampler([{"role": "user", "content": "hi"}])
+    assert called["n"] == 0
+
+
+def test_abort_short_circuits_retry(sampler):
+    """If a request fails AND abort fires before the next retry, the sampler
+    bails with ``SamplerAborted`` instead of looping through ``max_retries``."""
+    sampler.max_retries = 5
+    calls = {"n": 0}
+
+    def failing_create(**_kwargs):
+        calls["n"] += 1
+        # Mark abort *during* the first failure so the retry loop sees it.
+        sampler._abort_event.set()
+        raise RuntimeError("boom")
+
+    sampler.client.chat.completions.create = failing_create
+    with pytest.raises(SamplerAborted):
+        sampler([{"role": "user", "content": "hi"}])
+    assert calls["n"] == 1  # no retries after abort
 
 
 def test_bad_request_returns_empty_sample(sampler):

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from sgl_eval.runner import WorkerAborted
 from sgl_eval.sampler import ChatCompletionSampler, SamplerAborted
 from sgl_eval.types import GenConfig
 
@@ -117,6 +118,20 @@ def test_reasoning_tokens_absent(sampler):
     NeMo-Skills' fallback in BaseMetrics.update treats it as zero."""
     out = sampler([{"role": "user", "content": "hi"}])
     assert out.reasoning_tokens is None
+
+
+def test_sampler_aborted_subclasses_worker_aborted():
+    """Runner only knows ``WorkerAborted``; sampler-side ``SamplerAborted``
+    must propagate through the runner's ``except WorkerAborted`` clause."""
+    assert issubclass(SamplerAborted, WorkerAborted)
+
+
+def test_aborted_property_reflects_event(sampler):
+    """``sampler.aborted`` mirrors the internal event so callers (e.g. the
+    CLI) don't need to share the ``threading.Event`` directly."""
+    assert sampler.aborted is False
+    sampler._abort_event.set()
+    assert sampler.aborted is True
 
 
 def test_abort_before_call_raises(sampler):


### PR DESCRIPTION
Catch SIGINT in `sgl-eval run`: close the sampler's httpx client to kill in-flight requests, drop the aborted samples, and still write `metrics.json` with `partial: true`. Streaming `output-rs*.jsonl` already covered scored samples; this fills in the missing summary + run-meta. Second Ctrl-C hard-exits.