### PR TITLE
Add `--chat-template-kwarg` for model-specific template keys

### DIFF
--- a/preset.md
+++ b/preset.md
@@ -24,6 +24,8 @@ sampling:                          # all sub-fields optional
   top_p: 0.95
   max_tokens: null
   thinking: true                   # mapped to chat_template_kwargs.thinking
+  chat_template_kwargs:            # for templates reading another key
+    enable_thinking: false         # (Qwen3); merged over `thinking`
 
 expected:                          # optional, informational only
   score: 0.85                      # 0..1, headline metric (pass@1 for k>1,

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -71,6 +71,15 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="override chat_template_kwargs.thinking (per-benchmark default applies otherwise)",
     )
     p_run.add_argument(
+        "--chat-template-kwarg",
+        action="append",
+        metavar="K=V",
+        default=None,
+        help="extra chat_template_kwargs entry, repeatable. Values parse as JSON "
+        "when possible (e.g. enable_thinking=false), else stay strings. Use this "
+        "when the model's template reads a key other than 'thinking'.",
+    )
+    p_run.add_argument(
         "--out-dir",
         default="~/.sgl_eval",
         help="parent dir for run folders; each run writes into "

--- a/sgl_eval/preset.py
+++ b/sgl_eval/preset.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import json
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -52,6 +53,9 @@ class Sampling:
     # Mapped to ``GenConfig.chat_template_kwargs.thinking`` at apply time;
     # exposed flat here so preset YAML stays human-readable.
     thinking: Optional[bool] = None
+    # For templates that read some other key (Qwen3: ``enable_thinking``).
+    # Same score-changing weight as ``thinking``, so it belongs in the bundle.
+    chat_template_kwargs: Optional[Dict[str, Any]] = None
 
 
 @dataclass
@@ -195,6 +199,27 @@ def pick(*candidates: Any) -> Any:
     return None
 
 
+def parse_chat_template_kwargs(args: argparse.Namespace) -> Dict[str, Any]:
+    """Parse repeated ``--chat-template-kwarg K=V`` into a dict.
+
+    Values go through JSON first (so ``false`` / ``0`` / ``[1,2]`` keep their
+    type) and fall back to the raw string. Needed because the key a model's
+    chat template reads is model-specific -- Qwen3 wants ``enable_thinking``,
+    not the generic ``thinking``.
+    """
+    parsed: Dict[str, Any] = {}
+    for item in getattr(args, "chat_template_kwarg", None) or []:
+        key, sep, raw = item.partition("=")
+        if not sep or not key.strip():
+            raise SystemExit(f"--chat-template-kwarg expects K=V, got {item!r}")
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError:
+            value = raw
+        parsed[key.strip()] = value
+    return parsed
+
+
 def apply_to_gen(
     default: GenConfig, preset: Optional["Preset"], args: argparse.Namespace
 ) -> GenConfig:
@@ -202,14 +227,19 @@ def apply_to_gen(
 
     ``args`` must expose ``temperature``, ``top_p``, ``max_tokens``,
     ``thinking`` (any of which may be ``None`` for "unset"). ``seed`` is
-    optional -- it has no preset field, being a reproducibility knob rather
-    than part of the run's identity.
+    optional and has no preset field -- it is a reproducibility knob, not part
+    of the run we are reproducing. ``chat_template_kwarg`` does have one: it
+    changes the prompt, so a preset that could not carry it would replay a
+    different run.
     """
     p = preset.sampling if preset else None
     chat_template_kwargs = dict(default.chat_template_kwargs or {})
     thinking = pick(args.thinking, p.thinking if p else None)
     if thinking is not None:
         chat_template_kwargs["thinking"] = thinking
+    if p and p.chat_template_kwargs:
+        chat_template_kwargs.update(p.chat_template_kwargs)
+    chat_template_kwargs.update(parse_chat_template_kwargs(args))
     return GenConfig(
         temperature=pick(args.temperature, p.temperature if p else None, default.temperature),
         top_p=pick(args.top_p, p.top_p if p else None, default.top_p),

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -159,6 +159,49 @@ def test_apply_to_gen_keeps_ns_sampling_extras() -> None:
     assert (gen.min_p, gen.repetition_penalty) == (0.01, 1.05)
 
 
+def test_chat_template_kwarg_parses_json_then_falls_back_to_string() -> None:
+    """A model's template may read any key (Qwen3 wants ``enable_thinking``),
+    and the value's type matters -- ``false`` must not arrive as ``"false"``."""
+    gen = apply_to_gen(
+        GenConfig(),
+        preset=None,
+        args=_args(chat_template_kwarg=["enable_thinking=false", "style=terse"]),
+    )
+    assert gen.chat_template_kwargs == {"enable_thinking": False, "style": "terse"}
+
+
+def test_chat_template_kwarg_wins_over_thinking() -> None:
+    gen = apply_to_gen(
+        GenConfig(chat_template_kwargs={"thinking": True}),
+        preset=None,
+        args=_args(chat_template_kwarg=["thinking=false"]),
+    )
+    assert gen.chat_template_kwargs == {"thinking": False}
+
+
+def test_preset_carries_chat_template_kwargs() -> None:
+    """A preset has to be able to replay the run it names. ``enable_thinking``
+    changes the prompt exactly like ``thinking`` does, so a preset without it
+    would silently replay with the model's default thinking state."""
+    default = GenConfig()
+    gen = apply_to_gen(
+        default, _preset_with(chat_template_kwargs={"enable_thinking": False}), _args()
+    )
+    assert gen.chat_template_kwargs == {"enable_thinking": False}
+    # CLI still wins over the preset.
+    gen = apply_to_gen(
+        default,
+        _preset_with(chat_template_kwargs={"enable_thinking": False}),
+        _args(chat_template_kwarg=["enable_thinking=true"]),
+    )
+    assert gen.chat_template_kwargs == {"enable_thinking": True}
+
+
+def test_chat_template_kwarg_rejects_missing_equals() -> None:
+    with pytest.raises(SystemExit):
+        apply_to_gen(GenConfig(), preset=None, args=_args(chat_template_kwarg=["thinking"]))
+
+
 def test_apply_to_gen_thinking_priority() -> None:
     """``thinking`` is the only sampling field that lives under
     ``chat_template_kwargs``; verify it follows the same priority chain."""


### PR DESCRIPTION
## Summary
- Add `--chat-template-kwarg K=V` (repeatable) for templates that read a key other than `thinking` -- Qwen3 reads `enable_thinking`
- Values parse as JSON first, so `false` arrives as a bool rather than `"false"`; anything that is not valid JSON stays a string
- Add `chat_template_kwargs` to the preset `sampling` schema

## Notes
- Resolution order is spec default -> `thinking` -> preset -> CLI, so `--chat-template-kwarg` wins over both `--thinking` and the preset
- `thinking` already had a preset field because it changes the prompt; `enable_thinking` changes it identically, so leaving it CLI-only would make those runs unreplayable from their own preset

Stacks on #24.
