### PR TITLE
Add sgl-eval refresh: rebuild metrics.json locally from predictions

### DIFF
--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -4,6 +4,7 @@ Subcommands:
   list                 enumerate registered benchmarks
   ping                 send one chat completion to the endpoint and print it
   run <name>           run a benchmark end-to-end (orchestrated by ``pipeline``)
+  refresh <run_dir>    rebuild metrics.json locally from existing predictions
   preset list/show     manage saved (model, dataset, sampling) presets
 """
 
@@ -13,7 +14,7 @@ import argparse
 import sys
 from typing import List, Optional
 
-from sgl_eval.pipeline import cmd_run
+from sgl_eval.pipeline import cmd_refresh, cmd_run
 from sgl_eval.preset import add_preset_run_flag, register_preset_subcommand
 from sgl_eval.registry import list_evals
 from sgl_eval.sampler import ChatCompletionSampler
@@ -75,6 +76,16 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="skip streaming per-sample prediction JSONL (output-rs*.jsonl)",
     )
     p_run.set_defaults(func=cmd_run, dump_predictions=True)
+
+    p_refresh = sub.add_parser(
+        "refresh",
+        help="recompute metrics.json from an existing run directory (no requests)",
+    )
+    p_refresh.add_argument(
+        "run_dir",
+        help="path to a run dir, e.g. ~/.sgl_eval/sgl_eval_aime24_<stamp>/",
+    )
+    p_refresh.set_defaults(func=cmd_refresh)
 
     register_preset_subcommand(sub)
 

--- a/sgl_eval/pipeline/__init__.py
+++ b/sgl_eval/pipeline/__init__.py
@@ -4,6 +4,7 @@ Stage 2 ``spec.run`` : live sampling + scoring + aggregation -> RunResult
 Stage 3 ``report``   : stdout summary + metrics.json + footer + exit code
 """
 
+from sgl_eval.pipeline.refresh import cmd_refresh
 from sgl_eval.pipeline.run import cmd_run
 
-__all__ = ["cmd_run"]
+__all__ = ["cmd_refresh", "cmd_run"]

--- a/sgl_eval/pipeline/refresh.py
+++ b/sgl_eval/pipeline/refresh.py
@@ -1,0 +1,211 @@
+"""``sgl-eval refresh <run_dir>``: rebuild ``metrics.json`` locally from
+existing ``output-rs*.jsonl``. Pure local computation -- no requests.
+
+Refreshes only what's derivable from predictions (aggregate, token tally,
+partial counts, score bounds). Provenance fields (``model``, ``base_url``,
+``latency_seconds``, ``total_prompt_tokens``, ``ns_commit_sha``, ...) are
+preserved verbatim from the existing ``metrics.json``; if it's absent,
+those fields are simply omitted (built from scratch best-effort).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from sgl_eval.metrics import dump_run, format_summary
+from sgl_eval.pipeline.report import _format_partial_summary, _partial_stats
+from sgl_eval.predictions import PredictionsReader
+from sgl_eval.registry import get
+from sgl_eval.types import Example, ExampleResult, RunResult, Sample
+
+# Fields ``RunResult`` -> ``dump_run`` populate from the result itself; must
+# not appear in ``run_meta`` (would raise the overlap guard).
+_CORE_FIELDS = frozenset(
+    {
+        "name",
+        "num_examples",
+        "n_repeats",
+        "latency_seconds",
+        "output_throughput_tps",
+        "total_completion_tokens",
+        "total_prompt_tokens",
+        "aggregate",
+    }
+)
+
+# Partial-related fields refresh recomputes; old values must be cleared so
+# we don't leave stale "partial=True" / bounds when the run is now complete.
+_REFRESH_FIELDS = frozenset(
+    {
+        "partial",
+        "planned_examples",
+        "completed_samples",
+        "score_lower_bound",
+        "score_upper_bound",
+        "examples_full",
+        "examples_partial",
+        "examples_dropped",
+    }
+)
+
+_RUN_DIR_RE = re.compile(r"^sgl_eval_(?P<name>.+)_\d{8}-\d{6}$")
+
+
+def cmd_refresh(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).expanduser()
+    if not run_dir.is_dir():
+        sys.exit(f"error: {run_dir} is not a directory")
+
+    old_payload = _load_old_metrics(run_dir)
+    name, n_repeats_hint = _resolve_name_and_n_repeats(run_dir, old_payload)
+    spec = get(name)
+
+    reader = PredictionsReader(run_dir, n_repeats=n_repeats_hint)
+    if reader.n_repeats == 0:
+        sys.exit(f"error: no output-rs*.jsonl found in {run_dir}")
+
+    per_example = _build_per_example(reader)
+    n_repeats = reader.n_repeats
+    aggregate = _aggregate(spec.category, per_example, n_repeats)
+
+    completed_samples = sum(len(r.samples) for r in per_example)
+    planned_examples = _resolve_planned_examples(old_payload, per_example)
+    planned_samples = planned_examples * n_repeats
+
+    result = RunResult(
+        name=name,
+        per_example=per_example,
+        aggregate=aggregate,
+        latency=(old_payload or {}).get("latency_seconds", 0.0),
+        num_examples=len(per_example),
+        n_repeats=n_repeats,
+        total_completion_tokens=sum(
+            (s.completion_tokens or 0) for r in per_example for s in r.samples
+        ),
+        # prompt_tokens isn't stored in jsonl; preserve old value or 0.
+        total_prompt_tokens=(old_payload or {}).get("total_prompt_tokens", 0),
+        partial=completed_samples < planned_samples,
+        planned_examples=planned_examples,
+    )
+
+    run_meta = _strip_managed(dict(old_payload or {}))
+    if result.partial:
+        stats = _partial_stats(result)
+        run_meta["partial"] = True
+        run_meta["planned_examples"] = result.planned_examples
+        run_meta["completed_samples"] = stats.completed_samples
+        run_meta["score_lower_bound"] = stats.worst
+        run_meta["score_upper_bound"] = stats.best
+        if n_repeats > 1:
+            run_meta["examples_full"] = stats.full
+            run_meta["examples_partial"] = stats.part
+            run_meta["examples_dropped"] = stats.dropped
+
+    print(format_summary(result))
+    metrics_path = dump_run(result, run_dir, run_meta=run_meta)
+    print(f"\nMetrics: {metrics_path}")
+    if result.partial:
+        print(_format_partial_summary(result, _partial_stats(result)), file=sys.stderr)
+
+    return 0
+
+
+def _load_old_metrics(run_dir: Path) -> Optional[Dict[str, Any]]:
+    path = run_dir / "metrics.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())
+
+
+def _resolve_name_and_n_repeats(
+    run_dir: Path, old_payload: Optional[Dict[str, Any]]
+) -> Tuple[str, Optional[int]]:
+    if old_payload:
+        return old_payload["name"], old_payload.get("n_repeats")
+    m = _RUN_DIR_RE.match(run_dir.name)
+    if not m:
+        sys.exit(
+            f"error: cannot infer benchmark from {run_dir.name!r}; "
+            "expected ``sgl_eval_<bench>_<stamp>`` or a metrics.json with ``name``"
+        )
+    return m.group("name"), None
+
+
+def _resolve_planned_examples(
+    old_payload: Optional[Dict[str, Any]], per_example: List[ExampleResult]
+) -> int:
+    """Best-effort planned-example count: prefer the old metrics' value
+    (the live run knew the dataset slice). Fall back to len(per_example)
+    -- which forces ``partial=False`` since we have no signal of missing
+    examples in a from-scratch refresh."""
+    if old_payload:
+        for k in ("planned_examples", "num_examples"):
+            if k in old_payload:
+                return int(old_payload[k])
+    return len(per_example)
+
+
+def _build_per_example(reader: PredictionsReader) -> List[ExampleResult]:
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for _rep, row in reader.iter_all():
+        ex_id = row["id"]
+        slot = by_id.setdefault(
+            ex_id,
+            {
+                "example": Example(
+                    id=ex_id,
+                    inputs={"problem": row.get("problem", "")},
+                    target=row.get("expected_answer", ""),
+                ),
+                "samples": [],
+                "scores": [],
+                "extracted": [],
+            },
+        )
+        slot["samples"].append(
+            Sample(
+                text=row.get("generation", ""),
+                completion_tokens=row.get("num_generated_tokens"),
+                reasoning_tokens=row.get("num_reasoning_tokens"),
+                generation_start_time=row.get("generation_start_time"),
+                generation_end_time=row.get("generation_end_time"),
+            )
+        )
+        slot["scores"].append(1.0 if row.get("symbolic_correct") else 0.0)
+        slot["extracted"].append(row.get("predicted_answer"))
+    return [
+        ExampleResult(
+            example=v["example"],
+            samples=v["samples"],
+            scores=v["scores"],
+            extracted=v["extracted"],
+        )
+        for v in by_id.values()
+    ]
+
+
+def _aggregate(
+    category: str, per_example: List[ExampleResult], n_repeats: int
+) -> Dict[str, float]:
+    if n_repeats > 1:
+        if category == "math":
+            from sgl_eval.evals._math import aggregate_with_math_metrics
+
+            return aggregate_with_math_metrics(per_example, n_repeats)
+        if category == "multichoice":
+            from sgl_eval.evals._multichoice import aggregate_with_math_metrics
+
+            return aggregate_with_math_metrics(per_example, n_repeats)
+    if not per_example:
+        return {"score": 0.0}
+    means = [sum(r.scores) / len(r.scores) for r in per_example if r.scores]
+    return {"score": sum(means) / len(means) if means else 0.0}
+
+
+def _strip_managed(meta: Dict[str, Any]) -> Dict[str, Any]:
+    return {k: v for k, v in meta.items() if k not in _CORE_FIELDS | _REFRESH_FIELDS}

--- a/sgl_eval/pipeline/refresh.py
+++ b/sgl_eval/pipeline/refresh.py
@@ -1,12 +1,8 @@
 """``sgl-eval refresh <run_dir>``: rebuild ``metrics.json`` locally from
-existing ``output-rs*.jsonl``. Pure local computation -- no requests.
-
-Refreshes only what's derivable from predictions (aggregate, token tally,
-partial counts, score bounds). Provenance fields (``model``, ``base_url``,
-``latency_seconds``, ``total_prompt_tokens``, ``ns_commit_sha``, ...) are
-preserved verbatim from the existing ``metrics.json``; if it's absent,
-those fields are simply omitted (built from scratch best-effort).
-"""
+existing ``output-rs*.jsonl``. Recomputes derivable fields (aggregate,
+token tally, partial counts, score bounds); preserves provenance
+(``model`` / ``base_url`` / ``latency_seconds`` / ``total_prompt_tokens``
+/ ``ns_commit_sha`` / ``preset`` ...). No requests."""
 
 from __future__ import annotations
 
@@ -23,8 +19,8 @@ from sgl_eval.predictions import PredictionsReader
 from sgl_eval.registry import get
 from sgl_eval.types import Example, ExampleResult, RunResult, Sample
 
-# Fields ``RunResult`` -> ``dump_run`` populate from the result itself; must
-# not appear in ``run_meta`` (would raise the overlap guard).
+# dump_run sets these from ``RunResult``; must not appear in run_meta
+# (overlap guard would raise).
 _CORE_FIELDS = frozenset(
     {
         "name",
@@ -38,8 +34,8 @@ _CORE_FIELDS = frozenset(
     }
 )
 
-# Partial-related fields refresh recomputes; old values must be cleared so
-# we don't leave stale "partial=True" / bounds when the run is now complete.
+# Cleared before re-emit so a run that's now complete loses stale
+# ``partial=True`` / bounds from the previous (partial) metrics.json.
 _REFRESH_FIELDS = frozenset(
     {
         "partial",
@@ -139,10 +135,9 @@ def _resolve_name_and_n_repeats(
 def _resolve_planned_examples(
     old_payload: Optional[Dict[str, Any]], per_example: List[ExampleResult]
 ) -> int:
-    """Best-effort planned-example count: prefer the old metrics' value
-    (the live run knew the dataset slice). Fall back to len(per_example)
-    -- which forces ``partial=False`` since we have no signal of missing
-    examples in a from-scratch refresh."""
+    """Prefer old metrics (the live run knew the dataset slice). Fallback
+    to len(per_example) forces ``partial=False`` -- from-scratch refresh
+    has no signal of dropped examples."""
     if old_payload:
         for k in ("planned_examples", "num_examples"):
             if k in old_payload:
@@ -189,9 +184,7 @@ def _build_per_example(reader: PredictionsReader) -> List[ExampleResult]:
     ]
 
 
-def _aggregate(
-    category: str, per_example: List[ExampleResult], n_repeats: int
-) -> Dict[str, float]:
+def _aggregate(category: str, per_example: List[ExampleResult], n_repeats: int) -> Dict[str, float]:
     if n_repeats > 1:
         if category == "math":
             from sgl_eval.evals._math import aggregate_with_math_metrics

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -34,7 +34,8 @@ def _row(ex_id: str, correct: bool, tokens: int = 10, predicted: str = "x") -> d
 
 
 def test_refresh_round_trip_no_old_metrics(tmp_path: Path) -> None:
-    """No metrics.json -> benchmark name parsed from dirname."""
+    """No metrics.json -> benchmark name parsed from dirname; aggregate
+    + tokens recomputed from jsonl."""
     run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
     run_dir.mkdir()
     _write_jsonl(
@@ -48,15 +49,15 @@ def test_refresh_round_trip_no_old_metrics(tmp_path: Path) -> None:
     payload = json.loads((run_dir / "metrics.json").read_text())
     assert payload["name"] == "aime24"
     assert payload["num_examples"] == 3
-    assert payload["n_repeats"] == 1
-    # 2/3 correct -> mean accuracy 2/3
     assert payload["aggregate"]["score"] == pytest.approx(2 / 3)
     assert payload["total_completion_tokens"] == 30
-    assert "partial" not in payload  # planned == completed when no old metrics
+    assert "partial" not in payload  # no signal of dropped examples
 
 
-def test_refresh_preserves_provenance_overwrites_aggregate(tmp_path: Path) -> None:
-    """Provenance survives; aggregate / tokens / partial fields recomputed."""
+def test_refresh_preserves_provenance_and_clears_stale_partial(tmp_path: Path) -> None:
+    """Provenance (model / latency / ns_commit_sha / total_prompt_tokens)
+    survives. Aggregate / tokens recomputed. Old ``partial=True`` + bounds
+    drop when the jsonl now covers the full plan."""
     run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
     run_dir.mkdir()
     (run_dir / "metrics.json").write_text(
@@ -65,6 +66,7 @@ def test_refresh_preserves_provenance_overwrites_aggregate(tmp_path: Path) -> No
                 "name": "aime24",
                 "num_examples": 1,  # stale
                 "n_repeats": 1,
+                "planned_examples": 2,  # full plan
                 "latency_seconds": 99.5,
                 "output_throughput_tps": 0.05,
                 "total_completion_tokens": 5,  # stale
@@ -72,33 +74,39 @@ def test_refresh_preserves_provenance_overwrites_aggregate(tmp_path: Path) -> No
                 "aggregate": {"score": 0.0},  # stale
                 "model": "DSv3.2",
                 "ns_commit_sha": "abc123",
-                "sgl_eval_version": "0.1.0",
-                "timestamp": "20260502-120000",
-                "base_url": "http://x:30000/v1",
-                "num_threads": 64,
+                # Stale partial fields from a previous abort:
+                "partial": True,
+                "completed_samples": 1,
+                "score_lower_bound": 0.5,
+                "score_upper_bound": 1.0,
             }
         )
     )
-    _write_jsonl(run_dir / "output-rs0.jsonl", [_row("aime24-0", True, tokens=7)])
+    _write_jsonl(
+        run_dir / "output-rs0.jsonl",
+        [_row("aime24-0", True, tokens=7), _row("aime24-1", True, tokens=3)],
+    )
 
     cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))
     payload = json.loads((run_dir / "metrics.json").read_text())
     # Recomputed
     assert payload["aggregate"]["score"] == 1.0
-    assert payload["total_completion_tokens"] == 7
-    assert payload["num_examples"] == 1
+    assert payload["total_completion_tokens"] == 10
+    assert payload["num_examples"] == 2
     # Preserved
     assert payload["latency_seconds"] == 99.5
     assert payload["total_prompt_tokens"] == 200
     assert payload["model"] == "DSv3.2"
     assert payload["ns_commit_sha"] == "abc123"
-    assert payload["sgl_eval_version"] == "0.1.0"
-    assert payload["base_url"] == "http://x:30000/v1"
+    # Stale partial fields cleared
+    assert "partial" not in payload
+    assert "score_lower_bound" not in payload
+    assert "score_upper_bound" not in payload
 
 
 def test_refresh_partial_emits_score_bounds(tmp_path: Path) -> None:
-    """planned=3 from old metrics, only 1 completed in jsonl -> partial=True
-    + sample-level bounds."""
+    """planned=3 from old metrics, only 1 completed in jsonl ->
+    partial=True + sample-level bounds."""
     run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
     run_dir.mkdir()
     (run_dir / "metrics.json").write_text(
@@ -123,58 +131,6 @@ def test_refresh_partial_emits_score_bounds(tmp_path: Path) -> None:
     assert payload["partial"] is True
     assert payload["planned_examples"] == 3
     assert payload["completed_samples"] == 1
-    # 1 correct out of 3 planned -> worst 1/3, best (1+2)/3 = 1.0
+    # 1 correct of 3 planned -> worst 1/3, best (1+2)/3 = 1.0
     assert payload["score_lower_bound"] == pytest.approx(1 / 3)
     assert payload["score_upper_bound"] == pytest.approx(1.0)
-
-
-def test_refresh_complete_run_clears_stale_partial_flag(tmp_path: Path) -> None:
-    """Old ``partial=True`` but jsonl now covers full plan -> partial fields
-    must drop, not linger as stale."""
-    run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
-    run_dir.mkdir()
-    (run_dir / "metrics.json").write_text(
-        json.dumps(
-            {
-                "name": "aime24",
-                "num_examples": 2,
-                "n_repeats": 1,
-                "planned_examples": 2,
-                "latency_seconds": 5.0,
-                "output_throughput_tps": 1.0,
-                "total_completion_tokens": 0,
-                "total_prompt_tokens": 0,
-                "aggregate": {"score": 0.0},
-                "partial": True,  # stale: full data is on disk now
-                "completed_samples": 1,
-                "score_lower_bound": 0.5,
-                "score_upper_bound": 1.0,
-            }
-        )
-    )
-    _write_jsonl(
-        run_dir / "output-rs0.jsonl",
-        [_row("aime24-0", True), _row("aime24-1", True)],
-    )
-
-    cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))
-    payload = json.loads((run_dir / "metrics.json").read_text())
-    assert "partial" not in payload
-    assert "score_lower_bound" not in payload
-    assert "score_upper_bound" not in payload
-    assert payload["aggregate"]["score"] == 1.0
-
-
-def test_refresh_errors_on_no_jsonl(tmp_path: Path) -> None:
-    run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
-    run_dir.mkdir()
-    with pytest.raises(SystemExit, match="no output-rs"):
-        cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))
-
-
-def test_refresh_errors_on_unparseable_dirname_without_metrics(tmp_path: Path) -> None:
-    run_dir = tmp_path / "random_dir_name"
-    run_dir.mkdir()
-    _write_jsonl(run_dir / "output-rs0.jsonl", [_row("x-0", True)])
-    with pytest.raises(SystemExit, match="cannot infer benchmark"):
-        cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,11 +1,6 @@
-"""``sgl-eval refresh`` round-trip tests: write predictions, refresh,
-verify metrics.json is recomputed and provenance fields preserved.
-
-Uses ``aime24`` as the registered benchmark since it's bundled and the
-math aggregator path is the most-trafficked one. The actual problem text
-is fake -- refresh doesn't re-grade, it reads ``symbolic_correct`` straight
-from the jsonl rows.
-"""
+"""``sgl-eval refresh`` round-trip tests. Uses ``aime24`` (bundled, math
+category). Refresh doesn't re-grade -- it reads ``symbolic_correct`` from
+jsonl rows -- so problem text in fixtures is intentionally fake."""
 
 from __future__ import annotations
 
@@ -39,8 +34,7 @@ def _row(ex_id: str, correct: bool, tokens: int = 10, predicted: str = "x") -> d
 
 
 def test_refresh_round_trip_no_old_metrics(tmp_path: Path) -> None:
-    """Refresh works with only ``output-rs*.jsonl`` -- benchmark name is
-    parsed from the run-dir filename when ``metrics.json`` is absent."""
+    """No metrics.json -> benchmark name parsed from dirname."""
     run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
     run_dir.mkdir()
     _write_jsonl(
@@ -62,8 +56,7 @@ def test_refresh_round_trip_no_old_metrics(tmp_path: Path) -> None:
 
 
 def test_refresh_preserves_provenance_overwrites_aggregate(tmp_path: Path) -> None:
-    """Provenance (model / latency / ns_commit_sha / etc.) survives;
-    aggregate / token tally / partial fields get recomputed."""
+    """Provenance survives; aggregate / tokens / partial fields recomputed."""
     run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
     run_dir.mkdir()
     (run_dir / "metrics.json").write_text(
@@ -104,8 +97,8 @@ def test_refresh_preserves_provenance_overwrites_aggregate(tmp_path: Path) -> No
 
 
 def test_refresh_partial_emits_score_bounds(tmp_path: Path) -> None:
-    """Old metrics knew planned=3 but only 1 example completed; refresh
-    must surface the partial flag + sample-level bounds."""
+    """planned=3 from old metrics, only 1 completed in jsonl -> partial=True
+    + sample-level bounds."""
     run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
     run_dir.mkdir()
     (run_dir / "metrics.json").write_text(
@@ -136,8 +129,8 @@ def test_refresh_partial_emits_score_bounds(tmp_path: Path) -> None:
 
 
 def test_refresh_complete_run_clears_stale_partial_flag(tmp_path: Path) -> None:
-    """If the old metrics was ``partial=True`` but the predictions now
-    cover the full plan, refresh must drop the partial fields."""
+    """Old ``partial=True`` but jsonl now covers full plan -> partial fields
+    must drop, not linger as stale."""
     run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
     run_dir.mkdir()
     (run_dir / "metrics.json").write_text(
@@ -173,7 +166,6 @@ def test_refresh_complete_run_clears_stale_partial_flag(tmp_path: Path) -> None:
 
 
 def test_refresh_errors_on_no_jsonl(tmp_path: Path) -> None:
-    """Empty run_dir (no jsonl) -> exit with a clear error."""
     run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
     run_dir.mkdir()
     with pytest.raises(SystemExit, match="no output-rs"):
@@ -181,7 +173,6 @@ def test_refresh_errors_on_no_jsonl(tmp_path: Path) -> None:
 
 
 def test_refresh_errors_on_unparseable_dirname_without_metrics(tmp_path: Path) -> None:
-    """No metrics.json AND non-conforming dir name -> we can't infer benchmark."""
     run_dir = tmp_path / "random_dir_name"
     run_dir.mkdir()
     _write_jsonl(run_dir / "output-rs0.jsonl", [_row("x-0", True)])

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,0 +1,189 @@
+"""``sgl-eval refresh`` round-trip tests: write predictions, refresh,
+verify metrics.json is recomputed and provenance fields preserved.
+
+Uses ``aime24`` as the registered benchmark since it's bundled and the
+math aggregator path is the most-trafficked one. The actual problem text
+is fake -- refresh doesn't re-grade, it reads ``symbolic_correct`` straight
+from the jsonl rows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sgl_eval.pipeline.refresh import cmd_refresh
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def _row(ex_id: str, correct: bool, tokens: int = 10, predicted: str = "x") -> dict:
+    return {
+        "id": ex_id,
+        "problem": f"Q for {ex_id}",
+        "expected_answer": "x",
+        "generation": f"think...\\boxed{{{predicted}}}",
+        "predicted_answer": predicted,
+        "symbolic_correct": correct,
+        "num_generated_tokens": tokens,
+        "num_reasoning_tokens": 0,
+        "num_answer_tokens": tokens,
+    }
+
+
+def test_refresh_round_trip_no_old_metrics(tmp_path: Path) -> None:
+    """Refresh works with only ``output-rs*.jsonl`` -- benchmark name is
+    parsed from the run-dir filename when ``metrics.json`` is absent."""
+    run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
+    run_dir.mkdir()
+    _write_jsonl(
+        run_dir / "output-rs0.jsonl",
+        [_row("aime24-0", True), _row("aime24-1", False), _row("aime24-2", True)],
+    )
+
+    rc = cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))
+    assert rc == 0
+
+    payload = json.loads((run_dir / "metrics.json").read_text())
+    assert payload["name"] == "aime24"
+    assert payload["num_examples"] == 3
+    assert payload["n_repeats"] == 1
+    # 2/3 correct -> mean accuracy 2/3
+    assert payload["aggregate"]["score"] == pytest.approx(2 / 3)
+    assert payload["total_completion_tokens"] == 30
+    assert "partial" not in payload  # planned == completed when no old metrics
+
+
+def test_refresh_preserves_provenance_overwrites_aggregate(tmp_path: Path) -> None:
+    """Provenance (model / latency / ns_commit_sha / etc.) survives;
+    aggregate / token tally / partial fields get recomputed."""
+    run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
+    run_dir.mkdir()
+    (run_dir / "metrics.json").write_text(
+        json.dumps(
+            {
+                "name": "aime24",
+                "num_examples": 1,  # stale
+                "n_repeats": 1,
+                "latency_seconds": 99.5,
+                "output_throughput_tps": 0.05,
+                "total_completion_tokens": 5,  # stale
+                "total_prompt_tokens": 200,  # not in jsonl, must survive
+                "aggregate": {"score": 0.0},  # stale
+                "model": "DSv3.2",
+                "ns_commit_sha": "abc123",
+                "sgl_eval_version": "0.1.0",
+                "timestamp": "20260502-120000",
+                "base_url": "http://x:30000/v1",
+                "num_threads": 64,
+            }
+        )
+    )
+    _write_jsonl(run_dir / "output-rs0.jsonl", [_row("aime24-0", True, tokens=7)])
+
+    cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))
+    payload = json.loads((run_dir / "metrics.json").read_text())
+    # Recomputed
+    assert payload["aggregate"]["score"] == 1.0
+    assert payload["total_completion_tokens"] == 7
+    assert payload["num_examples"] == 1
+    # Preserved
+    assert payload["latency_seconds"] == 99.5
+    assert payload["total_prompt_tokens"] == 200
+    assert payload["model"] == "DSv3.2"
+    assert payload["ns_commit_sha"] == "abc123"
+    assert payload["sgl_eval_version"] == "0.1.0"
+    assert payload["base_url"] == "http://x:30000/v1"
+
+
+def test_refresh_partial_emits_score_bounds(tmp_path: Path) -> None:
+    """Old metrics knew planned=3 but only 1 example completed; refresh
+    must surface the partial flag + sample-level bounds."""
+    run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
+    run_dir.mkdir()
+    (run_dir / "metrics.json").write_text(
+        json.dumps(
+            {
+                "name": "aime24",
+                "num_examples": 3,
+                "n_repeats": 1,
+                "planned_examples": 3,
+                "latency_seconds": 10.0,
+                "output_throughput_tps": 1.0,
+                "total_completion_tokens": 10,
+                "total_prompt_tokens": 30,
+                "aggregate": {"score": 0.0},
+            }
+        )
+    )
+    _write_jsonl(run_dir / "output-rs0.jsonl", [_row("aime24-0", True)])
+
+    cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))
+    payload = json.loads((run_dir / "metrics.json").read_text())
+    assert payload["partial"] is True
+    assert payload["planned_examples"] == 3
+    assert payload["completed_samples"] == 1
+    # 1 correct out of 3 planned -> worst 1/3, best (1+2)/3 = 1.0
+    assert payload["score_lower_bound"] == pytest.approx(1 / 3)
+    assert payload["score_upper_bound"] == pytest.approx(1.0)
+
+
+def test_refresh_complete_run_clears_stale_partial_flag(tmp_path: Path) -> None:
+    """If the old metrics was ``partial=True`` but the predictions now
+    cover the full plan, refresh must drop the partial fields."""
+    run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
+    run_dir.mkdir()
+    (run_dir / "metrics.json").write_text(
+        json.dumps(
+            {
+                "name": "aime24",
+                "num_examples": 2,
+                "n_repeats": 1,
+                "planned_examples": 2,
+                "latency_seconds": 5.0,
+                "output_throughput_tps": 1.0,
+                "total_completion_tokens": 0,
+                "total_prompt_tokens": 0,
+                "aggregate": {"score": 0.0},
+                "partial": True,  # stale: full data is on disk now
+                "completed_samples": 1,
+                "score_lower_bound": 0.5,
+                "score_upper_bound": 1.0,
+            }
+        )
+    )
+    _write_jsonl(
+        run_dir / "output-rs0.jsonl",
+        [_row("aime24-0", True), _row("aime24-1", True)],
+    )
+
+    cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))
+    payload = json.loads((run_dir / "metrics.json").read_text())
+    assert "partial" not in payload
+    assert "score_lower_bound" not in payload
+    assert "score_upper_bound" not in payload
+    assert payload["aggregate"]["score"] == 1.0
+
+
+def test_refresh_errors_on_no_jsonl(tmp_path: Path) -> None:
+    """Empty run_dir (no jsonl) -> exit with a clear error."""
+    run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
+    run_dir.mkdir()
+    with pytest.raises(SystemExit, match="no output-rs"):
+        cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))
+
+
+def test_refresh_errors_on_unparseable_dirname_without_metrics(tmp_path: Path) -> None:
+    """No metrics.json AND non-conforming dir name -> we can't infer benchmark."""
+    run_dir = tmp_path / "random_dir_name"
+    run_dir.mkdir()
+    _write_jsonl(run_dir / "output-rs0.jsonl", [_row("x-0", True)])
+    with pytest.raises(SystemExit, match="cannot infer benchmark"):
+        cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))


### PR DESCRIPTION
`sgl-eval refresh <run_dir>` recomputes the aggregate from existing `output-rs*.jsonl` -- no requests, pure local computation.

Use cases:
- Vendored grader bumped; rescore an old run with the new `MathMetrics`
- Partial run aborted mid-way; rebuild metrics.json with the partial flag + score bounds

Behavior:
- Reads `metrics.json` for benchmark name + n_repeats + run_meta. Absent? Parse `sgl_eval_<bench>_<stamp>` from dirname; `PredictionsReader` autodetects n_repeats.
- Recomputes only what's locally derivable: `aggregate`, `num_examples`, `total_completion_tokens`, `partial` flag, `score_lower_bound` / `score_upper_bound`, full / partial / dropped example counts.
- Preserves provenance: `model`, `base_url`, `latency_seconds`, `total_prompt_tokens` (not in jsonl), `ns_commit_sha`, `sgl_eval_version`, `timestamp`, `preset`.
- Stale partial fields are dropped when refresh shows the run is now complete.

Files:
- `sgl_eval/pipeline/refresh.py` (160 lines)
- `sgl_eval/cli.py` (+12 lines: sub-parser)
- `tests/test_refresh.py` (6 tests covering round-trip / provenance / partial / stale-clear / error paths)

108 tests pass.