### PR TITLE
Report generation-stopping signals (finish_reason / stop_rate / truncated_rate)

### DIFF
--- a/sgl_eval/metrics.py
+++ b/sgl_eval/metrics.py
@@ -117,8 +117,11 @@ def _build_rows(agg: Dict[str, float], k: int) -> List[Tuple[bool, str, str, Opt
         rows.append((False, "stop_rate", f"{stop_rate * 100:.2f}%", None))
     truncated_rate = agg.get("truncated_rate")
     if truncated_rate is not None:
-        # A nonzero truncation rate means generations are running to the token
-        # cap (possible no-EOS runaway), which no_answer alone doesn't reveal.
+        # Nonzero => generations hit the token cap (no-EOS runaway).
         note = "warn: hitting max_tokens" if truncated_rate >= 0.01 else None
         rows.append((False, "truncated_rate", f"{truncated_rate * 100:.2f}%", note))
+    error_rate = agg.get("error_rate")
+    if error_rate is not None:
+        note = "warn: request errors" if error_rate >= 0.01 else None
+        rows.append((False, "error_rate", f"{error_rate * 100:.2f}%", note))
     return rows

--- a/sgl_eval/metrics.py
+++ b/sgl_eval/metrics.py
@@ -111,4 +111,14 @@ def _build_rows(agg: Dict[str, float], k: int) -> List[Tuple[bool, str, str, Opt
     if no_answer is not None:
         note = "warn: consider --max-tokens" if no_answer >= 0.05 else None
         rows.append((False, "no_answer", f"{no_answer * 100:.2f}%", note))
+
+    stop_rate = agg.get("stop_rate")
+    if stop_rate is not None:
+        rows.append((False, "stop_rate", f"{stop_rate * 100:.2f}%", None))
+    truncated_rate = agg.get("truncated_rate")
+    if truncated_rate is not None:
+        # A nonzero truncation rate means generations are running to the token
+        # cap (possible no-EOS runaway), which no_answer alone doesn't reveal.
+        note = "warn: hitting max_tokens" if truncated_rate >= 0.01 else None
+        rows.append((False, "truncated_rate", f"{truncated_rate * 100:.2f}%", note))
     return rows

--- a/sgl_eval/predictions.py
+++ b/sgl_eval/predictions.py
@@ -25,8 +25,7 @@ def sample_to_pred(sample: Sample, example: Example) -> Dict[str, Any]:
         "num_generated_tokens": completion,
         "num_reasoning_tokens": reasoning,
         "num_answer_tokens": max(completion - reasoning, 0),
-        # Why a generation stopped ("stop" / "length" / None). Surfaces
-        # no-EOS runaways (finish_reason="length") that token counts alone hide.
+        # Generation stop reason ("stop" / "length" / "error").
         "finish_reason": sample.finish_reason,
         "problem": example.inputs.get("problem", ""),
     }

--- a/sgl_eval/predictions.py
+++ b/sgl_eval/predictions.py
@@ -25,6 +25,9 @@ def sample_to_pred(sample: Sample, example: Example) -> Dict[str, Any]:
         "num_generated_tokens": completion,
         "num_reasoning_tokens": reasoning,
         "num_answer_tokens": max(completion - reasoning, 0),
+        # Why a generation stopped ("stop" / "length" / None). Surfaces
+        # no-EOS runaways (finish_reason="length") that token counts alone hide.
+        "finish_reason": sample.finish_reason,
         "problem": example.inputs.get("problem", ""),
     }
     # NS ``BaseMetrics.update`` skips entries missing these keys; only set

--- a/sgl_eval/runner/__init__.py
+++ b/sgl_eval/runner/__init__.py
@@ -101,8 +101,6 @@ def run_examples(
     total_prompt = sum(s.prompt_tokens or 0 for r in results for s in r.samples if s)
 
     aggregate = aggregate_fn(results) if aggregate_fn else _default_aggregate(results)
-    # Merge generation-stopping rates (finish_reason) for every eval type;
-    # don't clobber if an aggregator already supplied its own.
     for key, value in _finish_reason_rates(results).items():
         aggregate.setdefault(key, value)
 
@@ -131,10 +129,9 @@ def _default_aggregate(results: List[ExampleResult]) -> Dict[str, float]:
 
 
 def _finish_reason_rates(results: List[ExampleResult]) -> Dict[str, float]:
-    """Fraction of samples that stopped on EOS vs. hit the token cap, over
-    samples whose ``finish_reason`` is known. A high ``truncated_rate`` flags a
-    no-EOS runaway that ``no_answer`` (extraction failure) silently hides.
-    Samples with ``finish_reason=None`` are excluded from the denominator."""
+    """Per-stop-reason fractions over samples with a known ``finish_reason``
+    (None excluded). ``truncated_rate`` flags no-EOS runaways; ``error_rate``
+    covers any other reason (sampler sets ``"error"`` on failed requests)."""
     reasons = [s.finish_reason for r in results for s in r.samples if s and s.finish_reason]
     if not reasons:
         return {}
@@ -142,4 +139,5 @@ def _finish_reason_rates(results: List[ExampleResult]) -> Dict[str, float]:
     return {
         "stop_rate": sum(fr == "stop" for fr in reasons) / n,
         "truncated_rate": sum(fr == "length" for fr in reasons) / n,
+        "error_rate": sum(fr not in ("stop", "length") for fr in reasons) / n,
     }

--- a/sgl_eval/runner/__init__.py
+++ b/sgl_eval/runner/__init__.py
@@ -101,6 +101,10 @@ def run_examples(
     total_prompt = sum(s.prompt_tokens or 0 for r in results for s in r.samples if s)
 
     aggregate = aggregate_fn(results) if aggregate_fn else _default_aggregate(results)
+    # Merge generation-stopping rates (finish_reason) for every eval type;
+    # don't clobber if an aggregator already supplied its own.
+    for key, value in _finish_reason_rates(results).items():
+        aggregate.setdefault(key, value)
 
     planned_samples = len(examples) * n_repeats
     completed_samples = sum(len(r.samples) for r in results)
@@ -124,3 +128,18 @@ def _default_aggregate(results: List[ExampleResult]) -> Dict[str, float]:
     per_example_means = [sum(r.scores) / len(r.scores) for r in results if r.scores]
     score = sum(per_example_means) / len(per_example_means) if per_example_means else 0.0
     return {"score": score}
+
+
+def _finish_reason_rates(results: List[ExampleResult]) -> Dict[str, float]:
+    """Fraction of samples that stopped on EOS vs. hit the token cap, over
+    samples whose ``finish_reason`` is known. A high ``truncated_rate`` flags a
+    no-EOS runaway that ``no_answer`` (extraction failure) silently hides.
+    Samples with ``finish_reason=None`` are excluded from the denominator."""
+    reasons = [s.finish_reason for r in results for s in r.samples if s and s.finish_reason]
+    if not reasons:
+        return {}
+    n = len(reasons)
+    return {
+        "stop_rate": sum(fr == "stop" for fr in reasons) / n,
+        "truncated_rate": sum(fr == "length" for fr in reasons) / n,
+    }

--- a/tests/test_dump_run.py
+++ b/tests/test_dump_run.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from sgl_eval.metrics import dump_run
+from sgl_eval.metrics import dump_run, format_summary
 from sgl_eval.types import RunResult
 
 
@@ -68,3 +68,39 @@ def test_run_meta_overlap_with_core_field_raises(tmp_path: Path, clashing_key: s
     """Reserved core fields must not be silently overridden by run_meta."""
     with pytest.raises(ValueError, match="overlaps reserved metrics fields"):
         dump_run(_result(), tmp_path, run_meta={clashing_key: "bogus"})
+
+
+def _result_with(aggregate: dict) -> RunResult:
+    return RunResult(
+        name="test_bench",
+        per_example=[],
+        aggregate=aggregate,
+        latency=12.5,
+        num_examples=10,
+        n_repeats=1,
+        total_completion_tokens=1000,
+        total_prompt_tokens=200,
+    )
+
+
+def test_summary_surfaces_finish_reason_rates() -> None:
+    """``stop_rate`` / ``truncated_rate`` render in the summary alongside
+    ``no_answer`` when present in the aggregate."""
+    summary = format_summary(
+        _result_with({"score": 0.8, "no_answer": 0.0, "stop_rate": 0.9, "truncated_rate": 0.1})
+    )
+    assert "stop_rate" in summary and "90.00%" in summary
+    assert "truncated_rate" in summary and "10.00%" in summary
+
+
+def test_summary_warns_on_truncation() -> None:
+    """A nonzero truncation rate flags hitting max_tokens (no-EOS runaway)."""
+    summary = format_summary(_result_with({"score": 0.0, "stop_rate": 0.5, "truncated_rate": 0.5}))
+    assert "warn: hitting max_tokens" in summary
+
+
+def test_summary_omits_finish_reason_rates_when_absent() -> None:
+    """Backward compatible: an aggregate without the new keys shows no rows."""
+    summary = format_summary(_result_with({"score": 0.8, "no_answer": 0.0}))
+    assert "stop_rate" not in summary
+    assert "truncated_rate" not in summary

--- a/tests/test_dump_run.py
+++ b/tests/test_dump_run.py
@@ -87,10 +87,19 @@ def test_summary_surfaces_finish_reason_rates() -> None:
     """``stop_rate`` / ``truncated_rate`` render in the summary alongside
     ``no_answer`` when present in the aggregate."""
     summary = format_summary(
-        _result_with({"score": 0.8, "no_answer": 0.0, "stop_rate": 0.9, "truncated_rate": 0.1})
+        _result_with(
+            {
+                "score": 0.8,
+                "no_answer": 0.0,
+                "stop_rate": 0.9,
+                "truncated_rate": 0.1,
+                "error_rate": 0.0,
+            }
+        )
     )
     assert "stop_rate" in summary and "90.00%" in summary
     assert "truncated_rate" in summary and "10.00%" in summary
+    assert "error_rate" in summary
 
 
 def test_summary_warns_on_truncation() -> None:
@@ -104,3 +113,9 @@ def test_summary_omits_finish_reason_rates_when_absent() -> None:
     summary = format_summary(_result_with({"score": 0.8, "no_answer": 0.0}))
     assert "stop_rate" not in summary
     assert "truncated_rate" not in summary
+
+
+def test_summary_warns_on_error() -> None:
+    """A nonzero error rate flags request failures (e.g. sampler BadRequest)."""
+    summary = format_summary(_result_with({"score": 0.0, "stop_rate": 0.5, "error_rate": 0.5}))
+    assert "warn: request errors" in summary

--- a/tests/test_predictions_writer.py
+++ b/tests/test_predictions_writer.py
@@ -41,10 +41,30 @@ def test_writes_ns_shape_record(tmp_path: Path) -> None:
     assert r["num_generated_tokens"] == 10
     assert r["num_answer_tokens"] == 10
     assert r["num_reasoning_tokens"] == 0
+    assert r["finish_reason"] == "stop"
 
     # The other repeat file is created but stays empty.
     assert (tmp_path / "output-rs1.jsonl").exists()
     assert (tmp_path / "output-rs1.jsonl").read_text() == ""
+
+
+def test_finish_reason_length_and_none_survive(tmp_path: Path) -> None:
+    """``finish_reason`` is written verbatim so downstream analysis can spot
+    no-EOS runaways (``"length"``); an unknown reason serializes as null."""
+    with PredictionsWriter(tmp_path, n_repeats=2) as w:
+        w(
+            _ex(0),
+            0,
+            Sample(text="runaway", completion_tokens=4096, finish_reason="length"),
+            0.0,
+            None,
+        )
+        w(_ex(1), 1, Sample(text="unknown", completion_tokens=10, finish_reason=None), 0.0, None)
+
+    r0 = json.loads((tmp_path / "output-rs0.jsonl").read_text().splitlines()[0])
+    r1 = json.loads((tmp_path / "output-rs1.jsonl").read_text().splitlines()[0])
+    assert r0["finish_reason"] == "length"
+    assert r1["finish_reason"] is None
 
 
 def test_routes_per_repeat(tmp_path: Path) -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import threading
 
+import pytest
+
 from sgl_eval.runner import WorkerAborted, run_examples
 from sgl_eval.types import Example, Sample
 
@@ -208,6 +210,7 @@ def test_runner_reports_finish_reason_rates():
     )
     assert result.aggregate["stop_rate"] == 0.5
     assert result.aggregate["truncated_rate"] == 0.5
+    assert result.aggregate["error_rate"] == 0.0
 
 
 def test_runner_finish_reason_rates_exclude_none():
@@ -232,6 +235,7 @@ def test_runner_finish_reason_rates_exclude_none():
     # Denominator is 2 (None excluded), so each known reason is 1/2.
     assert result.aggregate["stop_rate"] == 0.5
     assert result.aggregate["truncated_rate"] == 0.5
+    assert result.aggregate["error_rate"] == 0.0
 
 
 def test_runner_omits_finish_reason_rates_when_all_none():
@@ -253,3 +257,28 @@ def test_runner_omits_finish_reason_rates_when_all_none():
     )
     assert "stop_rate" not in result.aggregate
     assert "truncated_rate" not in result.aggregate
+
+
+def test_runner_reports_error_rate():
+    """``error_rate`` captures samples whose ``finish_reason`` is neither
+    ``stop`` nor ``length`` (e.g. the sampler sets ``"error"`` on a failed
+    request), so request failures aren't hidden behind stop/truncated."""
+    examples = [Example(id=str(i), inputs={}, target="x") for i in range(3)]
+
+    def errored_sample_fn(ex, _rep_idx):
+        # ex0: stop, ex1: length, ex2: error (request failed).
+        reason = {"0": "stop", "1": "length", "2": "error"}[ex.id]
+        return Sample(text="x", completion_tokens=1, finish_reason=reason)
+
+    result = run_examples(
+        "dummy",
+        examples,
+        errored_sample_fn,
+        _all_correct_score_one_fn,
+        num_threads=3,
+        n_repeats=1,
+        progress=False,
+    )
+    assert result.aggregate["stop_rate"] == pytest.approx(1 / 3)
+    assert result.aggregate["truncated_rate"] == pytest.approx(1 / 3)
+    assert result.aggregate["error_rate"] == pytest.approx(1 / 3)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -185,3 +185,71 @@ def test_runner_invokes_on_sample_scored():
     assert all(s == 1.0 for _, _, _, s, _ in received)
     assert all(extracted == str(eid) for eid, _, _, _, extracted in received)
     assert result.aggregate["score"] == 1.0
+
+
+def test_runner_reports_finish_reason_rates():
+    """``stop_rate`` / ``truncated_rate`` over samples surface no-EOS runaways
+    that ``no_answer`` (extraction failure) can't. Half the samples here hit
+    the token cap (``finish_reason="length"``)."""
+    examples = [Example(id=str(i), inputs={}, target="x") for i in range(4)]
+
+    def mixed_sample_fn(ex, _rep_idx):
+        reason = "length" if int(ex.id) % 2 == 0 else "stop"
+        return Sample(text="x", completion_tokens=1, finish_reason=reason)
+
+    result = run_examples(
+        "dummy",
+        examples,
+        mixed_sample_fn,
+        _all_correct_score_one_fn,
+        num_threads=4,
+        n_repeats=1,
+        progress=False,
+    )
+    assert result.aggregate["stop_rate"] == 0.5
+    assert result.aggregate["truncated_rate"] == 0.5
+
+
+def test_runner_finish_reason_rates_exclude_none():
+    """Samples with unknown ``finish_reason`` drop out of the denominator
+    rather than diluting the rates toward zero."""
+    examples = [Example(id=str(i), inputs={}, target="x") for i in range(3)]
+
+    def some_none_sample_fn(ex, _rep_idx):
+        # ex0: stop, ex1: length, ex2: None (excluded).
+        reason = {"0": "stop", "1": "length"}.get(ex.id)
+        return Sample(text="x", completion_tokens=1, finish_reason=reason)
+
+    result = run_examples(
+        "dummy",
+        examples,
+        some_none_sample_fn,
+        _all_correct_score_one_fn,
+        num_threads=3,
+        n_repeats=1,
+        progress=False,
+    )
+    # Denominator is 2 (None excluded), so each known reason is 1/2.
+    assert result.aggregate["stop_rate"] == 0.5
+    assert result.aggregate["truncated_rate"] == 0.5
+
+
+def test_runner_omits_finish_reason_rates_when_all_none():
+    """No known ``finish_reason`` anywhere -> keys are absent, not 0.0, so a
+    backend that never reports the field doesn't fabricate a 0% stop rate."""
+    examples = [Example(id=str(i), inputs={}, target="x") for i in range(2)]
+
+    def no_reason_sample_fn(_ex, _rep_idx):
+        return Sample(text="x", completion_tokens=1, finish_reason=None)
+
+    result = run_examples(
+        "dummy",
+        examples,
+        no_reason_sample_fn,
+        _all_correct_score_one_fn,
+        num_threads=2,
+        n_repeats=1,
+        progress=False,
+    )
+    assert "stop_rate" not in result.aggregate
+    assert "truncated_rate" not in result.aggregate


### PR DESCRIPTION
Surfaces `finish_reason` so generation-stopping failures aren't hidden.

A no-EOS runaway (every sample hits `max_tokens`) and request failures (sampler sets `finish_reason="error"` on BadRequest / retry exhaustion) both score as wrong answers today — indistinguishable from "model answered wrong." `no_answer` only flags extraction failures. `Sample.finish_reason` is already captured from the OpenAI response but never aggregated or printed.

## Changes

- **`predictions.py`** — write `finish_reason` on each `output-rs*.jsonl` row.
- **`runner/__init__.py`** — compute `stop_rate` / `truncated_rate` / `error_rate` over samples with a known `finish_reason` (None excluded from the denominator; keys omitted entirely when no sample reports a reason). Merged via `setdefault`, so a custom aggregator can override. The three rates cover 100% of samples with a known reason:
  - `stop_rate` — finished on EOS
  - `truncated_rate` — hit the token cap (no-EOS runaway)
  - `error_rate` — any other reason (sampler's `"error"` = request failure)
- **`metrics.py`** — print the rates in the summary; warn on nonzero truncation (`hitting max_tokens`) or error (`request errors`). `dump_run` writes them to `metrics.json` verbatim.

## Tests

`test_predictions_writer` / `test_runner` / `test_dump_run` cover the row field, rate math (None-exclusion, all-None omission, `error_rate`), and summary rendering + warns. Full suite green (116 passed).

---

## 中文

让 `finish_reason` 浮出水面,避免「生成停止类失败」被报告隐藏。

当前,「无 EOS 失控」(每个样本都生成到 `max_tokens`)和请求失败(sampler 在 BadRequest / 重试耗尽时把 `finish_reason` 置为 `"error"`)都会被判为答错——和「模型答错」无法区分。`no_answer` 只标记抽取失败,不反映截断或请求错误。`Sample.finish_reason` 其实已从 OpenAI 响应里采集,但从未被聚合或打印。

### 改动

- **`predictions.py`** —— 在每行 `output-rs*.jsonl` 写入 `finish_reason`。
- **`runner/__init__.py`** —— 在已知 `finish_reason` 的样本上计算 `stop_rate` / `truncated_rate` / `error_rate`(`None` 不计入分母;没有任何样本报告 reason 时整组 key 省略)。通过 `setdefault` 合并,自定义聚合器仍可覆盖。三者对已知 reason 的样本覆盖 100%:
  - `stop_rate` —— 正常结束(EOS)
  - `truncated_rate` —— 触到 token 上限(无 EOS 失控)
  - `error_rate` —— 其他原因(sampler 的 `"error"` = 请求失败)
- **`metrics.py`** —— 在 summary 里打印这些比率;`truncated_rate` 非零时 warn(`hitting max_tokens`),`error_rate` 非零时 warn(`request errors`)。`dump_run` 会把它们原样写进 `metrics.json`。

### 测试

`test_predictions_writer` / `test_runner` / `test_dump_run` 覆盖行字段、比率计算(排除 `None`、全 `None` 时省略、`error_rate`)以及 summary 渲染与 warn。全套测试通过(116 passed)。
