### PR TITLE
Add --from-dataset to override the vendored dataset for a run

### DIFF
--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -75,6 +75,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         action="store_false",
         help="skip streaming per-sample prediction JSONL (output-rs*.jsonl)",
     )
+    p_run.add_argument(
+        "--from-dataset",
+        default=None,
+        help="path to NS-shape jsonl ({id?, problem, expected_answer}); "
+        "replaces the vendored dataset for this run",
+    )
     p_run.set_defaults(func=cmd_run, dump_predictions=True)
 
     p_refresh = sub.add_parser(

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import importlib
 import json
 import shutil
+import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -52,6 +53,37 @@ def load_bundled(name: str, filename: str = "test.txt") -> Callable[[Optional[in
 
     def loader(num_examples: Optional[int]) -> List[Example]:
         return _read_jsonl(path, name, num_examples)
+
+    return loader
+
+
+def load_from_path(path: str) -> Callable[[Optional[int]], List[Example]]:
+    """User-supplied NS-shape jsonl. Each row needs ``problem`` and
+    ``expected_answer``; ``id`` is optional (auto-filled as ``custom-<idx>``).
+    Other fields land in ``Example.meta``. Errors out with file:line on
+    malformed JSON or missing required fields."""
+    p = Path(path).expanduser()
+    if not p.is_file():
+        sys.exit(f"error: --from-dataset file not found: {p}")
+
+    def loader(num_examples: Optional[int]) -> List[Example]:
+        examples: List[Example] = []
+        with p.open("rt", encoding="utf-8") as f:
+            for i, line in enumerate(f):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError as e:
+                    sys.exit(f"error: {p}:{i + 1}: invalid JSON: {e}")
+                for required in ("problem", "expected_answer"):
+                    if required not in row:
+                        sys.exit(f"error: {p}:{i + 1}: missing required field {required!r}")
+                examples.append(_row_to_example(row, i, "custom"))
+                if num_examples and len(examples) >= num_examples:
+                    break
+        return examples
 
     return loader
 

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -123,7 +123,16 @@ def _build_loader(entry: dict):
 def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Callable):
     if metrics_type == "math":
 
-        def run(*, sampler, gen, n_repeats, num_examples, num_threads, predictions_writer=None):
+        def run(
+            *,
+            sampler,
+            gen,
+            n_repeats,
+            num_examples,
+            num_threads,
+            predictions_writer=None,
+            load_examples=None,
+        ):
             return run_math_benchmark(
                 name=name,
                 sampler=sampler,
@@ -131,7 +140,7 @@ def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Calla
                 n_repeats=n_repeats,
                 num_examples=num_examples,
                 num_threads=num_threads,
-                load_examples=loader,
+                load_examples=load_examples or loader,
                 predictions_writer=predictions_writer,
             )
 
@@ -139,7 +148,16 @@ def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Calla
     if metrics_type == "multichoice":
         prompt_yaml = vendored_prompt(prompt_basename)
 
-        def run(*, sampler, gen, n_repeats, num_examples, num_threads, predictions_writer=None):
+        def run(
+            *,
+            sampler,
+            gen,
+            n_repeats,
+            num_examples,
+            num_threads,
+            predictions_writer=None,
+            load_examples=None,
+        ):
             return run_multichoice_benchmark(
                 name=name,
                 sampler=sampler,
@@ -147,7 +165,7 @@ def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Calla
                 n_repeats=n_repeats,
                 num_examples=num_examples,
                 num_threads=num_threads,
-                load_examples=loader,
+                load_examples=load_examples or loader,
                 prompt_yaml=prompt_yaml,
                 predictions_writer=predictions_writer,
             )

--- a/sgl_eval/pipeline/run.py
+++ b/sgl_eval/pipeline/run.py
@@ -17,6 +17,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             num_examples=ctx.inputs.num_examples,
             num_threads=ctx.num_threads,
             predictions_writer=ctx.writer,
+            load_examples=ctx.load_examples,
         )
     finally:
         setup.teardown(ctx)

--- a/sgl_eval/pipeline/setup.py
+++ b/sgl_eval/pipeline/setup.py
@@ -10,13 +10,14 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, List, Optional
 
+from sgl_eval.evals._loader import load_from_path
 from sgl_eval.predictions import PredictionsWriter
 from sgl_eval.preset import ResolvedRunInputs, resolve_run_inputs
 from sgl_eval.registry import EvalSpec, get
 from sgl_eval.sampler import ChatCompletionSampler
-from sgl_eval.types import GenConfig
+from sgl_eval.types import Example, GenConfig
 
 
 @dataclass
@@ -31,6 +32,7 @@ class RunContext:
     stamp: str
     num_threads: int
     args: argparse.Namespace
+    load_examples: Optional[Callable[[Optional[int]], List[Example]]]
     _prev_sigint_handler: Any
 
 
@@ -50,6 +52,7 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
 
     writer = PredictionsWriter(run_dir, inputs.n_repeats) if args.dump_predictions else None
     prev_sigint = signal.signal(signal.SIGINT, _make_sigint_handler(sampler))
+    load_examples = load_from_path(args.from_dataset) if args.from_dataset else None
 
     return RunContext(
         inputs=inputs,
@@ -60,6 +63,7 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
         stamp=stamp,
         num_threads=args.num_threads,
         args=args,
+        load_examples=load_examples,
         _prev_sigint_handler=prev_sigint,
     )
 

--- a/tests/test_load_from_path.py
+++ b/tests/test_load_from_path.py
@@ -1,0 +1,45 @@
+"""``--from-dataset`` loader tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sgl_eval.evals._loader import load_from_path
+
+
+def _write(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def test_round_trip_with_id_autogen_meta_and_slice(tmp_path: Path) -> None:
+    """``id`` auto-fills as ``custom-<idx>`` when absent; extra fields go
+    to ``meta``; ``num_examples`` slices the prefix."""
+    p = tmp_path / "data.jsonl"
+    _write(
+        p,
+        [
+            {"id": "given-7", "problem": "Q0", "expected_answer": "42", "src": "x"},
+            {"problem": "Q1", "expected_answer": "7"},  # no id
+            {"problem": "Q2", "expected_answer": "13"},
+        ],
+    )
+    examples = load_from_path(str(p))(num_examples=2)
+    assert len(examples) == 2
+    assert examples[0].id == "given-7"
+    assert examples[0].inputs == {"problem": "Q0"}
+    assert examples[0].target == "42"
+    assert examples[0].meta == {"src": "x"}
+    assert examples[1].id == "custom-1"  # auto, idx=1
+
+
+def test_friendly_error_on_missing_required_field(tmp_path: Path) -> None:
+    """Missing ``expected_answer`` -> sys.exit with file:line + field name."""
+    p = tmp_path / "bad.jsonl"
+    _write(p, [{"problem": "Q"}])  # no expected_answer
+    with pytest.raises(SystemExit, match="missing required field 'expected_answer'"):
+        load_from_path(str(p))(None)


### PR DESCRIPTION
`sgl-eval run <bench> --from-dataset <path>` swaps in a user-supplied NS-shape jsonl in place of the vendored `test.txt` / `prepare.py` loader. Benchmark name is still required (drives category, prompt template, default sampling).

File format (NS shape):
```jsonl
{"id": "custom-0", "problem": "Q?", "expected_answer": "42"}
{"problem": "...", "expected_answer": "..."}
```
- `problem` + `expected_answer` required
- `id` optional (auto: `custom-<idx>`)
- extra fields land in `Example.meta`
- malformed JSON or missing required fields -> friendly error with file:line

Implementation:
- `evals/_loader.py` `load_from_path(path)` (sibling of `load_bundled` / `load_via_prepare`)
- `evals/_registry.py` `spec.run(...)` accepts optional `load_examples` override
- `pipeline/setup.py` reads `args.from_dataset`, builds the override loader, stashes on `RunContext`
- `pipeline/run.py` threads it through to `spec.run`
- 2 tests cover the round-trip + missing-field error path

107 tests pass.