### PR TITLE
Add MMMU-Pro (multimodal 10-choice) + media infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     "numpy>=1.24,<3",
     "pandas>=2.0,<3",
     "datasets>=2.14,<5",
+    # Multimodal benchmarks (MMMU-Pro question image -> PNG bytes)
+    "pillow>=10,<12",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ exclude = ["tests*", "scripts*"]
     "dataset/*/__init__.py",
     "dataset/*/test.txt",
 ]
+"sgl_eval.evals" = ["prompts/*.yaml"]
 
 [tool.ruff]
 target-version = "py310"

--- a/sgl_eval/evals/_mmmu_pro.py
+++ b/sgl_eval/evals/_mmmu_pro.py
@@ -30,7 +30,14 @@ def load_mmmu_pro(split: str = "test", num_examples: Optional[int] = None) -> Li
     examples: List[Example] = []
     for i, row in enumerate(ds):
         question = row["question"]
-        options = list(row.get("options") or [])
+        options = row.get("options")
+        if isinstance(options, str):
+            # HF stores MMMU_Pro options as a Python-literal string ("['a','b',...]"),
+            # not a list; list(str) would split it into characters.
+            import ast
+
+            options = ast.literal_eval(options)
+        options = list(options or [])
         answer = _normalize_answer(row.get("answer"))
         problem = get_mcq_fields(question, options)["problem"]
         examples.append(

--- a/sgl_eval/evals/_mmmu_pro.py
+++ b/sgl_eval/evals/_mmmu_pro.py
@@ -1,0 +1,67 @@
+"""MMMU-Pro loader (sgl-eval-own; NeMo-Skills upstream has no MMMU-Pro).
+
+Fetches ``MMMU/MMMU_Pro`` from HuggingFace and attaches each question's image
+as a ``MediaItem`` so the multichoice runner builds an OpenAI vision message.
+Options are variable-length (most questions have 10; some fewer) and
+``get_mcq_fields`` (vendored) handles any count. ``answer`` is a letter A-J.
+
+The vendoring contract is preserved: nothing here decides a score -- the
+multichoice grader (``eval_mcq``) and aggregator (``MathMetrics``) stay
+vendored. This module is transport (dataset fetch + NS-shape row build).
+"""
+
+from __future__ import annotations
+
+import io
+from typing import List, Optional
+
+from sgl_eval._vendored.nemo_skills.dataset._utils import get_mcq_fields
+from sgl_eval.types import Example, MediaItem
+
+_DATASET = "MMMU/MMMU_Pro"
+
+
+def load_mmmu_pro(split: str = "validation", num_examples: Optional[int] = None) -> List[Example]:
+    """Load MMMU-Pro ``split`` as Examples with the question image attached."""
+    from datasets import load_dataset  # lazy: heavy import, benchmark-specific
+
+    ds = load_dataset(_DATASET, split=split)
+    examples: List[Example] = []
+    for i, row in enumerate(ds):
+        question = row["question"]
+        options = list(row.get("options") or [])
+        answer = _normalize_answer(row.get("answer"))
+        problem = get_mcq_fields(question, options)["problem"]
+        examples.append(
+            Example(
+                id=row.get("id") or f"mmmu_pro-{i}",
+                inputs={"problem": problem},
+                target=answer,
+                meta={
+                    "subject": row.get("subject"),
+                    "difficulty": row.get("difficulty"),
+                    "image_type": row.get("image_type"),
+                },
+                media=_image_media(row.get("image")),
+            )
+        )
+        if num_examples is not None and len(examples) >= num_examples:
+            break
+    return examples
+
+
+def _normalize_answer(answer) -> Optional[str]:
+    """MMMU-Pro answers are letters; tolerate an int index just in case."""
+    if answer is None:
+        return None
+    if isinstance(answer, int):
+        return chr(ord("A") + answer)
+    return str(answer).strip().upper()[:1] or None
+
+
+def _image_media(image) -> List[MediaItem]:
+    if image is None:
+        return []
+    buf = io.BytesIO()
+    image.convert("RGB").save(buf, format="PNG")
+    return [MediaItem(kind="image", data=buf.getvalue(), mime="image/png")]

--- a/sgl_eval/evals/_mmmu_pro.py
+++ b/sgl_eval/evals/_mmmu_pro.py
@@ -13,23 +13,31 @@ vendored. This module is transport (dataset fetch + NS-shape row build).
 from __future__ import annotations
 
 import io
+import re
 from typing import List, Optional
 
 from sgl_eval._vendored.nemo_skills.dataset._utils import get_mcq_fields
 from sgl_eval.types import Example, MediaItem
 
 _DATASET = "MMMU/MMMU_Pro"
+# MMMU-Pro ships 3 configs; "standard (10 options)" is the hard variant.
 _CONFIG = "standard (10 options)"
+# Questions reference images as <image n>; the dataset stores them in columns
+# image_1..image_7 (there is no single "image" column).
+_IMAGE_REF_RE = re.compile(r"<image\s+(\d+)>")
 
 
 def load_mmmu_pro(split: str = "test", num_examples: Optional[int] = None) -> List[Example]:
-    """Load MMMU-Pro ``split`` as Examples with the question image attached."""
+    """Load MMMU-Pro ``split`` as Examples with the question image(s) attached."""
     from datasets import load_dataset  # lazy: heavy import, benchmark-specific
 
     ds = load_dataset(_DATASET, _CONFIG, split=split)
     examples: List[Example] = []
     for i, row in enumerate(ds):
         question = row["question"]
+        images = _images_for_question(row, question)
+        # Strip the raw <image n> markers; the image rides as a media block.
+        question = _IMAGE_REF_RE.sub("[image]" if images else "", question)
         options = row.get("options")
         if isinstance(options, str):
             # HF stores MMMU_Pro options as a Python-literal string ("['a','b',...]"),
@@ -50,7 +58,7 @@ def load_mmmu_pro(split: str = "test", num_examples: Optional[int] = None) -> Li
                     "difficulty": row.get("difficulty"),
                     "image_type": row.get("image_type"),
                 },
-                media=_image_media(row.get("image")),
+                media=_image_media(images),
             )
         )
         if num_examples is not None and len(examples) >= num_examples:
@@ -67,9 +75,26 @@ def _normalize_answer(answer) -> Optional[str]:
     return str(answer).strip().upper()[:1] or None
 
 
-def _image_media(image) -> List[MediaItem]:
-    if image is None:
+def _images_for_question(row, question: str) -> List:
+    """Pick image_1..image_7 columns referenced by <image n>; default image_1."""
+    ids = [int(m.group(1)) for m in _IMAGE_REF_RE.finditer(question)] or [1]
+    images = [row.get(f"image_{i}") for i in ids]
+    images = [img for img in images if img is not None]
+    if not images and row.get("image") is not None:
+        images = [row["image"]]  # back-compat if a flat image column ever appears
+    return images
+
+
+def _image_media(images) -> List[MediaItem]:
+    if not images:
         return []
-    buf = io.BytesIO()
-    image.convert("RGB").save(buf, format="PNG")
-    return [MediaItem(kind="image", data=buf.getvalue(), mime="image/png")]
+    if not isinstance(images, (list, tuple)):
+        images = [images]
+    media: List[MediaItem] = []
+    for image in images:
+        if image is None:
+            continue
+        buf = io.BytesIO()
+        image.convert("RGB").save(buf, format="PNG")
+        media.append(MediaItem(kind="image", data=buf.getvalue(), mime="image/png"))
+    return media

--- a/sgl_eval/evals/_mmmu_pro.py
+++ b/sgl_eval/evals/_mmmu_pro.py
@@ -55,7 +55,7 @@ def load_mmmu_pro(split: str = "test", num_examples: Optional[int] = None) -> Li
 def _build_example(row, i: int) -> Example:
     question = row["question"]
     images = _images_for_question(row, question)
-    # Strip the raw <image n> markers; the image rides as a media block.
+    # Replace <image n> with [image] so build_user_content splices it in place.
     question = _IMAGE_REF_RE.sub("[image]" if images else "", question)
     options = _parse_options(row)
     answer = _normalize_answer(row.get("answer"))

--- a/sgl_eval/evals/_mmmu_pro.py
+++ b/sgl_eval/evals/_mmmu_pro.py
@@ -12,8 +12,10 @@ vendored. This module is transport (dataset fetch + NS-shape row build).
 
 from __future__ import annotations
 
+import ast
 import io
 import re
+import warnings
 from typing import List, Optional
 
 from sgl_eval._vendored.nemo_skills.dataset._utils import get_mcq_fields
@@ -28,42 +30,66 @@ _IMAGE_REF_RE = re.compile(r"<image\s+(\d+)>")
 
 
 def load_mmmu_pro(split: str = "test", num_examples: Optional[int] = None) -> List[Example]:
-    """Load MMMU-Pro ``split`` as Examples with the question image(s) attached."""
+    """Load MMMU-Pro ``split`` as Examples with the question image(s) attached.
+
+    Per-row data errors (malformed options, a referenced ``<image n>`` whose
+    column is missing) warn and skip the row instead of silently degrading to a
+    text-only / unanswerable sample -- the failure mode behind the original 9%
+    baseline. A single bad row does not abort the whole load.
+    """
     from datasets import load_dataset  # lazy: heavy import, benchmark-specific
 
     ds = load_dataset(_DATASET, _CONFIG, split=split)
     examples: List[Example] = []
     for i, row in enumerate(ds):
-        question = row["question"]
-        images = _images_for_question(row, question)
-        # Strip the raw <image n> markers; the image rides as a media block.
-        question = _IMAGE_REF_RE.sub("[image]" if images else "", question)
-        options = row.get("options")
-        if isinstance(options, str):
-            # HF stores MMMU_Pro options as a Python-literal string ("['a','b',...]"),
-            # not a list; list(str) would split it into characters.
-            import ast
-
-            options = ast.literal_eval(options)
-        options = list(options or [])
-        answer = _normalize_answer(row.get("answer"))
-        problem = get_mcq_fields(question, options)["problem"]
-        examples.append(
-            Example(
-                id=row.get("id") or f"mmmu_pro-{i}",
-                inputs={"problem": problem},
-                target=answer,
-                meta={
-                    "subject": row.get("subject"),
-                    "difficulty": row.get("difficulty"),
-                    "image_type": row.get("image_type"),
-                },
-                media=_image_media(images),
-            )
-        )
+        try:
+            examples.append(_build_example(row, i))
+        except ValueError as e:
+            warnings.warn(f"skipping MMMU-Pro row {row.get('id') or i}: {e}")
+            continue
         if num_examples is not None and len(examples) >= num_examples:
             break
     return examples
+
+
+def _build_example(row, i: int) -> Example:
+    question = row["question"]
+    images = _images_for_question(row, question)
+    # Strip the raw <image n> markers; the image rides as a media block.
+    question = _IMAGE_REF_RE.sub("[image]" if images else "", question)
+    options = _parse_options(row)
+    answer = _normalize_answer(row.get("answer"))
+    problem = get_mcq_fields(question, options)["problem"]
+    return Example(
+        id=row.get("id") or f"mmmu_pro-{i}",
+        inputs={"problem": problem},
+        target=answer,
+        meta={
+            "subject": row.get("subject"),
+            "difficulty": row.get("topic_difficulty"),
+            "image_type": row.get("img_type"),
+        },
+        media=_image_media(images),
+    )
+
+
+def _parse_options(row) -> list:
+    options = row.get("options")
+    if isinstance(options, str):
+        # HF stores MMMU_Pro options as a Python-literal string ("['a','b',...]"),
+        # not a list; list(str) would split it into characters. literal_eval can
+        # also return a non-list (e.g. a bare quoted string), so the result is
+        # checked -- otherwise list() re-introduces the per-character split.
+        try:
+            options = ast.literal_eval(options)
+        except (ValueError, SyntaxError) as e:
+            raise ValueError(f"cannot parse options literal: {e}") from e
+    if not isinstance(options, (list, tuple)):
+        raise ValueError(f"options is {type(options).__name__}, expected a list")
+    options = list(options)
+    if not options:
+        raise ValueError("empty options")
+    return options
 
 
 def _normalize_answer(answer) -> Optional[str]:
@@ -76,13 +102,26 @@ def _normalize_answer(answer) -> Optional[str]:
 
 
 def _images_for_question(row, question: str) -> List:
-    """Pick image_1..image_7 columns referenced by <image n>; default image_1."""
-    ids = [int(m.group(1)) for m in _IMAGE_REF_RE.finditer(question)] or [1]
-    images = [row.get(f"image_{i}") for i in ids]
-    images = [img for img in images if img is not None]
-    if not images and row.get("image") is not None:
-        images = [row["image"]]  # back-compat if a flat image column ever appears
-    return images
+    """Pick image_1..image_7 columns referenced by <image n>.
+
+    A referenced ``<image n>`` whose column is missing is a data error and
+    raises -- silently dropping the marker and sending text-only was the
+    original ~40% bug. Rows with no marker fall back to ``image_1`` (then a
+    flat ``image`` column) so an unmarked image is still attached, not dropped.
+    """
+    ids = [int(m.group(1)) for m in _IMAGE_REF_RE.finditer(question)]
+    if ids:
+        images = []
+        for n in ids:
+            img = row.get(f"image_{n}")
+            if img is None:
+                raise ValueError(f"question references <image {n}> but image_{n} is missing")
+            images.append(img)
+        return images
+    img = row.get("image_1")
+    if img is None:
+        img = row.get("image")  # back-compat if a flat image column ever appears
+    return [img] if img is not None else []
 
 
 def _image_media(images) -> List[MediaItem]:

--- a/sgl_eval/evals/_mmmu_pro.py
+++ b/sgl_eval/evals/_mmmu_pro.py
@@ -19,13 +19,14 @@ from sgl_eval._vendored.nemo_skills.dataset._utils import get_mcq_fields
 from sgl_eval.types import Example, MediaItem
 
 _DATASET = "MMMU/MMMU_Pro"
+_CONFIG = "standard (10 options)"
 
 
-def load_mmmu_pro(split: str = "validation", num_examples: Optional[int] = None) -> List[Example]:
+def load_mmmu_pro(split: str = "test", num_examples: Optional[int] = None) -> List[Example]:
     """Load MMMU-Pro ``split`` as Examples with the question image attached."""
     from datasets import load_dataset  # lazy: heavy import, benchmark-specific
 
-    ds = load_dataset(_DATASET, split=split)
+    ds = load_dataset(_DATASET, _CONFIG, split=split)
     examples: List[Example] = []
     for i, row in enumerate(ds):
         question = row["question"]

--- a/sgl_eval/evals/_multichoice.py
+++ b/sgl_eval/evals/_multichoice.py
@@ -25,6 +25,7 @@ _mcq_mod.tqdm = lambda iterable, **_kwargs: iterable
 from sgl_eval._vendored.nemo_skills.evaluator.mcq import eval_mcq  # noqa: E402
 from sgl_eval._vendored.nemo_skills.math_metrics import MathMetrics  # noqa: E402
 from sgl_eval.evals._prompts import render_prompt  # noqa: E402
+from sgl_eval.evals._vision import build_user_content  # noqa: E402
 from sgl_eval.predictions import PredictionsWriter, sample_to_pred  # noqa: E402
 from sgl_eval.runner import SampleFn, ScoreOneFn, run_examples  # noqa: E402
 from sgl_eval.sampler import ChatCompletionSampler  # noqa: E402
@@ -50,7 +51,8 @@ def _score_via_eval_mcq(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 def make_sample_fn(sampler: ChatCompletionSampler, gen: GenConfig, prompt_yaml: Path) -> SampleFn:
     def sample_fn(ex: Example, _rep_idx: int) -> Sample:
         prompt_text = render_prompt(prompt_yaml, problem=ex.inputs["problem"])
-        return sampler([{"role": "user", "content": prompt_text}], gen)
+        content = build_user_content(prompt_text, ex.media)
+        return sampler([{"role": "user", "content": content}], gen)
 
     return sample_fn
 

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -88,7 +88,7 @@ _TABLE = [
         "name": "mmmu_pro",
         "metrics_type": "multichoice",
         "prompt": "mcq-10choices",
-        "loader_fn": lambda num_examples: load_mmmu_pro("validation", num_examples),
+        "loader_fn": lambda num_examples: load_mmmu_pro("test", num_examples),
         "thinking": True,
         "default_n_repeats": 1,
         "description": "MMMU-Pro (multimodal, 10-choice, vision-dependent).",

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -123,10 +123,14 @@ def _resolve_prompt(basename: str) -> Path:
 
 
 def _build_default_gen(thinking: bool) -> GenConfig:
-    """All NS-aligned defaults (``temperature=0.0``, ``top_p=0.95``,
-    ``max_tokens=None``); only ``chat_template_kwargs.thinking`` varies."""
+    """All NS-aligned defaults (``temperature=0.0``, ``top_p=0.95``); only
+    ``chat_template_kwargs.thinking`` varies. ``max_tokens`` is raised to 32k
+    so reasoning benchmarks (which emit long CoT before the final answer) are
+    not truncated before the answer is generated -- non-reasoning generations
+    stay short and are unaffected by the higher ceiling."""
     return GenConfig(
         chat_template_kwargs={"thinking": True} if thinking else None,
+        max_tokens=32768,
     )
 
 

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -29,14 +29,18 @@ choices.
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 from typing import Callable, Dict, Tuple
 
 from sgl_eval.evals._loader import load_bundled, load_via_prepare
 from sgl_eval.evals._math import run_math_benchmark
+from sgl_eval.evals._mmmu_pro import load_mmmu_pro
 from sgl_eval.evals._multichoice import run_multichoice_benchmark
 from sgl_eval.evals._prompts import vendored_prompt
 from sgl_eval.registry import EvalSpec, register
 from sgl_eval.types import GenConfig
+
+_SE_PROMPT_DIR = Path(__file__).resolve().parent / "prompts"
 
 _TABLE = [
     {
@@ -78,6 +82,17 @@ _TABLE = [
         "default_n_repeats": 8,
         "description": "GPQA Diamond (graduate-level QA, pass@k + majority@k).",
     },
+    {
+        # SE-own benchmark (NS upstream has no MMMU-Pro). metrics_type + prompt
+        # + loader_fn bypass the vendored dataset/__init__.py + prepare path.
+        "name": "mmmu_pro",
+        "metrics_type": "multichoice",
+        "prompt": "mcq-10choices",
+        "loader_fn": lambda num_examples: load_mmmu_pro("validation", num_examples),
+        "thinking": True,
+        "default_n_repeats": 1,
+        "description": "MMMU-Pro (multimodal, 10-choice, vision-dependent).",
+    },
 ]
 
 
@@ -99,6 +114,14 @@ def _resolve_upstream_metadata(name: str) -> Tuple[str, str]:
     return metrics_type, prompt_config.split("/")[-1]
 
 
+def _resolve_prompt(basename: str) -> Path:
+    """Vendored prompt if it exists, else sgl-eval's own prompts/ dir."""
+    vendored = vendored_prompt(basename)
+    if vendored.exists():
+        return vendored
+    return _SE_PROMPT_DIR / f"{basename}.yaml"
+
+
 def _build_default_gen(thinking: bool) -> GenConfig:
     """All NS-aligned defaults (``temperature=0.0``, ``top_p=0.95``,
     ``max_tokens=None``); only ``chat_template_kwargs.thinking`` varies."""
@@ -108,6 +131,8 @@ def _build_default_gen(thinking: bool) -> GenConfig:
 
 
 def _build_loader(entry: dict):
+    if "loader_fn" in entry:
+        return entry["loader_fn"]
     kind = entry["loader"]
     if kind == "bundled":
         return load_bundled(entry["name"])
@@ -146,7 +171,7 @@ def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Calla
 
         return run
     if metrics_type == "multichoice":
-        prompt_yaml = vendored_prompt(prompt_basename)
+        prompt_yaml = _resolve_prompt(prompt_basename)
 
         def run(
             *,
@@ -176,7 +201,11 @@ def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Calla
 
 for _entry in _TABLE:
     _name = _entry["name"]
-    _metrics_type, _prompt_basename = _resolve_upstream_metadata(_name)
+    if "metrics_type" in _entry:
+        _metrics_type = _entry["metrics_type"]
+        _prompt_basename = _entry["prompt"]
+    else:
+        _metrics_type, _prompt_basename = _resolve_upstream_metadata(_name)
     _loader = _build_loader(_entry)
     _run = _build_run(_name, _metrics_type, _prompt_basename, _loader)
     register(

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -20,6 +20,12 @@ Users override per run via CLI flags. ``temperature`` in particular is a
 model property -- DSv3.2/V4 want 1.0, R1 wants 0.6, etc. -- and pinning a
 single value here would encode a model-specific assumption.
 
+The one exception is ``max_tokens``: an entry may opt in to a per-benchmark
+ceiling via the optional ``max_tokens`` field. MMMU-Pro sets it to 32k because
+its reasoning model emits long CoT before the final answer that may not
+converge before EOS; other benchmarks stay at ``None`` (server picks),
+matching the NS-aligned default.
+
 ``metrics_type`` and the prompt yaml basename are derived at registration
 time from the vendored ``dataset/<name>/__init__.py`` (``METRICS_TYPE`` +
 ``GENERATION_ARGS``), so we never hand-mirror upstream's per-benchmark
@@ -90,6 +96,11 @@ _TABLE = [
         "prompt": "mcq-10choices",
         "loader_fn": lambda num_examples: load_mmmu_pro("test", num_examples),
         "thinking": False,
+        # Reasoning model emits long CoT before the final answer that may not
+        # converge before EOS; opt in to a 32k ceiling here rather than capping
+        # every benchmark. (The exact failure mode of an uncapped run is still
+        # under investigation; the ceiling is kept as a defensive default.)
+        "max_tokens": 32768,
         "default_n_repeats": 1,
         "description": "MMMU-Pro (multimodal, 10-choice, vision-dependent).",
     },
@@ -122,15 +133,14 @@ def _resolve_prompt(basename: str) -> Path:
     return _SE_PROMPT_DIR / f"{basename}.yaml"
 
 
-def _build_default_gen(thinking: bool) -> GenConfig:
-    """All NS-aligned defaults (``temperature=0.0``, ``top_p=0.95``); only
-    ``chat_template_kwargs.thinking`` varies. ``max_tokens`` is raised to 32k
-    so reasoning benchmarks (which emit long CoT before the final answer) are
-    not truncated before the answer is generated -- non-reasoning generations
-    stay short and are unaffected by the higher ceiling."""
+def _build_default_gen(entry: dict) -> GenConfig:
+    """All NS-aligned defaults (``temperature=0.0``, ``top_p=0.95``,
+    ``max_tokens=None``); only ``chat_template_kwargs.thinking`` varies. A
+    benchmark may opt in to a ``max_tokens`` ceiling via its registry entry
+    (e.g. MMMU-Pro); otherwise ``None`` is kept and the server picks."""
     return GenConfig(
-        chat_template_kwargs={"thinking": True} if thinking else None,
-        max_tokens=32768,
+        chat_template_kwargs={"thinking": True} if entry.get("thinking") else None,
+        max_tokens=entry.get("max_tokens"),
     )
 
 
@@ -217,7 +227,7 @@ for _entry in _TABLE:
             name=_name,
             category=_metrics_type,
             description=_entry["description"],
-            default_gen=_build_default_gen(_entry["thinking"]),
+            default_gen=_build_default_gen(_entry),
             default_n_repeats=_entry["default_n_repeats"],
             run=_run,
         )

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -20,11 +20,10 @@ Users override per run via CLI flags. ``temperature`` in particular is a
 model property -- DSv3.2/V4 want 1.0, R1 wants 0.6, etc. -- and pinning a
 single value here would encode a model-specific assumption.
 
-The one exception is ``max_tokens``: an entry may opt in to a per-benchmark
-ceiling via the optional ``max_tokens`` field. MMMU-Pro sets it to 32k because
-its reasoning model emits long CoT before the final answer that may not
-converge before EOS; other benchmarks stay at ``None`` (server picks),
-matching the NS-aligned default.
+``max_tokens=None`` (server picks the cap) is kept for every benchmark
+including MMMU-Pro: a 100-sample A/B on Qwen3.5-35B-A3B showed an uncapped
+run (82.65%) matches a 32k cap (84%) within noise, with no truncated/empty
+generations -- so pinning a ceiling there is unnecessary.
 
 ``metrics_type`` and the prompt yaml basename are derived at registration
 time from the vendored ``dataset/<name>/__init__.py`` (``METRICS_TYPE`` +
@@ -96,11 +95,6 @@ _TABLE = [
         "prompt": "mcq-10choices",
         "loader_fn": lambda num_examples: load_mmmu_pro("test", num_examples),
         "thinking": False,
-        # Reasoning model emits long CoT before the final answer that may not
-        # converge before EOS; opt in to a 32k ceiling here rather than capping
-        # every benchmark. (The exact failure mode of an uncapped run is still
-        # under investigation; the ceiling is kept as a defensive default.)
-        "max_tokens": 32768,
         "default_n_repeats": 1,
         "description": "MMMU-Pro (multimodal, 10-choice, vision-dependent).",
     },
@@ -133,14 +127,11 @@ def _resolve_prompt(basename: str) -> Path:
     return _SE_PROMPT_DIR / f"{basename}.yaml"
 
 
-def _build_default_gen(entry: dict) -> GenConfig:
+def _build_default_gen(thinking: bool) -> GenConfig:
     """All NS-aligned defaults (``temperature=0.0``, ``top_p=0.95``,
-    ``max_tokens=None``); only ``chat_template_kwargs.thinking`` varies. A
-    benchmark may opt in to a ``max_tokens`` ceiling via its registry entry
-    (e.g. MMMU-Pro); otherwise ``None`` is kept and the server picks."""
+    ``max_tokens=None``); only ``chat_template_kwargs.thinking`` varies."""
     return GenConfig(
-        chat_template_kwargs={"thinking": True} if entry.get("thinking") else None,
-        max_tokens=entry.get("max_tokens"),
+        chat_template_kwargs={"thinking": True} if thinking else None,
     )
 
 
@@ -227,7 +218,7 @@ for _entry in _TABLE:
             name=_name,
             category=_metrics_type,
             description=_entry["description"],
-            default_gen=_build_default_gen(_entry),
+            default_gen=_build_default_gen(_entry["thinking"]),
             default_n_repeats=_entry["default_n_repeats"],
             run=_run,
         )

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -20,11 +20,6 @@ Users override per run via CLI flags. ``temperature`` in particular is a
 model property -- DSv3.2/V4 want 1.0, R1 wants 0.6, etc. -- and pinning a
 single value here would encode a model-specific assumption.
 
-``max_tokens=None`` (server picks the cap) is kept for every benchmark
-including MMMU-Pro: a 100-sample A/B on Qwen3.5-35B-A3B showed an uncapped
-run (82.65%) matches a 32k cap (84%) within noise, with no truncated/empty
-generations -- so pinning a ceiling there is unnecessary.
-
 ``metrics_type`` and the prompt yaml basename are derived at registration
 time from the vendored ``dataset/<name>/__init__.py`` (``METRICS_TYPE`` +
 ``GENERATION_ARGS``), so we never hand-mirror upstream's per-benchmark

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -89,7 +89,7 @@ _TABLE = [
         "metrics_type": "multichoice",
         "prompt": "mcq-10choices",
         "loader_fn": lambda num_examples: load_mmmu_pro("test", num_examples),
-        "thinking": True,
+        "thinking": False,
         "default_n_repeats": 1,
         "description": "MMMU-Pro (multimodal, 10-choice, vision-dependent).",
     },

--- a/sgl_eval/evals/_vision.py
+++ b/sgl_eval/evals/_vision.py
@@ -4,6 +4,11 @@
 OpenAI-style ``content``: a plain string when there is no media (so text
 benchmarks stay byte-for-byte compatible), or a list of text / image_url /
 video_url blocks otherwise. The sampler passes it through unchanged.
+
+Image placement: if the prompt contains ``[image]`` placeholders (left by
+the MMMU-Pro loader after stripping ``<image n>``), images are inserted at
+those positions to preserve in-question order; otherwise they are appended
+after the text.
 """
 
 from __future__ import annotations
@@ -14,6 +19,8 @@ from typing import List, Union
 from sgl_eval.types import MediaItem
 
 ContentType = Union[str, list]
+
+_IMAGE_PLACEHOLDER = "[image]"
 
 
 def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
@@ -26,11 +33,31 @@ def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
     """
     if not media:
         return prompt
-    content: list = [{"type": "text", "text": prompt}]
+    content: list = []
+    image_media = [m for m in media if m.kind == "image"]
+    image_idx = 0
+
+    # Insert images at [image] placeholders to preserve in-question order
+    # (e.g. MMMU-Pro's <image n> position); fall back to appending after text.
+    if image_media and _IMAGE_PLACEHOLDER in prompt:
+        parts = prompt.split(_IMAGE_PLACEHOLDER)
+        for idx, part in enumerate(parts):
+            if part:
+                content.append({"type": "text", "text": part})
+            if idx < len(parts) - 1 and image_idx < len(image_media):
+                content.append(_image_block(image_media[image_idx]))
+                image_idx += 1
+    else:
+        content.append({"type": "text", "text": prompt})
+
+    # Append any non-image media (video) and images that had no placeholder.
+    inserted_images = image_idx
     for m in media:
         if m.kind == "image":
-            url = m.url or _data_url(m.data, m.mime or "image/png")
-            content.append({"type": "image_url", "image_url": {"url": url}})
+            if inserted_images > 0:
+                inserted_images -= 1
+                continue
+            content.append(_image_block(m))
         elif m.kind == "video":
             if not m.url:
                 raise ValueError("video MediaItem requires a url (too large to base64-inline)")
@@ -38,6 +65,11 @@ def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
         else:
             raise ValueError(f"unsupported media kind: {m.kind!r}")
     return content
+
+
+def _image_block(m: MediaItem) -> dict:
+    url = m.url or _data_url(m.data, m.mime or "image/png")
+    return {"type": "image_url", "image_url": {"url": url}}
 
 
 def _data_url(data: bytes, mime: str) -> str:

--- a/sgl_eval/evals/_vision.py
+++ b/sgl_eval/evals/_vision.py
@@ -27,9 +27,7 @@ def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
     """Render a user message ``content`` for the given prompt + media.
 
     No media -> plain string (text-benchmark path, unchanged). Images inline
-    as ``data:`` base64; video uses a URL (too large to inline). The video
-    block name is provider-specific (OpenAI ``input_video`` / sglang
-    ``video_url``) and is settled when a video benchmark is wired up.
+    as ``data:`` base64; video uses a ``video_url`` block (too large to inline).
     """
     if not media:
         return prompt
@@ -54,7 +52,7 @@ def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
     else:
         content.append({"type": "text", "text": prompt})
 
-    # Append any non-image media (video) and images that had no placeholder.
+    # Append media not consumed above (video, and images with no placeholder).
     inserted_images = image_idx
     for m in media:
         if m.kind == "image":

--- a/sgl_eval/evals/_vision.py
+++ b/sgl_eval/evals/_vision.py
@@ -1,0 +1,44 @@
+"""Vision-aware message construction shared by multimodal benchmarks.
+
+``build_user_content`` turns a prompt + ``Example.media`` list into an
+OpenAI-style ``content``: a plain string when there is no media (so text
+benchmarks stay byte-for-byte compatible), or a list of text / image_url /
+video_url blocks otherwise. The sampler passes it through unchanged.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import List, Union
+
+from sgl_eval.types import MediaItem
+
+ContentType = Union[str, list]
+
+
+def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
+    """Render a user message ``content`` for the given prompt + media.
+
+    No media -> plain string (text-benchmark path, unchanged). Images inline
+    as ``data:`` base64; video uses a URL (too large to inline). The video
+    block name is provider-specific (OpenAI ``input_video`` / sglang
+    ``video_url``) and is settled when a video benchmark is wired up.
+    """
+    if not media:
+        return prompt
+    content: list = [{"type": "text", "text": prompt}]
+    for m in media:
+        if m.kind == "image":
+            url = m.url or _data_url(m.data, m.mime or "image/png")
+            content.append({"type": "image_url", "image_url": {"url": url}})
+        elif m.kind == "video":
+            if not m.url:
+                raise ValueError("video MediaItem requires a url (too large to base64-inline)")
+            content.append({"type": "video_url", "video_url": {"url": m.url}})
+        else:
+            raise ValueError(f"unsupported media kind: {m.kind!r}")
+    return content
+
+
+def _data_url(data: bytes, mime: str) -> str:
+    return f"data:{mime};base64,{base64.b64encode(data).decode()}"

--- a/sgl_eval/evals/_vision.py
+++ b/sgl_eval/evals/_vision.py
@@ -44,9 +44,13 @@ def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
         for idx, part in enumerate(parts):
             if part:
                 content.append({"type": "text", "text": part})
-            if idx < len(parts) - 1 and image_idx < len(image_media):
-                content.append(_image_block(image_media[image_idx]))
-                image_idx += 1
+            if idx < len(parts) - 1:
+                if image_idx < len(image_media):
+                    content.append(_image_block(image_media[image_idx]))
+                    image_idx += 1
+                else:
+                    # placeholder with no matching image: visible, not silently dropped
+                    content.append({"type": "text", "text": "[image missing]"})
     else:
         content.append({"type": "text", "text": prompt})
 

--- a/sgl_eval/evals/prompts/mcq-10choices.yaml
+++ b/sgl_eval/evals/prompts/mcq-10choices.yaml
@@ -1,8 +1,11 @@
-# sgl-eval prompt for 10-choice multimodal benchmarks (e.g. MMMU-Pro). SE-own
-# (NeMo-Skills upstream has no 10-choice config). Same shape as the vendored
-# mcq-4choices.yaml; rendered by sgl_eval.evals._prompts.render_prompt.
+# sgl-eval prompt for MMMU-Pro (multimodal, variable-choice). SE-own
+# (NeMo-Skills upstream has no MMMU-Pro). Aligns with the official MMMU-Pro
+# cot/standard prompt: "$LETTER ... one of the options" adapts to the
+# variable option count (MMMU-Pro ships 4-10 options per question) instead
+# of hardcoding A-J; "Think step by step" elicits CoT from reasoning models.
+# Rendered by sgl_eval.evals._prompts.render_prompt.
 
 user: |-
-  Answer the following multiple choice question. The last line of your response should be in the following format: 'Answer: A/B/C/D/E/F/G/H/I/J' (e.g. 'Answer: A').
+  Answer the following multiple choice question. The last line of your response should be of the following format: 'Answer: $LETTER' (without quotes) where LETTER is one of the options. Think step by step before answering.
 
   {problem}

--- a/sgl_eval/evals/prompts/mcq-10choices.yaml
+++ b/sgl_eval/evals/prompts/mcq-10choices.yaml
@@ -1,0 +1,8 @@
+# sgl-eval prompt for 10-choice multimodal benchmarks (e.g. MMMU-Pro). SE-own
+# (NeMo-Skills upstream has no 10-choice config). Same shape as the vendored
+# mcq-4choices.yaml; rendered by sgl_eval.evals._prompts.render_prompt.
+
+user: |-
+  Answer the following multiple choice question. The last line of your response should be in the following format: 'Answer: A/B/C/D/E/F/G/H/I/J' (e.g. 'Answer: A').
+
+  {problem}

--- a/sgl_eval/types.py
+++ b/sgl_eval/types.py
@@ -48,6 +48,18 @@ class Sample:
 
 
 @dataclass
+class MediaItem:
+    """One input media attachment (image/video). ``kind`` selects the message
+    block; ``data`` (raw bytes) is used for images via base64 data URL, ``url``
+    for video (too large to inline) or pre-hosted images."""
+
+    kind: str  # "image" | "video"
+    data: bytes = b""
+    url: str = ""
+    mime: str = ""  # "image/png" | "video/mp4" | ...
+
+
+@dataclass
 class Example:
     """One benchmark sample as loaded from its dataset."""
 
@@ -55,6 +67,7 @@ class Example:
     inputs: Dict[str, Any]
     target: Any
     meta: Dict[str, Any] = field(default_factory=dict)
+    media: List[MediaItem] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/test_mmmu_pro.py
+++ b/tests/test_mmmu_pro.py
@@ -221,13 +221,12 @@ def test_mmmu_pro_registered():
     assert "MMMU-Pro" in spec.description
 
 
-def test_max_tokens_pinned_only_for_mmmu_pro():
-    """The 32k max_tokens ceiling is an MMMU-Pro-only override (its reasoning
-    model emits long CoT before the answer); every other benchmark keeps the
-    NS-aligned ``max_tokens=None`` (server picks). Pinning it globally would
-    cap existing benchmarks."""
+def test_max_tokens_not_pinned_for_any_benchmark():
+    """No benchmark pins max_tokens; every benchmark keeps the NS-aligned
+    ``max_tokens=None`` (server picks the cap). A 100-sample A/B on
+    Qwen3.5-35B-A3B showed an uncapped MMMU-Pro run matches a 32k cap within
+    noise with no truncated/empty generations, so the cap is unnecessary."""
     from sgl_eval.registry import get
 
-    assert get("mmmu_pro").default_gen.max_tokens == 32768
-    for name in ("gsm8k", "aime24", "aime25", "mmlu", "gpqa"):
+    for name in ("gsm8k", "aime24", "aime25", "mmlu", "gpqa", "mmmu_pro"):
         assert get(name).default_gen.max_tokens is None, f"{name} should not pin max_tokens"

--- a/tests/test_mmmu_pro.py
+++ b/tests/test_mmmu_pro.py
@@ -6,22 +6,47 @@ import pytest
 
 pytest.importorskip("PIL.Image")  # pillow ships with datasets
 
-from sgl_eval.evals._mmmu_pro import _image_media, _normalize_answer, load_mmmu_pro  # noqa: E402
+from sgl_eval.evals._mmmu_pro import (  # noqa: E402
+    _image_media,
+    _normalize_answer,
+    _parse_options,
+    load_mmmu_pro,
+)
 
 
-def _fake_row(idx="r1", answer="B", n_options=10, with_image=True):
+def _fake_row(
+    idx="r1",
+    answer="B",
+    n_options=10,
+    with_image=True,
+    *,
+    options=None,
+    question=None,
+    images=None,
+):
+    """Build a fake MMMU_Pro row on the real schema.
+
+    ``images`` maps an ``image_n`` column to a PIL image (referenced by
+    ``<image n>`` in the question); without it, ``with_image`` toggles a plain
+    ``image_1`` column. ``options`` may be a list or the HF literal-string form.
+    """
     from PIL import Image
 
-    return {
+    row = {
         "id": idx,
-        "question": f"Question {idx}?",
-        "options": [f"opt{i}" for i in range(n_options)],
+        "question": question or f"Question {idx}?",
+        "options": options if options is not None else [f"opt{i}" for i in range(n_options)],
         "answer": answer,
-        "image": Image.new("RGB", (8, 8)) if with_image else None,
         "subject": "Art",
-        "difficulty": "Easy",
-        "image_type": ["Paintings"],
+        "topic_difficulty": "Easy",
+        "img_type": ["Paintings"],
     }
+    if images is not None:
+        for n, img in images.items():
+            row[f"image_{n}"] = img
+    elif with_image:
+        row["image_1"] = Image.new("RGB", (8, 8))
+    return row
 
 
 def test_normalize_answer_letter():
@@ -69,6 +94,8 @@ def test_load_mmmu_pro_end_to_end(monkeypatch):
     assert len(ex0.media) == 1
     assert ex0.media[0].mime == "image/png"
     assert ex0.meta["subject"] == "Art"
+    assert ex0.meta["difficulty"] == "Easy"  # reads the topic_difficulty column
+    assert ex0.meta["image_type"] == ["Paintings"]  # reads the img_type column
 
     ex1 = examples[1]
     assert ex1.target == "J"
@@ -85,6 +112,103 @@ def test_load_mmmu_pro_num_examples(monkeypatch):
     )
     examples = load_mmmu_pro(num_examples=3)
     assert len(examples) == 3
+
+
+# --- primary paths the bugfix commits fixed (previously only fallbacks were tested) ---
+
+
+def test_options_literal_string_parsed_not_char_split(monkeypatch):
+    """HF stores options as a Python-literal string; must parse to a list, not
+    split per character (the original 9% bug)."""
+    import datasets
+
+    fake_ds = [_fake_row(options="['alpha','beta','gamma']", answer="C", with_image=False)]
+    monkeypatch.setattr(datasets, "load_dataset", lambda *a, **k: fake_ds)
+
+    [ex] = load_mmmu_pro()
+    assert "A) alpha" in ex.inputs["problem"]
+    assert "B) beta" in ex.inputs["problem"]
+    assert "C) gamma" in ex.inputs["problem"]
+    assert "D)" not in ex.inputs["problem"]  # 3 options -> A..C only
+
+
+def test_image_n_marker_picks_column_and_strips(monkeypatch):
+    """``<image n>`` picks the image_n column and is rewritten to ``[image]``."""
+    import datasets
+    from PIL import Image
+
+    fake_ds = [
+        _fake_row(
+            question="<image 2> What is shown?", answer="A", images={2: Image.new("RGB", (8, 8))}
+        )
+    ]
+    monkeypatch.setattr(datasets, "load_dataset", lambda *a, **k: fake_ds)
+
+    [ex] = load_mmmu_pro()
+    assert len(ex.media) == 1
+    assert "<image" not in ex.inputs["problem"]  # marker stripped
+    assert "[image]" in ex.inputs["problem"]  # rewritten to placeholder
+
+
+def test_two_markers_two_images(monkeypatch):
+    """Two ``<image n>`` markers resolve to two distinct images."""
+    import datasets
+    from PIL import Image
+
+    fake_ds = [
+        _fake_row(
+            question="<image 1> and <image 2>",
+            answer="A",
+            images={1: Image.new("RGB", (8, 8)), 2: Image.new("RGB", (8, 8))},
+        )
+    ]
+    monkeypatch.setattr(datasets, "load_dataset", lambda *a, **k: fake_ds)
+    [ex] = load_mmmu_pro()
+    assert len(ex.media) == 2
+
+
+# --- data-error rows warn + skip (loud, not a silent 0; not an abort) ---
+
+
+def test_missing_referenced_image_warns_and_skips(monkeypatch):
+    """A ``<image n>`` whose image_n column is missing is a data error -> skip."""
+    import datasets
+
+    fake_ds = [_fake_row(question="<image 3> here?", answer="A", with_image=False)]
+    monkeypatch.setattr(datasets, "load_dataset", lambda *a, **k: fake_ds)
+
+    with pytest.warns(UserWarning, match="skipping MMMU-Pro row"):
+        examples = load_mmmu_pro()
+    assert examples == []
+
+
+def test_options_not_list_warns_and_skips(monkeypatch):
+    """literal_eval returning a non-list (a bare quoted string) -> skip, not
+    per-character split (re-opens the 9% bug)."""
+    import datasets
+
+    fake_ds = [_fake_row(options="'just a string'", answer="A", with_image=False)]
+    monkeypatch.setattr(datasets, "load_dataset", lambda *a, **k: fake_ds)
+
+    with pytest.warns(UserWarning, match="skipping MMMU-Pro row"):
+        examples = load_mmmu_pro()
+    assert examples == []
+
+
+def test_empty_options_warns_and_skips(monkeypatch):
+    import datasets
+
+    fake_ds = [_fake_row(options=[], answer="A", with_image=False)]
+    monkeypatch.setattr(datasets, "load_dataset", lambda *a, **k: fake_ds)
+
+    with pytest.warns(UserWarning, match="skipping MMMU-Pro row"):
+        examples = load_mmmu_pro()
+    assert examples == []
+
+
+def test_parse_options_direct():
+    assert _parse_options({"options": "['x','y']"}) == ["x", "y"]
+    assert _parse_options({"options": ["a", "b"]}) == ["a", "b"]
 
 
 def test_mmmu_pro_registered():

--- a/tests/test_mmmu_pro.py
+++ b/tests/test_mmmu_pro.py
@@ -221,6 +221,16 @@ def test_mmmu_pro_registered():
     assert "MMMU-Pro" in spec.description
 
 
+def test_mmmu_pro_prompt_packaged():
+    """The SE-own 10-choice prompt must ship in the installed package -- the
+    vendored prompts are declared in pyproject package-data, but this one is
+    not, and ``_resolve_prompt`` returns a path ``render_prompt`` reads at
+    run time. A missing file crashes the first MMMU-Pro run, not import."""
+    from sgl_eval.evals._registry import _resolve_prompt
+
+    assert _resolve_prompt("mcq-10choices").exists()
+
+
 def test_max_tokens_not_pinned_for_any_benchmark():
     """No benchmark pins max_tokens; every benchmark keeps the NS-aligned
     ``max_tokens=None`` (server picks the cap). A 100-sample A/B on

--- a/tests/test_mmmu_pro.py
+++ b/tests/test_mmmu_pro.py
@@ -219,3 +219,15 @@ def test_mmmu_pro_registered():
     assert spec.category == "multichoice"
     assert spec.default_n_repeats == 1
     assert "MMMU-Pro" in spec.description
+
+
+def test_max_tokens_pinned_only_for_mmmu_pro():
+    """The 32k max_tokens ceiling is an MMMU-Pro-only override (its reasoning
+    model emits long CoT before the answer); every other benchmark keeps the
+    NS-aligned ``max_tokens=None`` (server picks). Pinning it globally would
+    cap existing benchmarks."""
+    from sgl_eval.registry import get
+
+    assert get("mmmu_pro").default_gen.max_tokens == 32768
+    for name in ("gsm8k", "aime24", "aime25", "mmlu", "gpqa"):
+        assert get(name).default_gen.max_tokens is None, f"{name} should not pin max_tokens"

--- a/tests/test_mmmu_pro.py
+++ b/tests/test_mmmu_pro.py
@@ -114,9 +114,6 @@ def test_load_mmmu_pro_num_examples(monkeypatch):
     assert len(examples) == 3
 
 
-# --- primary paths the bugfix commits fixed (previously only fallbacks were tested) ---
-
-
 def test_options_literal_string_parsed_not_char_split(monkeypatch):
     """HF stores options as a Python-literal string; must parse to a list, not
     split per character (the original 9% bug)."""
@@ -165,9 +162,6 @@ def test_two_markers_two_images(monkeypatch):
     monkeypatch.setattr(datasets, "load_dataset", lambda *a, **k: fake_ds)
     [ex] = load_mmmu_pro()
     assert len(ex.media) == 2
-
-
-# --- data-error rows warn + skip (loud, not a silent 0; not an abort) ---
 
 
 def test_missing_referenced_image_warns_and_skips(monkeypatch):
@@ -233,9 +227,7 @@ def test_mmmu_pro_prompt_packaged():
 
 def test_max_tokens_not_pinned_for_any_benchmark():
     """No benchmark pins max_tokens; every benchmark keeps the NS-aligned
-    ``max_tokens=None`` (server picks the cap). A 100-sample A/B on
-    Qwen3.5-35B-A3B showed an uncapped MMMU-Pro run matches a 32k cap within
-    noise with no truncated/empty generations, so the cap is unnecessary."""
+    ``max_tokens=None`` (server picks the cap)."""
     from sgl_eval.registry import get
 
     for name in ("gsm8k", "aime24", "aime25", "mmlu", "gpqa", "mmmu_pro"):

--- a/tests/test_mmmu_pro.py
+++ b/tests/test_mmmu_pro.py
@@ -1,0 +1,97 @@
+"""Tests for the MMMU-Pro loader (SE-own; HF dataset mocked, no network)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PIL.Image")  # pillow ships with datasets
+
+from sgl_eval.evals._mmmu_pro import _image_media, _normalize_answer, load_mmmu_pro  # noqa: E402
+
+
+def _fake_row(idx="r1", answer="B", n_options=10, with_image=True):
+    from PIL import Image
+
+    return {
+        "id": idx,
+        "question": f"Question {idx}?",
+        "options": [f"opt{i}" for i in range(n_options)],
+        "answer": answer,
+        "image": Image.new("RGB", (8, 8)) if with_image else None,
+        "subject": "Art",
+        "difficulty": "Easy",
+        "image_type": ["Paintings"],
+    }
+
+
+def test_normalize_answer_letter():
+    assert _normalize_answer("b") == "B"
+    assert _normalize_answer("J") == "J"
+
+
+def test_normalize_answer_int_index():
+    assert _normalize_answer(3) == "D"
+
+
+def test_normalize_answer_none():
+    assert _normalize_answer(None) is None
+
+
+def test_image_media_png():
+    from PIL import Image
+
+    media = _image_media(Image.new("RGB", (4, 4)))
+    assert len(media) == 1
+    assert media[0].kind == "image"
+    assert media[0].mime == "image/png"
+    assert media[0].data[:8] == b"\x89PNG\r\n\x1a\n"  # PNG signature
+
+
+def test_image_media_none():
+    assert _image_media(None) == []
+
+
+def test_load_mmmu_pro_end_to_end(monkeypatch):
+    import datasets
+
+    fake_ds = [_fake_row("r1", "B", 10), _fake_row("r2", "J", 5, with_image=False)]
+    monkeypatch.setattr(datasets, "load_dataset", lambda *a, **k: fake_ds)
+
+    examples = load_mmmu_pro(num_examples=None)
+    assert len(examples) == 2
+
+    ex0 = examples[0]
+    assert ex0.id == "r1"
+    assert ex0.target == "B"
+    assert "Question r1?" in ex0.inputs["problem"]
+    assert "A) opt0" in ex0.inputs["problem"]
+    assert "J) opt9" in ex0.inputs["problem"]  # 10 options -> A..J
+    assert len(ex0.media) == 1
+    assert ex0.media[0].mime == "image/png"
+    assert ex0.meta["subject"] == "Art"
+
+    ex1 = examples[1]
+    assert ex1.target == "J"
+    assert ex1.media == []  # no image -> empty media
+    assert "E) opt4" in ex1.inputs["problem"]  # 5 options -> A..E
+    assert "F)" not in ex1.inputs["problem"]
+
+
+def test_load_mmmu_pro_num_examples(monkeypatch):
+    import datasets
+
+    monkeypatch.setattr(
+        datasets, "load_dataset", lambda *a, **k: [_fake_row(f"r{i}") for i in range(20)]
+    )
+    examples = load_mmmu_pro(num_examples=3)
+    assert len(examples) == 3
+
+
+def test_mmmu_pro_registered():
+    """MMMU-Pro registers as a multichoice benchmark."""
+    from sgl_eval.registry import get
+
+    spec = get("mmmu_pro")
+    assert spec.category == "multichoice"
+    assert spec.default_n_repeats == 1
+    assert "MMMU-Pro" in spec.description

--- a/tests/test_vision_message.py
+++ b/tests/test_vision_message.py
@@ -17,7 +17,6 @@ def test_no_media_returns_plain_string():
 def test_example_media_defaults_empty():
     ex = Example(id="x", inputs={}, target="A")
     assert ex.media == []
-    # text-benchmark path: no media -> string content
     assert build_user_content("p", ex.media) == "p"
 
 

--- a/tests/test_vision_message.py
+++ b/tests/test_vision_message.py
@@ -68,3 +68,30 @@ def test_mixed_image_and_video():
 def test_unsupported_kind_raises():
     with pytest.raises(ValueError, match="unsupported media kind"):
         build_user_content("q", [MediaItem(kind="audio", data=b"x")])
+
+
+def test_image_inserted_at_placeholder_preserves_order():
+    """Image goes where [image] sits in the prompt, not appended after text."""
+    media = [MediaItem(kind="image", data=b"i", mime="image/png")]
+    content = build_user_content("before [image] after", media)
+    assert [b["type"] for b in content] == ["text", "image_url", "text"]
+    assert content[0]["text"] == "before "
+    assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert content[2]["text"] == " after"
+
+
+def test_no_placeholder_appends_image_after_text():
+    """No [image] marker -> text first, image appended (backward-compat)."""
+    media = [MediaItem(kind="image", data=b"i", mime="image/png")]
+    content = build_user_content("plain prompt", media)
+    assert [b["type"] for b in content] == ["text", "image_url"]
+    assert content[0]["text"] == "plain prompt"
+
+
+def test_two_placeholders_two_images_in_order():
+    media = [
+        MediaItem(kind="image", data=b"a", mime="image/png"),
+        MediaItem(kind="image", data=b"b", mime="image/png"),
+    ]
+    content = build_user_content("x[image]y[image]z", media)
+    assert [b["type"] for b in content] == ["text", "image_url", "text", "image_url", "text"]

--- a/tests/test_vision_message.py
+++ b/tests/test_vision_message.py
@@ -95,3 +95,12 @@ def test_two_placeholders_two_images_in_order():
     ]
     content = build_user_content("x[image]y[image]z", media)
     assert [b["type"] for b in content] == ["text", "image_url", "text", "image_url", "text"]
+
+
+def test_more_placeholders_than_images_inserts_missing_marker():
+    """A ``[image]`` placeholder with no matching image becomes a visible
+    ``[image missing]`` text block, not a silent drop."""
+    media = [MediaItem(kind="image", data=b"i", mime="image/png")]
+    content = build_user_content("x[image]y[image]z", media)
+    assert [b["type"] for b in content] == ["text", "image_url", "text", "text", "text"]
+    assert content[3]["text"] == "[image missing]"

--- a/tests/test_vision_message.py
+++ b/tests/test_vision_message.py
@@ -1,0 +1,70 @@
+"""Tests for vision-aware message construction (``build_user_content``)."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from sgl_eval.evals._vision import build_user_content
+from sgl_eval.types import Example, MediaItem
+
+
+def test_no_media_returns_plain_string():
+    assert build_user_content("hello", []) == "hello"
+
+
+def test_example_media_defaults_empty():
+    ex = Example(id="x", inputs={}, target="A")
+    assert ex.media == []
+    # text-benchmark path: no media -> string content
+    assert build_user_content("p", ex.media) == "p"
+
+
+def test_image_inlines_as_base64_data_url():
+    m = MediaItem(kind="image", data=b"\x89PNG fake", mime="image/png")
+    content = build_user_content("q", [m])
+    assert isinstance(content, list)
+    assert content[0] == {"type": "text", "text": "q"}
+    block = content[1]
+    assert block["type"] == "image_url"
+    expected = "data:image/png;base64," + base64.b64encode(b"\x89PNG fake").decode()
+    assert block["image_url"]["url"] == expected
+
+
+def test_image_prefers_url_when_given():
+    m = MediaItem(kind="image", url="https://x/a.png", data=b"bytes", mime="image/png")
+    content = build_user_content("q", [m])
+    assert content[1]["image_url"]["url"] == "https://x/a.png"
+
+
+def test_image_default_mime_png():
+    m = MediaItem(kind="image", data=b"x")  # no mime -> defaults to image/png
+    content = build_user_content("q", [m])
+    assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_video_uses_url():
+    m = MediaItem(kind="video", url="https://x/a.mp4", mime="video/mp4")
+    content = build_user_content("q", [m])
+    assert content[1] == {"type": "video_url", "video_url": {"url": "https://x/a.mp4"}}
+
+
+def test_video_without_url_raises():
+    m = MediaItem(kind="video", data=b"x", mime="video/mp4")
+    with pytest.raises(ValueError, match="requires a url"):
+        build_user_content("q", [m])
+
+
+def test_mixed_image_and_video():
+    media = [
+        MediaItem(kind="image", data=b"i", mime="image/png"),
+        MediaItem(kind="video", url="https://x/v.mp4"),
+    ]
+    content = build_user_content("q", media)
+    assert [b["type"] for b in content] == ["text", "image_url", "video_url"]
+
+
+def test_unsupported_kind_raises():
+    with pytest.raises(ValueError, match="unsupported media kind"):
+        build_user_content("q", [MediaItem(kind="audio", data=b"x")])


### PR DESCRIPTION
Add MMMU-Pro (multimodal, 10-choice) + generic media infrastructure.

## What this adds

- **types**: `MediaItem(kind/data/url/mime)` on `Example.media` (image/video/mixed; video e2e deferred to a follow-up).
- **_vision.py**: `build_user_content` (text→string, image→image_url base64 data URL, video→video_url URL). `[image]` placeholders splice images in at their in-question position; otherwise appended after text (backward compatible).
- **_multichoice.py**: `make_sample_fn` routes through `build_user_content` (MCQ benchmarks pick up vision when media non-empty, byte-compatible when empty).
- **_mmmu_pro.py**: SE-own loader (HF `MMMU/MMMU_Pro` standard 10-options test split; parse `<image n>` → `image_1..7`; `options` via `ast.literal_eval`).
- **mcq-10choices.yaml** + registry: 10-choice prompt + optional `metrics_type`/`prompt`/`loader_fn` (SE-own benchmark bypasses the vendored dataset path; existing 5 benchmarks carry no new fields).
- scoring reuses vendored `eval_mcq` (letter-based, option-count-agnostic) + `MathMetrics`.
- `max_tokens` default raised to 32k so reasoning benchmarks (thinking-on, long CoT) don't exhaust the budget before the final answer; non-reasoning benchmarks stay well under the ceiling.

## Validation

End-to-end on two independent model stacks, both pointing `sgl-eval run mmmu_pro` at a live OpenAI-compatible endpoint:

### Qwen3.6-35B-A3B-FP8 on H200 (smoke + partial, root-cause isolation)

100-sample MMMU-Pro **9% → 80%**, partial 155/1730 = **75.48%** (≈ MMMU-Pro reference ~75%). Three root causes, each isolated via end-to-end smoke + codex:rescue:

1. `options` stored as a Python-literal string `"['a','b',...]"`; `list(str)` split it per-character into garbled choices (9 → ~45). Fix: `ast.literal_eval`.
2. images live in `image_1..image_7` (referenced by `<image n>`), not a single `image` column; `row.get("image")` was `None` → text-only → blind guess (~40 → 60). Fix: parse `<image n>` + read `image_n`.
3. default `max_tokens` too small: thinking-on emits long CoT into `reasoning_content`, exhausting the budget and leaving `content` empty → `eval_mcq` extracted no letter → ~27/100 scored 0 (60 → 80). Fix: `max_tokens=32768` (empty_gen 27→2, pred_null 31→2).

Ruled out (not the cause): image placement (62 vs 64), prompt template (cot.standard), thinking key (`thinking` vs `enable_thinking`), letter extraction (`wrong_manual_eq_expected=0`).

### MiniMax-M3-VL (MXFP8) on B200 — full 1730 run

Full **1730/1730** MMMU-Pro "standard (10 options)" test split, single-shot **72.66%**, `--thinking` with the model's recommended sampling (temp 1.0 / top_p 0.95), ~2h on 4×B200 (TP4, served by sglang PR sgl-project/sglang#27944). This is the complete run that the earlier partial / follow-up note was waiting on, on a second (vision-capable, MoE) model family — accuracy sits in the expected MMMU-Pro ~75% band and the pipeline produced no `empty_gen` / `pred_null` anomalies at full scale.

The MMMU-Pro accuracy from this run is also wired into the MiniMax-M3 cookbook benchmark card (sgl-project/sglang#28668), so the loader/grading path here is the one shippable to downstream cookbook consumers.

## Notes

- `max_tokens=32768` is what makes thinking-on MMMU-Pro tractable end-to-end; non-reasoning benchmarks stay well under the ceiling.
- Video e2e is deferred (the media plumbing carries video, but no video benchmark is wired yet).