### PR TITLE
Align sampling with NeMo-Skills' `InferenceConfig` (`min_p`, `repetition_penalty`, `seed`)

### DIFF
--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -58,6 +58,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_run.add_argument("--temperature", type=float, default=None)
     p_run.add_argument("--top-p", type=float, default=None)
     p_run.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="sampling seed sent to the server (unset by default; NeMo-Skills "
+        "sends 0, so pass --seed 0 to match its runs)",
+    )
+    p_run.add_argument(
         "--thinking",
         action=argparse.BooleanOptionalAction,
         default=None,

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -65,6 +65,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         "sends 0, so pass --seed 0 to match its runs)",
     )
     p_run.add_argument(
+        "--strict-openai",
+        action="store_true",
+        help="omit the sampling params the OpenAI API itself rejects (min_p, "
+        "repetition_penalty). Only for endpoints that are neither sglang nor "
+        "vLLM -- both accept them, and NeMo-Skills always sends them",
+    )
+    p_run.add_argument(
         "--thinking",
         action=argparse.BooleanOptionalAction,
         default=None,

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -65,13 +65,6 @@ def main(argv: Optional[List[str]] = None) -> int:
         "sends 0, so pass --seed 0 to match its runs)",
     )
     p_run.add_argument(
-        "--strict-openai",
-        action="store_true",
-        help="omit the sampling params the OpenAI API itself rejects (min_p, "
-        "repetition_penalty). Only for endpoints that are neither sglang nor "
-        "vLLM -- both accept them, and NeMo-Skills always sends them",
-    )
-    p_run.add_argument(
         "--thinking",
         action=argparse.BooleanOptionalAction,
         default=None,

--- a/sgl_eval/preset.py
+++ b/sgl_eval/preset.py
@@ -201,15 +201,11 @@ def apply_to_gen(
     """Resolve a final ``GenConfig`` honoring CLI > preset > default.
 
     ``args`` must expose ``temperature``, ``top_p``, ``max_tokens``,
-    ``thinking`` (any of which may be ``None`` for "unset"). ``seed`` and
-    ``strict_openai`` are optional -- neither has a preset field, being a
-    reproducibility knob and an endpoint-compat knob rather than part of the
-    run's identity.
+    ``thinking`` (any of which may be ``None`` for "unset"). ``seed`` is
+    optional -- it has no preset field, being a reproducibility knob rather
+    than part of the run's identity.
     """
     p = preset.sampling if preset else None
-    # Endpoints that are not sglang/vLLM 400 on these, which the sampler turns
-    # into empty samples -- i.e. a whole run scoring 0.
-    strict = bool(getattr(args, "strict_openai", False))
     chat_template_kwargs = dict(default.chat_template_kwargs or {})
     thinking = pick(args.thinking, p.thinking if p else None)
     if thinking is not None:
@@ -218,8 +214,8 @@ def apply_to_gen(
         temperature=pick(args.temperature, p.temperature if p else None, default.temperature),
         top_p=pick(args.top_p, p.top_p if p else None, default.top_p),
         max_tokens=pick(args.max_tokens, p.max_tokens if p else None, default.max_tokens),
-        min_p=None if strict else default.min_p,
-        repetition_penalty=None if strict else default.repetition_penalty,
+        min_p=default.min_p,
+        repetition_penalty=default.repetition_penalty,
         reasoning_effort=default.reasoning_effort,
         chat_template_kwargs=chat_template_kwargs or None,
         extra_body=default.extra_body,

--- a/sgl_eval/preset.py
+++ b/sgl_eval/preset.py
@@ -201,11 +201,15 @@ def apply_to_gen(
     """Resolve a final ``GenConfig`` honoring CLI > preset > default.
 
     ``args`` must expose ``temperature``, ``top_p``, ``max_tokens``,
-    ``thinking`` (any of which may be ``None`` for "unset"). ``seed`` is
-    optional -- it has no preset field, being a reproducibility knob rather
-    than part of the run's identity.
+    ``thinking`` (any of which may be ``None`` for "unset"). ``seed`` and
+    ``strict_openai`` are optional -- neither has a preset field, being a
+    reproducibility knob and an endpoint-compat knob rather than part of the
+    run's identity.
     """
     p = preset.sampling if preset else None
+    # Endpoints that are not sglang/vLLM 400 on these, which the sampler turns
+    # into empty samples -- i.e. a whole run scoring 0.
+    strict = bool(getattr(args, "strict_openai", False))
     chat_template_kwargs = dict(default.chat_template_kwargs or {})
     thinking = pick(args.thinking, p.thinking if p else None)
     if thinking is not None:
@@ -214,8 +218,8 @@ def apply_to_gen(
         temperature=pick(args.temperature, p.temperature if p else None, default.temperature),
         top_p=pick(args.top_p, p.top_p if p else None, default.top_p),
         max_tokens=pick(args.max_tokens, p.max_tokens if p else None, default.max_tokens),
-        min_p=default.min_p,
-        repetition_penalty=default.repetition_penalty,
+        min_p=None if strict else default.min_p,
+        repetition_penalty=None if strict else default.repetition_penalty,
         reasoning_effort=default.reasoning_effort,
         chat_template_kwargs=chat_template_kwargs or None,
         extra_body=default.extra_body,

--- a/sgl_eval/preset.py
+++ b/sgl_eval/preset.py
@@ -201,7 +201,9 @@ def apply_to_gen(
     """Resolve a final ``GenConfig`` honoring CLI > preset > default.
 
     ``args`` must expose ``temperature``, ``top_p``, ``max_tokens``,
-    ``thinking`` (any of which may be ``None`` for "unset").
+    ``thinking`` (any of which may be ``None`` for "unset"). ``seed`` is
+    optional -- it has no preset field, being a reproducibility knob rather
+    than part of the run's identity.
     """
     p = preset.sampling if preset else None
     chat_template_kwargs = dict(default.chat_template_kwargs or {})
@@ -212,10 +214,12 @@ def apply_to_gen(
         temperature=pick(args.temperature, p.temperature if p else None, default.temperature),
         top_p=pick(args.top_p, p.top_p if p else None, default.top_p),
         max_tokens=pick(args.max_tokens, p.max_tokens if p else None, default.max_tokens),
+        min_p=default.min_p,
+        repetition_penalty=default.repetition_penalty,
         reasoning_effort=default.reasoning_effort,
         chat_template_kwargs=chat_template_kwargs or None,
         extra_body=default.extra_body,
-        seed=default.seed,
+        seed=pick(getattr(args, "seed", None), default.seed),
         system_message=default.system_message,
     )
 

--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -137,19 +137,17 @@ class ChatCompletionSampler:
         # NS sends min_p / repetition_penalty on every request (also via
         # extra_body). Omit them and sglang resolves both from the served
         # model's generation_config.json, so an endpoint whose model ships a
-        # non-default value would decode differently here than under NS.
-        # Neither is an OpenAI API param, so --strict-openai sets both to None.
-        extra_body: Dict[str, Any] = {}
-        if gen.min_p is not None:
-            extra_body["min_p"] = gen.min_p
-        if gen.repetition_penalty is not None:
-            extra_body["repetition_penalty"] = gen.repetition_penalty
+        # non-default value would decode differently here than under NS. Both
+        # are sglang / vLLM extensions, not OpenAI API params.
+        extra_body: Dict[str, Any] = {
+            "min_p": gen.min_p,
+            "repetition_penalty": gen.repetition_penalty,
+        }
         if gen.chat_template_kwargs:
             extra_body["chat_template_kwargs"] = gen.chat_template_kwargs
         if gen.extra_body:
             extra_body.update(gen.extra_body)
-        if extra_body:
-            kwargs["extra_body"] = extra_body
+        kwargs["extra_body"] = extra_body
         return kwargs
 
     @staticmethod

--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -23,22 +23,17 @@ from sgl_eval.types import GenConfig, MessageList, Sample
 LOG = logging.getLogger(__name__)
 
 
-# Pool ceiling, deliberately far above any plausible ``--num-threads`` (a
-# short-context sweep can run a few hundred). httpx defaults to 100, which would
-# cap concurrency below what the runner was told to use, silently.
+# Above any plausible --num-threads; httpx's default 100 would silently cap
+# concurrency below what the runner was told to use.
 _MAX_CONNECTIONS = 3600
 
 
 class _LargeHttpxClient(httpx.Client):
-    """httpx client tuned for long-running generations -- a long context to
-    prefill, or a reasoning model emitting tens of thousands of tokens.
+    """httpx client for generations that legitimately take hours.
 
-    The 4h *read* ceiling matches upstream NeMo-Skills' ``InferenceConfig``
-    ``timeout``, so a run cannot diverge from an NS run by giving up where NS
-    would still be waiting. ``connect`` stays short on purpose: failing to
-    connect means nothing was generated, so it cannot move a score, while at
-    4h x ``max_retries`` an unreachable endpoint would tie up a worker for a
-    day and look like a hang rather than an error.
+    The 4h read ceiling is NS's ``InferenceConfig.timeout``. ``connect`` stays
+    short: it cannot affect a score, and 4h x ``max_retries`` on an unreachable
+    endpoint looks like a hang rather than an error.
     """
 
     def __init__(self) -> None:
@@ -146,15 +141,11 @@ class ChatCompletionSampler:
         if gen.seed is not None:
             kwargs["seed"] = gen.seed
 
-        # NS sends min_p / repetition_penalty on every request (also via
-        # extra_body). Omit them and sglang resolves both from the served
-        # model's generation_config.json, so an endpoint whose model ships a
-        # non-default value would decode differently here than under NS.
-        # ``top_k`` deliberately stays out: NS only sends it when > 0 (its
-        # default is -1), so both sides leave it to the model's config.
-        # These are sglang / vLLM extensions rather than OpenAI API params, so a
-        # strict OpenAI endpoint 400s every request -- which surfaces as empty
-        # samples, i.e. a run scoring 0 with error_rate at 100%.
+        # NS sends both on every request; unsent, sglang takes them from the
+        # served model's generation_config.json instead -- how the same endpoint
+        # decodes differently here than under NS. top_k stays out because NS
+        # also only sends it when > 0. Neither is an OpenAI API param, so a
+        # strict OpenAI endpoint 400s every request.
         extra_body: Dict[str, Any] = {
             "min_p": gen.min_p,
             "repetition_penalty": gen.repetition_penalty,

--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -24,10 +24,15 @@ LOG = logging.getLogger(__name__)
 
 
 class _LargeHttpxClient(httpx.Client):
-    """httpx client tuned for long-running reasoning generations."""
+    """httpx client tuned for long-running reasoning generations.
+
+    The 4h per-call ceiling matches upstream NeMo-Skills' ``InferenceConfig``
+    ``timeout`` so a long-context run cannot diverge from an NS run by timing
+    out where NS would still be waiting.
+    """
 
     def __init__(self) -> None:
-        timeout = httpx.Timeout(3600)
+        timeout = httpx.Timeout(14400)
         limits = httpx.Limits(max_keepalive_connections=3600, max_connections=3600)
         super().__init__(timeout=timeout, limits=limits)
 
@@ -129,13 +134,19 @@ class ChatCompletionSampler:
         if gen.seed is not None:
             kwargs["seed"] = gen.seed
 
-        extra_body: Dict[str, Any] = {}
+        # NS sends min_p / repetition_penalty on every request (also via
+        # extra_body). Omit them and sglang resolves both from the served
+        # model's generation_config.json, so an endpoint whose model ships a
+        # non-default value would decode differently here than under NS.
+        extra_body: Dict[str, Any] = {
+            "min_p": gen.min_p,
+            "repetition_penalty": gen.repetition_penalty,
+        }
         if gen.chat_template_kwargs:
             extra_body["chat_template_kwargs"] = gen.chat_template_kwargs
         if gen.extra_body:
             extra_body.update(gen.extra_body)
-        if extra_body:
-            kwargs["extra_body"] = extra_body
+        kwargs["extra_body"] = extra_body
         return kwargs
 
     @staticmethod

--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -23,17 +23,29 @@ from sgl_eval.types import GenConfig, MessageList, Sample
 LOG = logging.getLogger(__name__)
 
 
-class _LargeHttpxClient(httpx.Client):
-    """httpx client tuned for long-running reasoning generations.
+# Pool ceiling, deliberately far above any plausible ``--num-threads`` (a
+# short-context sweep can run a few hundred). httpx defaults to 100, which would
+# cap concurrency below what the runner was told to use, silently.
+_MAX_CONNECTIONS = 3600
 
-    The 4h per-call ceiling matches upstream NeMo-Skills' ``InferenceConfig``
-    ``timeout`` so a long-context run cannot diverge from an NS run by timing
-    out where NS would still be waiting.
+
+class _LargeHttpxClient(httpx.Client):
+    """httpx client tuned for long-running generations -- a long context to
+    prefill, or a reasoning model emitting tens of thousands of tokens.
+
+    The 4h *read* ceiling matches upstream NeMo-Skills' ``InferenceConfig``
+    ``timeout``, so a run cannot diverge from an NS run by giving up where NS
+    would still be waiting. ``connect`` stays short on purpose: failing to
+    connect means nothing was generated, so it cannot move a score, while at
+    4h x ``max_retries`` an unreachable endpoint would tie up a worker for a
+    day and look like a hang rather than an error.
     """
 
     def __init__(self) -> None:
-        timeout = httpx.Timeout(14400)
-        limits = httpx.Limits(max_keepalive_connections=3600, max_connections=3600)
+        timeout = httpx.Timeout(14400, connect=30)
+        limits = httpx.Limits(
+            max_keepalive_connections=_MAX_CONNECTIONS, max_connections=_MAX_CONNECTIONS
+        )
         super().__init__(timeout=timeout, limits=limits)
 
 
@@ -137,8 +149,12 @@ class ChatCompletionSampler:
         # NS sends min_p / repetition_penalty on every request (also via
         # extra_body). Omit them and sglang resolves both from the served
         # model's generation_config.json, so an endpoint whose model ships a
-        # non-default value would decode differently here than under NS. Both
-        # are sglang / vLLM extensions, not OpenAI API params.
+        # non-default value would decode differently here than under NS.
+        # ``top_k`` deliberately stays out: NS only sends it when > 0 (its
+        # default is -1), so both sides leave it to the model's config.
+        # These are sglang / vLLM extensions rather than OpenAI API params, so a
+        # strict OpenAI endpoint 400s every request -- which surfaces as empty
+        # samples, i.e. a run scoring 0 with error_rate at 100%.
         extra_body: Dict[str, Any] = {
             "min_p": gen.min_p,
             "repetition_penalty": gen.repetition_penalty,

--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -138,15 +138,18 @@ class ChatCompletionSampler:
         # extra_body). Omit them and sglang resolves both from the served
         # model's generation_config.json, so an endpoint whose model ships a
         # non-default value would decode differently here than under NS.
-        extra_body: Dict[str, Any] = {
-            "min_p": gen.min_p,
-            "repetition_penalty": gen.repetition_penalty,
-        }
+        # Neither is an OpenAI API param, so --strict-openai sets both to None.
+        extra_body: Dict[str, Any] = {}
+        if gen.min_p is not None:
+            extra_body["min_p"] = gen.min_p
+        if gen.repetition_penalty is not None:
+            extra_body["repetition_penalty"] = gen.repetition_penalty
         if gen.chat_template_kwargs:
             extra_body["chat_template_kwargs"] = gen.chat_template_kwargs
         if gen.extra_body:
             extra_body.update(gen.extra_body)
-        kwargs["extra_body"] = extra_body
+        if extra_body:
+            kwargs["extra_body"] = extra_body
         return kwargs
 
     @staticmethod

--- a/sgl_eval/types.py
+++ b/sgl_eval/types.py
@@ -25,9 +25,10 @@ class GenConfig:
     top_p: float = 0.95
     max_tokens: Optional[int] = None
     # Sent on every request, like NS does. Left unsent they would resolve
-    # from the served model's generation_config.json instead.
-    min_p: float = 0.0
-    repetition_penalty: float = 1.0
+    # from the served model's generation_config.json instead. ``None`` omits
+    # them, for endpoints that reject non-OpenAI sampling params (--strict-openai).
+    min_p: Optional[float] = 0.0
+    repetition_penalty: Optional[float] = 1.0
     reasoning_effort: Optional[str] = None
     chat_template_kwargs: Optional[Dict[str, Any]] = None
     extra_body: Optional[Dict[str, Any]] = None

--- a/sgl_eval/types.py
+++ b/sgl_eval/types.py
@@ -15,14 +15,19 @@ class GenConfig:
     sampler instance can serve multiple benchmarks with different configs.
 
     Defaults mirror NeMo-Skills' ``InferenceConfig`` (``temperature=0.0``,
-    ``top_p=0.95``, ``max_tokens=None`` => server picks a cap). Per-benchmark
-    overrides live in ``sgl_eval/evals/_registry.py``; CLI overrides live in
+    ``top_p=0.95``, ``max_tokens=None`` => server picks a cap,
+    ``min_p=0.0``, ``repetition_penalty=1.0``). Per-benchmark overrides live
+    in ``sgl_eval/evals/_registry.py``; CLI overrides live in
     ``sgl_eval/cli.py``.
     """
 
     temperature: float = 0.0
     top_p: float = 0.95
     max_tokens: Optional[int] = None
+    # Sent on every request, like NS does. Left unsent they would resolve
+    # from the served model's generation_config.json instead.
+    min_p: float = 0.0
+    repetition_penalty: float = 1.0
     reasoning_effort: Optional[str] = None
     chat_template_kwargs: Optional[Dict[str, Any]] = None
     extra_body: Optional[Dict[str, Any]] = None

--- a/sgl_eval/types.py
+++ b/sgl_eval/types.py
@@ -25,10 +25,9 @@ class GenConfig:
     top_p: float = 0.95
     max_tokens: Optional[int] = None
     # Sent on every request, like NS does. Left unsent they would resolve
-    # from the served model's generation_config.json instead. ``None`` omits
-    # them, for endpoints that reject non-OpenAI sampling params (--strict-openai).
-    min_p: Optional[float] = 0.0
-    repetition_penalty: Optional[float] = 1.0
+    # from the served model's generation_config.json instead.
+    min_p: float = 0.0
+    repetition_penalty: float = 1.0
     reasoning_effort: Optional[str] = None
     chat_template_kwargs: Optional[Dict[str, Any]] = None
     extra_body: Optional[Dict[str, Any]] = None

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -151,6 +151,15 @@ def test_apply_to_gen_seed_is_cli_only() -> None:
     assert apply_to_gen(default, preset=None, args=_args(seed=0)).seed == 0
 
 
+def test_strict_openai_drops_the_ns_sampling_extras() -> None:
+    """The escape hatch for endpoints that reject non-OpenAI params."""
+    default = GenConfig(min_p=0.0, repetition_penalty=1.0)
+    gen = apply_to_gen(default, preset=None, args=_args(strict_openai=True))
+    assert (gen.min_p, gen.repetition_penalty) == (None, None)
+    # Unset flag keeps NS alignment.
+    assert apply_to_gen(default, preset=None, args=_args()).min_p == 0.0
+
+
 def test_apply_to_gen_keeps_ns_sampling_extras() -> None:
     """``min_p`` / ``repetition_penalty`` are NS-aligned defaults carried on the
     spec's GenConfig; resolution must not drop them back to the dataclass."""

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -143,6 +143,22 @@ def test_apply_to_gen_priority_chain() -> None:
     assert gen.temperature == 0.6
 
 
+def test_apply_to_gen_seed_is_cli_only() -> None:
+    """``seed`` has no preset field (it is a reproducibility knob, not part of
+    the run's identity), and stays unset unless the CLI asks for it."""
+    default = GenConfig()
+    assert apply_to_gen(default, preset=None, args=_args()).seed is None
+    assert apply_to_gen(default, preset=None, args=_args(seed=0)).seed == 0
+
+
+def test_apply_to_gen_keeps_ns_sampling_extras() -> None:
+    """``min_p`` / ``repetition_penalty`` are NS-aligned defaults carried on the
+    spec's GenConfig; resolution must not drop them back to the dataclass."""
+    default = GenConfig(min_p=0.01, repetition_penalty=1.05)
+    gen = apply_to_gen(default, preset=None, args=_args())
+    assert (gen.min_p, gen.repetition_penalty) == (0.01, 1.05)
+
+
 def test_apply_to_gen_thinking_priority() -> None:
     """``thinking`` is the only sampling field that lives under
     ``chat_template_kwargs``; verify it follows the same priority chain."""

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -151,15 +151,6 @@ def test_apply_to_gen_seed_is_cli_only() -> None:
     assert apply_to_gen(default, preset=None, args=_args(seed=0)).seed == 0
 
 
-def test_strict_openai_drops_the_ns_sampling_extras() -> None:
-    """The escape hatch for endpoints that reject non-OpenAI params."""
-    default = GenConfig(min_p=0.0, repetition_penalty=1.0)
-    gen = apply_to_gen(default, preset=None, args=_args(strict_openai=True))
-    assert (gen.min_p, gen.repetition_penalty) == (None, None)
-    # Unset flag keeps NS alignment.
-    assert apply_to_gen(default, preset=None, args=_args()).min_p == 0.0
-
-
 def test_apply_to_gen_keeps_ns_sampling_extras() -> None:
     """``min_p`` / ``repetition_penalty`` are NS-aligned defaults carried on the
     spec's GenConfig; resolution must not drop them back to the dataclass."""

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -78,6 +78,15 @@ def test_min_p_and_repetition_penalty_always_sent(sampler):
     assert extra["repetition_penalty"] == 1.0
 
 
+def test_strict_openai_sends_no_extra_body(sampler):
+    """A strict OpenAI-compatible endpoint 400s on unknown body params, and the
+    sampler turns a 400 into an empty sample -- i.e. the whole run scores 0.
+    ``None`` on both fields has to leave the request free of ``extra_body``."""
+    gen = GenConfig(min_p=None, repetition_penalty=None)
+    sampler([{"role": "user", "content": "hi"}], gen)
+    assert "extra_body" not in sampler._captured["kwargs"]
+
+
 def test_explicit_extra_body_wins_over_the_ns_defaults(sampler):
     gen = GenConfig(extra_body={"repetition_penalty": 1.05})
     sampler([{"role": "user", "content": "hi"}], gen)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -78,15 +78,6 @@ def test_min_p_and_repetition_penalty_always_sent(sampler):
     assert extra["repetition_penalty"] == 1.0
 
 
-def test_strict_openai_sends_no_extra_body(sampler):
-    """A strict OpenAI-compatible endpoint 400s on unknown body params, and the
-    sampler turns a 400 into an empty sample -- i.e. the whole run scores 0.
-    ``None`` on both fields has to leave the request free of ``extra_body``."""
-    gen = GenConfig(min_p=None, repetition_penalty=None)
-    sampler([{"role": "user", "content": "hi"}], gen)
-    assert "extra_body" not in sampler._captured["kwargs"]
-
-
 def test_explicit_extra_body_wins_over_the_ns_defaults(sampler):
     gen = GenConfig(extra_body={"repetition_penalty": 1.05})
     sampler([{"role": "user", "content": "hi"}], gen)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -67,6 +67,23 @@ def test_chat_template_kwargs_become_extra_body(sampler):
     assert kw["extra_body"]["chat_template_kwargs"] == {"thinking": True}
 
 
+def test_min_p_and_repetition_penalty_always_sent(sampler):
+    """Both are NS ``InferenceConfig`` fields. Left unsent, sglang resolves
+    them from the served model's generation_config.json -- so a model shipping
+    e.g. repetition_penalty=1.05 would silently decode differently than under
+    an NS run, and the scores would not be comparable."""
+    sampler([{"role": "user", "content": "hi"}], GenConfig())
+    extra = sampler._captured["kwargs"]["extra_body"]
+    assert extra["min_p"] == 0.0
+    assert extra["repetition_penalty"] == 1.0
+
+
+def test_explicit_extra_body_wins_over_the_ns_defaults(sampler):
+    gen = GenConfig(extra_body={"repetition_penalty": 1.05})
+    sampler([{"role": "user", "content": "hi"}], gen)
+    assert sampler._captured["kwargs"]["extra_body"]["repetition_penalty"] == 1.05
+
+
 def test_system_message_prepended(sampler):
     gen = GenConfig(system_message="you are a helper")
     sampler([{"role": "user", "content": "hi"}], gen)


### PR DESCRIPTION
## Summary
- Send `min_p=0.0` and `repetition_penalty=1.0` on every request, matching NeMo-Skills' `InferenceConfig` field for field
- Add `--seed` (unset by default; NS sends `random_seed=0`, so pass `--seed 0` to match its runs)
- Raise the per-call HTTP timeout 3600s -> 14400s, the value NS uses

## Why those two fields
- sglang resolves `min_p` / `repetition_penalty` from the request first, then the served model's `generation_config.json`, then its own defaults
- NS always sends them, so they never reach that fallback under an NS run; sgl-eval did not send them, so they always did
- A model shipping e.g. `repetition_penalty=1.05` therefore decoded differently here than under NS -- same endpoint, same prompt, non-comparable scores
- Both are sglang / vLLM extensions rather than OpenAI API params, so they travel in `extra_body`, exactly as in NS

## Note
- This changes decoding for any benchmark run against a model whose `generation_config.json` sets a non-default `min_p` / `repetition_penalty` (common on Qwen checkpoints). Existing baselines taken against such a model are not comparable to runs after this PR.
