### PR TITLE
Add `ruler2` (synthetic long-context, 12-subtask group)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,84 @@ defaults (`n_repeats`, `thinking`, sampling params). All scoring behavior
 (prompt, answer extraction, grading, pass@k / majority@k aggregation) comes
 from the vendored NeMo-Skills slice.
 
+### RULER2 -- long context
+
+`ruler2` is a **group** of 12 synthetic subtasks (`mk_niah_*`, `mv_niah_*`,
+`qa_*`), averaged into one headline by upstream's own
+`ruler2_score.compute_score`. It differs from every other benchmark in three
+ways worth knowing before the first run:
+
+```bash
+pip install 'sgl-eval[longcontext]'      # transformers, nltk, wonderwords, inflect
+
+sgl-eval run ruler2 --base-url http://localhost:30000/v1 \
+  --bench-arg seq_len=131072
+```
+
+**1. The dataset is generated, not downloaded.** It is bound to a tokenizer and
+a target length, so the cache key is `(tokenizer, seq_len, dataset_size)` under
+`~/.cache/sgl_eval/ruler2/<setup>/`. First build of a 128k setup takes tens of
+minutes and lands ~600 MB; later runs reuse it.
+
+| `--bench-arg` | default | meaning |
+|---|---|---|
+| `seq_len` | **required** | target context length; no default because the data is per-length |
+| `tokenizer` | the served model id | HF repo id or local path used to size samples |
+| `tokenizer_type` | `hf` | `hf` or `openai` (tiktoken) |
+| `dataset_size` | `100` | samples per subtask |
+| `tasks` | all 12 | comma-separated subset; scores a flagged partial average |
+
+These go straight to the vendored generator, whose own `random_seed` is fixed
+at 42 -- so a given config reproduces NeMo-Skills' dataset byte for byte. There
+is deliberately **no knob that shrinks `seq_len`**: it defines the dataset and
+therefore the score, which puts it under the vendoring rule. `bench_args` is
+recorded in `metrics.json` so a result always names its setup.
+
+**2. The window must hold prompt *plus* answer.** Prompts are sized with the
+raw tokenizer, but requests go through `/v1/chat/completions`, where the server
+prepends a chat template. And with `max_tokens` unset, a window exactly equal to
+`seq_len` leaves zero room to generate. Both failures are silent -- the sampler
+turns them into empty samples scoring 0, so the run finishes with all-zero
+metrics and a successful exit code. sgl-eval therefore queries the endpoint's
+context length up front and **refuses to start** unless it is at least
+`seq_len + max_tokens` (or `seq_len + 512` when `max_tokens` is unset). RULER2 is
+meant to be swept over lengths *below* the window, so pick `seq_len` accordingly
+rather than matching it to the window.
+
+**3. Concurrency defaults to 4, not 64.** The runner limits in-flight
+*requests*, not tokens; 64 concurrent 128k prompts would put ~8M tokens in
+flight. Override with `--num-threads` if the server can take it. Note that batch
+composition affects generation numerics, so `num_threads` is part of what a
+result is bound to -- it is recorded in `metrics.json`.
+
+### Matching a NeMo-Skills run
+
+Same vendored generator, prompt (`generic/default` is a bare `{question}`
+passthrough), endpoint type (`chat`), grader, and aggregator. Sampling lines up
+field for field with NS's `InferenceConfig` -- including `min_p=0.0` and
+`repetition_penalty=1.0`, which are sent explicitly rather than left to the
+served model's `generation_config.json`. One knob differs: NS sends `seed=0`,
+sgl-eval sends none unless asked, so add `--seed 0` for an exact match. It has
+no effect at `temperature=0`.
+
+Three values are yours to align, because they define the dataset rather than
+the request: pass the same `--bench-arg tokenizer=` NS was given (sgl-eval
+otherwise defaults to the served model id), the same `seq_len` (the official
+RULER2 sweep picks it explicitly, e.g. `1048576 - 768` to reserve room to
+answer), and the same `dataset_size`. `--num-examples` is *not* a substitute for
+`dataset_size`: it slices the generated file (NS's `++max_samples`), it does not
+change what gets generated.
+
+Output shows the headline plus a per-subtask breakdown, which is what tells you
+*which* capability degraded:
+
+```
+* score        =  62.41%
+    mk_niah_basic  =  91.00%
+    qa_hard        =  28.50%
+    ...
+```
+
 ---
 
 ## Architecture
@@ -160,7 +238,7 @@ pytest                             # upstream's own tests run against the
   MMLU-Pro, GPQA-extended, ...). Each is one row in `_registry.py:_TABLE`.
 - **New metrics types** (require a new runner per category, but graders
   are usually already in NeMo-Skills):
-  - `long_context`: LongBench V2, RULER, MRCR
+  - `long_context`: LongBench V2, MRCR (RULER2 is in -- see below)
   - `code`: HumanEval, MBPP, LiveCodeBench (with execution sandbox)
   - `instruction_following`: IFEval, IFBench
   - `multimodal` (VLM): MMMU, MathVista (needs an image-aware sampler)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ ways worth knowing before the first run:
 pip install 'sgl-eval[longcontext]'      # transformers, nltk, wonderwords, inflect
 
 sgl-eval run ruler2 --base-url http://localhost:30000/v1 \
-  --bench-arg seq_len=131072
+  --ruler2-seq-len 131072
 ```
 
 **1. The dataset is generated, not downloaded.** It is bound to a tokenizer and
@@ -138,19 +138,20 @@ a target length, so the cache key is `(tokenizer, seq_len, dataset_size)` under
 `~/.cache/sgl_eval/ruler2/<setup>/`. First build of a 128k setup takes tens of
 minutes and lands ~600 MB; later runs reuse it.
 
-| `--bench-arg` | default | meaning |
+| flag | default | meaning |
 |---|---|---|
-| `seq_len` | **required** | target context length; no default because the data is per-length |
-| `tokenizer` | the served model id | HF repo id or local path used to size samples |
-| `tokenizer_type` | `hf` | `hf` or `openai` (tiktoken) |
-| `dataset_size` | `100` | samples per subtask |
-| `tasks` | all 12 | comma-separated subset; scores a flagged partial average |
+| `--ruler2-seq-len` | **required** | target context length; no default because the data is per-length |
+| `--ruler2-tokenizer` | the served model id | HF repo id or local path used to size samples |
+| `--ruler2-tokenizer-type` | `hf` | `hf` or `openai` (tiktoken) |
+| `--ruler2-dataset-size` | `100` | samples per subtask |
+| `--ruler2-tasks` | all 12 | space-separated subset; scores a flagged partial average |
 
-These go straight to the vendored generator, whose own `random_seed` is fixed
-at 42 -- so a given config reproduces NeMo-Skills' dataset byte for byte. There
-is deliberately **no knob that shrinks `seq_len`**: it defines the dataset and
-therefore the score, which puts it under the vendoring rule. `bench_args` is
-recorded in `metrics.json` so a result always names its setup.
+`sgl-eval run --help` lists them under `ruler2 options`. They go straight to the
+vendored generator, whose own `random_seed` is fixed at 42 -- so a given config
+reproduces NeMo-Skills' dataset byte for byte. There is deliberately **no knob
+that shrinks `seq_len`**: it defines the dataset and therefore the score, which
+puts it under the vendoring rule. The chosen values are recorded in
+`metrics.json` so a result always names its setup.
 
 **2. The window must hold prompt *plus* answer.** Prompts are sized with the
 raw tokenizer, but requests go through `/v1/chat/completions`, where the server
@@ -180,7 +181,7 @@ sgl-eval sends none unless asked, so add `--seed 0` for an exact match. It has
 no effect at `temperature=0`.
 
 Three values are yours to align, because they define the dataset rather than
-the request: pass the same `--bench-arg tokenizer=` NS was given (sgl-eval
+the request: pass the same `--ruler2-tokenizer` NS was given (sgl-eval
 otherwise defaults to the served model id), the same `seq_len` (the official
 RULER2 sweep picks it explicitly, e.g. `1048576 - 768` to reserve room to
 answer), and the same `dataset_size`. `--num-examples` is *not* a substitute for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ dependencies = [
     "datasets>=2.14,<5",
     # Multimodal benchmarks (MMMU-Pro question image -> PNG bytes)
     "pillow>=10,<12",
+    # RULER2 grader (vendored evaluator/ruler.py imports this at module level)
+    "editdistance>=0.6,<1",
 ]
 
 [project.optional-dependencies]
@@ -58,6 +60,15 @@ dev = [
     "pytest-asyncio>=0.23,<2",
     "ruff>=0.5,<1",
     "black>=24.0,<26",
+]
+# RULER2 dataset generation. Only needed to BUILD the dataset -- scoring an
+# already-generated one needs core only. `transformers` is heavy and nothing
+# else in sgl-eval wants it, so it stays out of the default install.
+longcontext = [
+    "transformers>=4.40,<6",
+    "nltk>=3.8,<4",
+    "wonderwords>=2.2,<3",
+    "inflect>=7.0,<8",
 ]
 
 [project.scripts]

--- a/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
+++ b/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
@@ -22,6 +22,15 @@ pinned_deps:
   latex2sympy2_extended: ""     # upstream pin: unversioned
   numpy: ""                     # upstream pin: unversioned
   tqdm: ""                      # upstream pin: unversioned (used by evaluator/base.py)
+  editdistance: ""              # upstream pin: unversioned (evaluator/ruler.py WER)
+  # RULER2 dataset generation only. Kept out of the core install because
+  # nothing else needs them and `transformers` is heavy -- they live in the
+  # `longcontext` extra. All four are imported by dataset/ruler2/prepare_*.py;
+  # `transformers` / `tiktoken` are lazy (inside tokenizer.py's __init__).
+  nltk: ""
+  wonderwords: ""
+  inflect: ""
+  transformers: ""
 
 # Applied by sync_vendored.py to rewrite intra-nemo-skills imports so
 # vendored files resolve under sgl_eval._vendored.nemo_skills. Audited
@@ -35,6 +44,12 @@ import_rewrites:
   "from nemo_skills.evaluation.evaluator.math import": "from sgl_eval._vendored.nemo_skills.evaluator.math import"
   "from nemo_skills.evaluation.evaluator.mcq import": "from sgl_eval._vendored.nemo_skills.evaluator.mcq import"
   "from nemo_skills.dataset.utils import": "from sgl_eval._vendored.nemo_skills.dataset._utils import"
+  # ruler2/prepare.py spawns its sibling generators as `python -m
+  # nemo_skills.dataset.ruler2.prepare_niah` and emits SCORE_MODULE as a
+  # string literal. Both are module paths in source text rather than import
+  # statements, so the audit regex cannot see them -- rewrite the dotted
+  # prefix so the subprocess resolves under _vendored.
+  "nemo_skills.dataset.ruler2.": "sgl_eval._vendored.nemo_skills.dataset.ruler2."
 
 # Files synced verbatim from upstream (with rewrites + drop_functions +
 # drop_imports applied, plus a provenance banner for .py / .yaml).
@@ -65,6 +80,10 @@ files:
       - nemo_skills.code_execution
   - src: nemo_skills/evaluation/evaluator/mcq.py
     dst: evaluator/mcq.py
+  - src: nemo_skills/evaluation/evaluator/ruler.py
+    dst: evaluator/ruler.py
+  - src: nemo_skills/evaluation/metrics/ruler2_metrics.py
+    dst: ruler2_metrics.py
 
   # --- dataset utilities ---
   - src: nemo_skills/dataset/utils.py
@@ -96,6 +115,33 @@ files:
   - src: nemo_skills/dataset/gpqa/prepare.py
     dst: dataset/gpqa/prepare.py
 
+  # --- RULER2 (synthetic long-context; generated per tokenizer + seq length) ---
+  # Upstream ships no test split for this one: `__init__.py` is just
+  # REQUIRES_DATA_DIR = True, and the 12 subtasks are generated locally. Note
+  # sgl-eval calls the per-task `prepare_<task>(output_folder, ...)` functions
+  # directly rather than `prepare_dataset`, whose output_folder is hardcoded to
+  # `Path(__file__).parent / setup` -- i.e. it would write into _vendored.
+  - src: nemo_skills/dataset/ruler2/__init__.py
+    dst: dataset/ruler2/__init__.py
+  - src: nemo_skills/dataset/ruler2/prepare.py
+    dst: dataset/ruler2/prepare.py
+  - src: nemo_skills/dataset/ruler2/prepare_niah.py
+    dst: dataset/ruler2/prepare_niah.py
+  - src: nemo_skills/dataset/ruler2/prepare_qa.py
+    dst: dataset/ruler2/prepare_qa.py
+  - src: nemo_skills/dataset/ruler2/prepare_mmlu.py
+    dst: dataset/ruler2/prepare_mmlu.py
+  - src: nemo_skills/dataset/ruler2/tokenizer.py
+    dst: dataset/ruler2/tokenizer.py
+    # GeminiTokenizer is the only module-level `tenacity` user and needs a
+    # GEMINI_API_KEY. sgl-eval restricts tokenizer_type to hf/openai.
+    drop_functions:
+      - GeminiTokenizer
+    drop_imports:
+      - tenacity
+  - src: nemo_skills/dataset/ruler2/ruler2_score.py
+    dst: dataset/ruler2/ruler2_score.py
+
   # --- prompt templates ---
   - src: nemo_skills/prompt/config/generic/math.yaml
     dst: prompts/math.yaml
@@ -103,6 +149,10 @@ files:
     dst: prompts/mcq-4choices.yaml
   - src: nemo_skills/prompt/config/eval/aai/mcq-4choices-boxed.yaml
     dst: prompts/mcq-4choices-boxed.yaml
+  # RULER2's ++prompt_config. Pure passthrough (`user: "{question}"`) -- the
+  # long context is already assembled by the prepare scripts.
+  - src: nemo_skills/prompt/config/generic/default.yaml
+    dst: prompts/default.yaml
 
   # --- upstream's own behavior tests ---
   # Run as part of `pytest`. These are NS's canonical regression cases,

--- a/sgl_eval/_vendored/nemo_skills/dataset/ruler2/__init__.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/ruler2/__init__.py
@@ -1,0 +1,20 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/ruler2/__init__.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+REQUIRES_DATA_DIR = True

--- a/sgl_eval/_vendored/nemo_skills/dataset/ruler2/prepare.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/ruler2/prepare.py
@@ -1,0 +1,582 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/ruler2/prepare.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+import concurrent.futures
+import subprocess
+from pathlib import Path
+
+DEFAULT_SETTINGS = """
+DATASET_GROUP = "long-context"
+METRICS_TYPE = "{metrics_type}"
+GENERATION_ARGS = (
+    "++prompt_config=generic/default "
+    "{eval_args} "
+)
+"""
+
+
+def prepare_mk_niah_basic(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_niah",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--num_needle_k",
+            "1",
+            "--num_needle_v",
+            "1",
+            "--num_needle_q",
+            "1",
+            "--type_haystack",
+            "needle",
+            "--type_needle_k",
+            "words",
+            "--type_needle_v",
+            "numbers",
+            "--num_digits_v",
+            "10",
+        ],
+        check=True,
+    )
+
+
+def prepare_mk_niah_easy(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_mmlu",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "mmlu",
+            "--fewshot",
+            "0",
+            "--prompt_type",
+            "instruct",
+            "--num_order",
+            "0",
+            "--task_type",
+            "retrieve",
+            "--algo_type",
+            "single",
+        ],
+        check=True,
+    )
+
+
+def prepare_mk_niah_medium(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_mmlu",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "mmlu",
+            "--fewshot",
+            "5",
+            "--prompt_type",
+            "instruct",
+            "--num_order",
+            "0",
+            "--task_type",
+            "solve",
+            "--algo_type",
+            "2steps",
+        ],
+        check=True,
+    )
+
+
+def prepare_mk_niah_hard(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_mmlu",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "mmlu",
+            "--fewshot",
+            "5",
+            "--prompt_type",
+            "instruct",
+            "--num_order",
+            "0",
+            "--task_type",
+            "solve",
+            "--algo_type",
+            "single",
+        ],
+        check=True,
+    )
+
+
+def prepare_mv_niah_basic(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_niah",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--num_needle_k",
+            "1",
+            "--num_needle_v",
+            "4",
+            "--num_needle_q",
+            "1",
+            "--type_haystack",
+            "needle",
+            "--type_needle_k",
+            "words",
+            "--type_needle_v",
+            "numbers",
+            "--num_digits_v",
+            "10",
+        ],
+        check=True,
+    )
+
+
+def prepare_mv_niah_easy(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_mmlu",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "mmlu",
+            "--fewshot",
+            "0",
+            "--prompt_type",
+            "instruct",
+            "--num_order",
+            "4",
+            "--task_type",
+            "niah",
+            "--algo_type",
+            "single",
+        ],
+        check=True,
+    )
+
+
+def prepare_mv_niah_medium(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_mmlu",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "mmlu",
+            "--fewshot",
+            "0",
+            "--prompt_type",
+            "instruct",
+            "--num_order",
+            "4",
+            "--task_type",
+            "retrieve",
+            "--algo_type",
+            "2steps",
+        ],
+        check=True,
+    )
+
+
+def prepare_mv_niah_hard(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_mmlu",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "mmlu",
+            "--fewshot",
+            "0",
+            "--prompt_type",
+            "instruct",
+            "--num_order",
+            "4",
+            "--task_type",
+            "retrieve",
+            "--algo_type",
+            "single",
+        ],
+        check=True,
+    )
+
+
+def prepare_qa_basic(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_qa",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "hotpotqa",
+            "--fewshot",
+            "0",
+            "--prompt_type",
+            "instruct",
+            "--task_type",
+            "retrieve",
+            "--query_type",
+            "doc",
+        ],
+        check=True,
+    )
+
+
+def prepare_qa_easy(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_qa",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "hotpotqa",
+            "--fewshot",
+            "0",
+            "--prompt_type",
+            "instruct",
+            "--task_type",
+            "retrieve",
+            "--query_type",
+            "question",
+        ],
+        check=True,
+    )
+
+
+def prepare_qa_medium(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_qa",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "hotpotqa",
+            "--fewshot",
+            "0",
+            "--prompt_type",
+            "instruct",
+            "--task_type",
+            "solve",
+            "--algo_type",
+            "2steps",
+        ],
+        check=True,
+    )
+
+
+def prepare_qa_hard(output_folder, tokenizer_type, tokenizer_path, length, dataset_size):
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "sgl_eval._vendored.nemo_skills.dataset.ruler2.prepare_qa",
+            "--output_folder",
+            output_folder,
+            "--tokenizer_type",
+            tokenizer_type,
+            "--tokenizer_path",
+            tokenizer_path,
+            "--max_seq_length",
+            str(length),
+            "--num_samples",
+            str(dataset_size),
+            "--random_seed",
+            "42",
+            "--dataset",
+            "hotpotqa",
+            "--fewshot",
+            "0",
+            "--prompt_type",
+            "instruct",
+            "--task_type",
+            "solve",
+            "--algo_type",
+            "single",
+        ],
+        check=True,
+    )
+
+
+def prepare_task_for_ns(output_folder, task):
+    """Adding proper __init__.py"""
+    output_folder = Path(output_folder) / task
+    Path(output_folder).mkdir(parents=True, exist_ok=True)
+    with open(output_folder / "__init__.py", "w", encoding="utf-8") as init_file:
+        if task in ["mk_niah_medium", "mk_niah_hard"]:
+            metrics_type = "multichoice"
+            eval_args = "++eval_type=multichoice"
+        elif task in ["mv_niah_medium"]:
+            metrics_type = "ruler2"
+            eval_args = "++eval_type=ruler2 ++eval_config.match_type=2steps"
+        elif "qa" in task:
+            metrics_type = "ruler2"
+            eval_args = "++eval_type=ruler2 ++eval_config.match_type=part"
+        else:
+            metrics_type = "ruler2"
+            eval_args = "++eval_type=ruler2 ++eval_config.match_type=all"
+
+        init_file.write(DEFAULT_SETTINGS.format(metrics_type=metrics_type, eval_args=eval_args))
+
+
+def prepare_dataset(tasks, setup, max_seq_length, tokenizer_type, tokenizer_path, dataset_size):
+    prepare_task = {
+        "mk_niah_basic": prepare_mk_niah_basic,
+        "mk_niah_easy": prepare_mk_niah_easy,
+        "mk_niah_medium": prepare_mk_niah_medium,
+        "mk_niah_hard": prepare_mk_niah_hard,
+        "mv_niah_basic": prepare_mv_niah_basic,
+        "mv_niah_easy": prepare_mv_niah_easy,
+        "mv_niah_medium": prepare_mv_niah_medium,
+        "mv_niah_hard": prepare_mv_niah_hard,
+        "qa_basic": prepare_qa_basic,
+        "qa_easy": prepare_qa_easy,
+        "qa_medium": prepare_qa_medium,
+        "qa_hard": prepare_qa_hard,
+    }
+
+    output_folder = Path(__file__).parent / setup
+
+    # 1. installing necessary packages
+    # subprocess.run(["pip", "install", "wonderwords", "html2text", "tenacity"], check=True)
+
+    for task in tasks:
+        prepare_task_for_ns(output_folder, task)
+
+    # preparing the datasets based on user options, in parallel
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = [
+            executor.submit(
+                prepare_task[task],
+                str(output_folder / task),
+                tokenizer_type,
+                tokenizer_path,
+                max_seq_length,
+                dataset_size,
+            )
+            for task in tasks
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            future.result()  # Will raise exception if any subprocess fails
+
+    with open(output_folder / "__init__.py", "w", encoding="utf-8") as init_file:
+        init_file.write("IS_BENCHMARK_GROUP = True\n")
+        init_file.write("SCORE_MODULE = 'sgl_eval._vendored.nemo_skills.dataset.ruler2.ruler2_score'\n")
+        benchmarks = ", ".join(f"'ruler2.{setup}.{task}': {{}}" for task in tasks)
+        init_file.write(f"BENCHMARKS = {{{benchmarks}}}\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Prepare RULER2 dataset.")
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        nargs="+",
+        default=[
+            "mk_niah_basic",
+            "mk_niah_easy",
+            "mk_niah_medium",
+            "mk_niah_hard",
+            "mv_niah_basic",
+            "mv_niah_easy",
+            "mv_niah_medium",
+            "mv_niah_hard",
+            "qa_basic",
+            "qa_easy",
+            "qa_medium",
+            "qa_hard",
+        ],
+        help="List of tasks to prepare for RULER2 dataset.",
+    )
+    parser.add_argument(
+        "--setup",
+        type=str,
+        required=True,
+        help="Name of the setup for RULER2 dataset. Typically should be <model_name>_<sequence_length>.",
+    )
+    parser.add_argument(
+        "--max_seq_length",
+        type=int,
+        required=True,
+        help="Sequence length to check with RULER2.",
+    )
+    parser.add_argument(
+        "--tokenizer_type",
+        type=str,
+        default="hf",
+        help="Type of the tokenizer to use.",
+    )
+    parser.add_argument(
+        "--tokenizer_path",
+        type=str,
+        required=True,
+        help="Path to the tokenizer to use.",
+    )
+    parser.add_argument(
+        "--dataset_size",
+        type=int,
+        default=100,
+        help="Number of samples to prepare for RULER2 dataset.",
+    )
+
+    args, unknown = parser.parse_known_args()
+    prepare_dataset(
+        args.tasks,
+        args.setup,
+        args.max_seq_length,
+        args.tokenizer_type,
+        args.tokenizer_path,
+        args.dataset_size,
+    )
+    print("RULER2 dataset preparation completed.")

--- a/sgl_eval/_vendored/nemo_skills/dataset/ruler2/prepare_mmlu.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/ruler2/prepare_mmlu.py
@@ -1,0 +1,482 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/ruler2/prepare_mmlu.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import argparse
+import json
+import logging
+import math
+import random
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import inflect
+import numpy as np
+from datasets import load_dataset
+from tqdm import tqdm
+
+from .tokenizer import select_tokenizer
+
+convert = inflect.engine()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser()
+# Basic Configurations
+parser.add_argument("--output_folder", type=str)
+parser.add_argument("--tokenizer_type", type=str, default="hf", help="[Options] nemo, hf, openai.")
+parser.add_argument("--tokenizer_path", type=str, required=True, help="path to the tokenizer model")
+parser.add_argument(
+    "--max_seq_length",
+    type=int,
+    required=True,
+    help="max sequence length including all input tokens and generated tokens.",
+)
+parser.add_argument("--random_seed", type=int, default=42)
+parser.add_argument(
+    "--insert_position", type=float, default=-1, help="insert position of the true context in the context."
+)
+parser.add_argument("--num_samples", type=int, default=None, help="number of samples to generate")
+parser.add_argument("--dataset", type=str, default="gsm8k")
+parser.add_argument("--fewshot", type=int, default=0)
+parser.add_argument("--prompt_type", type=str, default="chat")
+parser.add_argument("--num_order", type=int, default=0)
+parser.add_argument(
+    "--algo_type",
+    type=str,
+    default="single",
+    choices=["single", "attention", "2steps", "3steps", "size_2steps", "size_single"],
+)
+parser.add_argument("--task_type", type=str, default="retrieve", choices=["retrieve", "solve", "niah"])
+
+args = parser.parse_args()
+random.seed(args.random_seed)
+np.random.seed(args.random_seed)
+
+# Load Tokenizer
+TOKENIZER = select_tokenizer(args.tokenizer_type, args.tokenizer_path)
+
+TOTAL_PROMPT = """{context}\n\n{example}{problem}"""
+if args.task_type == "retrieve":
+    CONTEXT_PROMPT = "Below are some questions. I will ask you to copy one of them. Please copy and paste the question you find.\n\n{needles}"
+    NEEDLE_PROMPT = "Question {i}: {question}"
+    if args.algo_type == "single":
+        PROBLEM_PROMPT = "Please copy the {order}Question {i} from the context."
+    elif args.algo_type == "attention":
+        PROBLEM_PROMPT = "Please first pay attention to all the Question {i} from the context and then only copy the {order}Question {i} in your response. Do not output any other questions."
+    elif args.algo_type == "2steps":
+        # PROBLEM_PROMPT = "Please first find all the Question {i} from the context and then copy the {order}Question {i} at the end."
+        PROBLEM_PROMPT = (
+            "Please first copy all the Question {i} from the context and then copy the {order}Question {i} at the end."
+        )
+        # PROBLEM_PROMPT = "Please first copy all instances of Question {i} from the context in the order in which they appear, and then copy the {order}Question {i} (1-indexed) at the end."
+    elif args.algo_type == "3steps":
+        PROBLEM_PROMPT = "Please first find how many Question {i} from the context, list them in order, and then copy the {order}Question {i} at the end."
+    elif args.algo_type == "size_2steps":
+        PROBLEM_PROMPT = (
+            "Please first find all the"
+            + str(args.num_order)
+            + " Question {i} from the context and then copy the {order}Question {i} at the end."
+        )
+    elif args.algo_type == "size_single":
+        PROBLEM_PROMPT = (
+            "There are "
+            + str(args.num_order)
+            + " Question {i} in the context. Please copy the {order}Question {i} from the context."
+        )
+
+    if args.fewshot > 0:
+        EXAMPLE_PROMPT = PROBLEM_PROMPT + "\nQuestion {i}: {question}"
+
+    if args.prompt_type == "base":
+        PROBLEM_PROMPT += "\nQuestion {i}:"
+
+elif args.task_type == "niah":
+    CONTEXT_PROMPT = "Below are some questions. I will ask you to copy some of them. Please copy and paste the questions you find.\n\n{needles}"
+    NEEDLE_PROMPT = "Question {i}: {question}"
+    PROBLEM_PROMPT = "Please find and copy all the Question {i} from the context."
+    if args.prompt_type == "base":
+        PROBLEM_PROMPT += "\nQuestion {i}:"
+
+
+elif args.task_type == "solve":
+    CONTEXT_PROMPT = "Below are some questions. I will ask you to solve one of them. Please solve the question you find and make sure to put the answer (and only answer) inside \\boxed\\{{\\}}.\n\n{needles}"
+    NEEDLE_PROMPT = "Question {i}: {question}"
+    if args.dataset == "gsm8k" or args.dataset == "math500":
+        if args.algo_type == "single":
+            PROBLEM_PROMPT = "Please solve the Question {i} from the context step by step."
+        elif args.algo_type == "2steps":
+            PROBLEM_PROMPT = "Please copy the Question {i} from the context and then solve it step by step."
+    elif args.dataset == "mmlu":
+        if args.algo_type == "single":
+            PROBLEM_PROMPT = "Please solve the Question {i} from the context with an answer from A, B, C, D."
+        elif args.algo_type == "2steps":
+            PROBLEM_PROMPT = (
+                "Please copy the Question {i} from the context and then solve it with an answer from A, B, C, D."
+            )
+    elif args.dataset == "mbpp":
+        if args.algo_type == "single":
+            PROBLEM_PROMPT = "Please solve the Question {i} from the context by generating or completing code.\nYour answer should be in the following format:\n```python\n# Your code here\n```"
+        elif args.algo_type == "2steps":
+            PROBLEM_PROMPT = "Please copy the Question {i} from the context and then solve it by generating or completing code.\nYour answer should be in the following format:\n```python\n# Your code here\n```"
+
+    if args.fewshot > 0:
+        if args.algo_type == "single":
+            EXAMPLE_PROMPT = PROBLEM_PROMPT + "\nSolution:{solution}"
+            if args.prompt_type == "base":
+                PROBLEM_PROMPT += "\nSolution:"
+        elif args.algo_type == "2steps":
+            EXAMPLE_PROMPT = PROBLEM_PROMPT + "\nQuestion {i}: {question}\nSolution:{solution}"
+            if args.prompt_type == "base":
+                PROBLEM_PROMPT += "\nQuestion {i}:"
+
+examples = []
+haystack, needle = [], []
+if args.dataset == "gsm8k":
+    test_dataset = load_dataset("openai/gsm8k", "main")
+    for d in test_dataset["train"]:
+        solution, answer = d["answer"].split("#### ")
+        haystack.append(
+            {
+                "Question": d["question"],
+                "Solution": " " + solution + f"So the answer is \\boxed{{{answer}}}.",
+                "Answer": answer,
+            }
+        )
+    for d in test_dataset["test"]:
+        solution, answer = d["answer"].split("#### ")
+        needle.append(
+            {
+                "Question": d["question"],
+                "Solution": " " + solution + f"So the answer is \\boxed{{{answer}}}.",
+                "Answer": answer,
+            }
+        )
+elif args.dataset == "math500":
+    questions = set()
+    test_dataset = load_dataset("HuggingFaceH4/MATH-500")
+    for d in test_dataset["test"]:
+        needle.append(
+            {
+                "Question": d["problem"],
+                "Solution": " " + d["solution"],
+                "Answer": d["answer"],
+            }
+        )
+        questions.add(d["problem"])
+
+    from math_verify import parse
+
+    for subject in [
+        "algebra",
+        "counting_and_probability",
+        "geometry",
+        "intermediate_algebra",
+        "number_theory",
+        "prealgebra",
+        "precalculus",
+    ]:
+        train_dataset = load_dataset("EleutherAI/hendrycks_math", subject)
+        for index, d in enumerate(train_dataset["test"]):
+            if d["problem"] not in questions:
+                haystack.append(
+                    {
+                        "Question": d["problem"],
+                        "Solution": " " + d["solution"],
+                        "Answer": parse(d["solution"])[-1],
+                    }
+                )
+
+
+elif args.dataset == "mmlu":
+    test_dataset = load_dataset("cais/mmlu", "all")
+    options = ["A", "B", "C", "D"]
+    haystack = []
+    needle = []
+    for d in test_dataset["test"]:
+        choices = d["choices"]
+        item = {
+            "Question": d["question"] + f"\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}",
+            "Solution": " " + f"\\boxed{{{options[d['answer']]}}}",
+            "Answer": options[d["answer"]],
+        }
+        needle.append(item)
+
+    for d in test_dataset["auxiliary_train"]:
+        choices = d["choices"]
+        item = {
+            "Question": d["question"] + f"\nA. {choices[0]}\nB. {choices[1]}\nC. {choices[2]}\nD. {choices[3]}",
+            "Solution": " " + f"\\boxed{{{options[d['answer']]}}}",
+            "Answer": options[d["answer"]],
+        }
+        haystack.append(item)
+
+
+elif args.dataset == "mbpp":
+    test_dataset = load_dataset("evalplus/mbppplus")
+    for d in test_dataset["test"]:
+        prompt = d["prompt"].replace("    ", "\t").strip()
+        assertion = d["test_list"][0]
+        needle.append(
+            {
+                "task_id": f"Mbpp/{d['task_id']}",
+                "Question": f"{prompt}\n{assertion}",
+                "Solution": f"\n```python\n{d['code'].strip()}\n```",
+                "canonical_solution": f"\n{d['code'].strip()}\n",
+                "assertion": "\n".join(d["test_list"]),
+            }
+        )
+
+    train_dataset = load_dataset("google-research-datasets/mbpp", "full")
+    for d in train_dataset["train"]:
+        prompt = d["text"].replace("    ", "\t").strip()
+        assertion = d["test_list"][0]
+        haystack.append(
+            {
+                "Question": f"{prompt}\n{assertion}",
+                "Solution": f"\n```python\n{d['code'].strip()}\n```",
+                "canonical_solution": f"\n{d['code'].strip()}\n",
+                "assertion": "\n".join(d["test_list"]),
+            }
+        )
+    for d in train_dataset["validation"]:
+        prompt = d["text"].replace("    ", "\t").strip()
+        assertion = d["test_list"][0]
+        haystack.append(
+            {
+                "Question": f"{prompt}\n{assertion}",
+                "Solution": f"\n```python\n{d['code'].strip()}\n```",
+                "canonical_solution": f"\n{d['code'].strip()}\n",
+                "assertion": "\n".join(d["test_list"]),
+            }
+        )
+    for d in train_dataset["test"]:
+        prompt = d["text"].replace("    ", "\t").strip()
+        assertion = d["test_list"][0]
+        haystack.append(
+            {
+                "Question": f"{prompt}\n{assertion}",
+                "Solution": f"\n```python\n{d['code'].strip()}\n```",
+                "canonical_solution": f"\n{d['code'].strip()}\n",
+                "assertion": "\n".join(d["test_list"]),
+            }
+        )
+else:
+    raise ValueError(f"Dataset {args.dataset} is not supported.")
+
+for item in needle:
+    item["Question"] = re.sub(r"\s+", " ", item["Question"])
+for item in haystack:
+    item["Question"] = re.sub(r"\s+", " ", item["Question"])
+
+logger.info(f"Dataset size: {len(needle)}")
+
+
+def generate_random_number(num_digits=7):
+    lower_bound = 10 ** (num_digits - 1)
+    upper_bound = 10**num_digits - 1
+    return str(random.randint(lower_bound, upper_bound))
+
+
+def generate_input_output(index, num_qs):
+    if num_qs > len(haystack):
+        repeats = (num_qs + len(haystack) - 1) // len(haystack)  # Ceiling division
+    else:
+        repeats = 1
+
+    curr_context = [dict(item) for item in random.sample([item for item in haystack for _ in range(repeats)], num_qs)]
+
+    if args.num_order > 0:
+        random_numbers = [generate_random_number() for _ in range(math.ceil((num_qs + 1) / args.num_order))]
+        random_numbers = random_numbers * args.num_order
+    else:
+        random_numbers = [generate_random_number() for _ in range(num_qs + 1)]
+
+    random.shuffle(random_numbers)
+    random_numbers = random_numbers[: num_qs + 1]
+    for i, q in enumerate(curr_context):
+        q["random_index"] = random_numbers[i]
+
+    random.shuffle(curr_context)
+    examples = random.sample(curr_context, args.fewshot)
+
+    true_context = dict(needle[index])
+    true_context["random_index"] = random_numbers[-1]
+    if args.insert_position < 0:
+        insert_position = random.randint(0, len(curr_context))
+    else:
+        insert_position = int(args.insert_position * len(curr_context))
+    curr_context.insert(insert_position, true_context)
+
+    counts = defaultdict(int)
+    for i, q in enumerate(curr_context):
+        counts[q["random_index"]] += 1
+        if args.num_order > 0:
+            q["order"] = convert.ordinal(counts[q["random_index"]]) + " (1 indexed) "
+        else:
+            q["order"] = ""
+
+    needles = "\n\n".join(
+        [NEEDLE_PROMPT.format(i=q["random_index"], question=q["Question"]) for i, q in enumerate(curr_context)]
+    )
+    if args.task_type == "niah":
+        problem = PROBLEM_PROMPT.format(i=true_context["random_index"])
+    else:
+        problem = PROBLEM_PROMPT.format(i=true_context["random_index"], order=true_context["order"])
+
+    if args.fewshot > 0:
+        if args.task_type == "retrieve":
+            example = "\n\n".join(
+                [
+                    EXAMPLE_PROMPT.format(i=q["random_index"], question=q["Question"], order=q["order"])
+                    for q in examples
+                ]
+            )
+        elif args.task_type == "solve":
+            if args.algo_type == "single":
+                example = "\n\n".join(
+                    [EXAMPLE_PROMPT.format(i=q["random_index"], solution=q["Solution"]) for q in examples]
+                )
+            elif args.algo_type == "2steps":
+                example = "\n\n".join(
+                    [
+                        EXAMPLE_PROMPT.format(i=q["random_index"], question=q["Question"], solution=q["Solution"])
+                        for q in examples
+                    ]
+                )
+
+        if args.prompt_type == "base":
+            example = f"{example}\n\n"
+        else:
+            example = f"Here are some examples to help you understand the task:\n\n{example}\n\nHere is the actual task you need to solve:\n\n"
+    else:
+        example = ""
+
+    context = CONTEXT_PROMPT.format(needles=needles)
+    input_text = TOTAL_PROMPT.format(
+        context=context,
+        problem=problem,
+        example=example,
+    )
+
+    if args.task_type == "retrieve":
+        expected_answer = {"expected_answer": [true_context["Question"]]}
+    elif args.task_type == "niah":
+        expected_answer = {
+            "expected_answer": [
+                c["Question"] for c in curr_context if c["random_index"] == true_context["random_index"]
+            ]
+        }
+    elif args.task_type == "solve":
+        if args.dataset == "mbpp":
+            expected_answer = {
+                "task_id": true_context["task_id"],
+                "assertion": true_context["assertion"],
+                "canonical_solution": true_context["canonical_solution"],
+            }
+        else:
+            expected_answer = {"expected_answer": true_context["Answer"]}
+
+    save_dict = {
+        "index": index,
+        "question": f"{context}\n\n{example}{problem}",
+        **expected_answer,
+    }
+    return input_text, save_dict
+
+
+def generate_samples(max_seq_length: int, incremental: int = 10):
+    write_jsons = []
+
+    # Estimate tokens per question to determine reasonable upper bound
+    sample_input_text, _ = generate_input_output(0, incremental)
+    sample_tokens = len(TOKENIZER.text_to_tokens(sample_input_text))
+    tokens_per_question = sample_tokens / incremental
+
+    # Let's do 3x to allow for some slack since we can get unlucky due to sampling.
+    # NOTE: We should test this for really large sequence lengths to make sure it's reasonable.
+    estimated_max_questions = int((max_seq_length / tokens_per_question) * 3)
+
+    # Binary search for optimal haystack size
+    lower_bound = incremental
+    upper_bound = max(estimated_max_questions, incremental * 2)  # Ensure upper_bound is reasonable
+
+    optimal_num_qs = None
+
+    logger.info(f"Estimated {tokens_per_question:.1f} tokens per question")
+    logger.info(f"Starting binary search with bounds: {lower_bound} to {upper_bound}")
+
+    while lower_bound <= upper_bound:
+        mid = (lower_bound + upper_bound) // 2
+        input_text, save_dict = generate_input_output(0, mid)
+        total_tokens = len(TOKENIZER.text_to_tokens(input_text))
+
+        logger.info(f"Testing haystack size: {mid}, resulting tokens: {total_tokens}/{max_seq_length}")
+
+        if total_tokens <= max_seq_length:
+            # This size works, can we go larger?
+            optimal_num_qs = mid
+            lower_bound = mid + 1
+        else:
+            # Too large, need to go smaller
+            upper_bound = mid - 1
+
+    num_qs = optimal_num_qs if optimal_num_qs is not None else incremental
+    logger.info(f"Final optimal haystack size (number of questions): {num_qs}")
+
+    if args.num_samples is not None:
+        needle_sample = random.sample(list(range(len(needle))), min(len(needle), args.num_samples))
+    else:
+        needle_sample = list(range(len(needle)))
+
+    # Generate samples
+    for index in tqdm(needle_sample):
+        used_qs = num_qs
+        while True:
+            try:
+                input_text, save_dict = generate_input_output(index, used_qs)
+                length = len(TOKENIZER.text_to_tokens(input_text))
+                assert length <= max_seq_length, f"{length} exceeds max_seq_length."
+                break
+            except AssertionError:
+                if used_qs > incremental:
+                    used_qs -= incremental
+                else:
+                    raise
+
+        save_dict["length"] = length
+        formatted_output = save_dict
+        write_jsons.append(formatted_output)
+
+    return write_jsons
+
+
+def main():
+    output_file = Path(args.output_folder) / "test.jsonl"
+
+    write_jsons = generate_samples(max_seq_length=args.max_seq_length, incremental=max(10, args.fewshot))
+
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in write_jsons:
+            fout.write(json.dumps(entry) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/sgl_eval/_vendored/nemo_skills/dataset/ruler2/prepare_niah.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/ruler2/prepare_niah.py
@@ -1,0 +1,281 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/ruler2/prepare_niah.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import argparse
+import json
+import math
+import random
+import uuid
+from pathlib import Path
+
+import nltk
+import numpy as np
+import wonderwords
+from tqdm import tqdm
+
+from .tokenizer import select_tokenizer
+
+try:
+    nltk.data.find("tokenizers/punkt")
+    nltk.data.find("tokenizers/punkt_tab")
+except LookupError:
+    nltk.download("punkt")
+    nltk.download("punkt_tab")
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--output_folder", type=str)
+parser.add_argument("--tokenizer_type", type=str, default="hf", help="[Options] nemo, hf, openai.")
+parser.add_argument("--tokenizer_path", type=str, required=True, help="path to the tokenizer model")
+parser.add_argument(
+    "--max_seq_length",
+    type=int,
+    required=True,
+    help="max sequence length including all input tokens and generated tokens.",
+)
+parser.add_argument("--num_samples", type=int, required=True, help="number of samples to generate")
+parser.add_argument("--random_seed", type=int, default=42)
+
+# Complexity Configurations
+parser.add_argument("--num_needle_k", type=int, default=1)
+parser.add_argument("--num_needle_v", type=int, default=1)
+parser.add_argument("--num_needle_q", type=int, default=1)
+parser.add_argument("--type_haystack", type=str, default="needle", help="[Options] needle.")
+parser.add_argument("--type_needle_k", type=str, default="words", help="[Options] numbers, words, uuids.")
+parser.add_argument("--type_needle_v", type=str, default="numbers", help="[Options] numbers, words, uuids.")
+parser.add_argument("--num_digits_k", type=int, default=7)
+parser.add_argument("--num_digits_v", type=int, default=7)
+
+args = parser.parse_args()
+random.seed(args.random_seed)
+np.random.seed(args.random_seed)
+args.num_needle_k = max(args.num_needle_k, args.num_needle_q)
+
+# Load Tokenizer
+TOKENIZER = select_tokenizer(args.tokenizer_type, args.tokenizer_path)
+
+TEMPLATE_SINGLE = """A special magic {type_needle_v} is hidden within the following text. Make sure to memorize it. I will quiz you about the {type_needle_v} afterwards.\n{context}\nWhat is the special magic {type_needle_v} for {query} mentioned in the provided text? The special magic {type_needle_v} for {query} mentioned in the provided text is"""
+TEMPLATE_MULTIPLE = """Some special magic {type_needle_v} are hidden within the following text. Make sure to memorize them. I will quiz you about the {type_needle_v} afterwards.\n{context}\nWhat are all the special magic {type_needle_v} for {query} mentioned in the provided text? The special magic {type_needle_v} for {query} mentioned in the provided text are"""
+
+# Define Needle/Haystack Format
+needle = "One of the special magic {type_needle_v} for {key} is: {value}."
+if args.type_haystack == "needle":
+    haystack = needle
+else:
+    raise NotImplementedError(f"{args.type_haystack} is not implemented.")
+
+# Words
+nouns = wonderwords.random_word._get_words_from_text_file("nounlist.txt")
+adjs = wonderwords.random_word._get_words_from_text_file("adjectivelist.txt")
+words = [f"{adj}-{noun}" for adj in adjs for noun in nouns]
+words = sorted(list(set(words)))
+
+# Positions
+DEPTHS = list(np.round(np.linspace(0, 100, num=40, endpoint=True)).astype(int))
+
+
+def generate_random_number(num_digits=7):
+    lower_bound = 10 ** (num_digits - 1)
+    upper_bound = 10**num_digits - 1
+    return str(random.randint(lower_bound, upper_bound))
+
+
+def generate_random_word():
+    word = random.choice(words)
+    return word
+
+
+def generate_random_uuid():
+    return str(uuid.UUID(int=random.getrandbits(128), version=4))
+
+
+def generate_random(type_needle: str, digits: int | None = None):
+    if type_needle == "numbers":
+        if digits is None:
+            raise ValueError("digits must be provided when type_needle='numbers'")
+        return generate_random_number(digits)
+    elif type_needle == "words":
+        return generate_random_word()
+    elif type_needle == "uuids":
+        return generate_random_uuid()
+    else:
+        raise NotImplementedError(f"{type_needle} is not implemented.")
+
+
+def generate_input_output(num_haystack):
+    keys, values, needles = [], [], []
+    for _ in range(args.num_needle_k):
+        keys.append(generate_random(args.type_needle_k, args.num_digits_k))
+        value = []
+        for _ in range(args.num_needle_v):
+            value.append(generate_random(args.type_needle_v, args.num_digits_v))
+            needles.append(
+                needle.format(
+                    type_needle_v=args.type_needle_v,
+                    key=keys[-1],
+                    value=value[-1],
+                )
+            )
+        values.append(value)
+
+    random.shuffle(needles)
+
+    # Context
+    if args.num_needle_v == 1:
+        sentences = [
+            haystack.format(
+                type_needle_v=args.type_needle_v,
+                key=generate_random(args.type_needle_k, args.num_digits_k),
+                value=generate_random(args.type_needle_v, args.num_digits_v),
+            )
+            for _ in range(num_haystack)
+        ]
+    else:
+        haystack_values = [generate_random(args.type_needle_v, args.num_digits_v) for _ in range(num_haystack)]
+        haystack_keys = (
+            [
+                generate_random(args.type_needle_k, args.num_digits_k)
+                for _ in range(math.ceil(num_haystack / args.num_needle_v))
+            ]
+            * args.num_needle_v
+        )[:num_haystack]
+        sentences = [
+            haystack.format(
+                type_needle_v=args.type_needle_v,
+                key=haystack_keys[i],
+                value=haystack_values[i],
+            )
+            for i in range(num_haystack)
+        ]
+        random.shuffle(sentences)
+
+    indexes = sorted(random.sample(range(num_haystack), len(needles)), reverse=True)
+    for index, element in zip(indexes, needles):
+        sentences.insert(index, element)
+    context = "\n".join(sentences)
+
+    ## Query and Answer
+    indices = random.sample(range(args.num_needle_k), args.num_needle_q)
+    queries = [keys[i] for i in indices]
+    answers = [a for i in indices for a in values[i]]
+    query = ", ".join(queries[:-1]) + ", and " + queries[-1] if len(queries) > 1 else queries[0]
+
+    if args.num_needle_q * args.num_needle_v == 1:
+        template = TEMPLATE_SINGLE
+        type_needle_v = args.type_needle_v[:-1]  # remove "s"
+    else:
+        template = TEMPLATE_MULTIPLE
+        type_needle_v = args.type_needle_v
+
+    input_text = template.format(
+        type_needle_v=type_needle_v,
+        context=context,
+        query=query,
+    )
+
+    return input_text, answers
+
+
+def generate_samples(num_samples: int, max_seq_length: int, incremental: int = 500):
+    write_jsons = []
+
+    if args.type_haystack == "needle":
+        incremental = max(5, args.num_needle_v * args.num_needle_k)
+
+    if args.max_seq_length < 4096:
+        incremental = 5
+
+    # Estimate tokens per question to determine reasonable upper bound
+    sample_input_text, _ = generate_input_output(incremental)
+    sample_tokens = len(TOKENIZER.text_to_tokens(sample_input_text))
+    tokens_per_haystack = sample_tokens / incremental
+
+    # Let's do 3x to allow for some slack since we can get unlucky due to sampling.
+    # NOTE: We should test this for really large sequence lengths to make sure it's reasonable.
+    estimated_max_questions = int((max_seq_length / tokens_per_haystack) * 3)
+
+    # Binary search for optimal haystack size
+    lower_bound = incremental
+    upper_bound = max(estimated_max_questions, incremental * 2)  # Ensure upper_bound is reasonable
+
+    optimal_num_haystack = None
+
+    logger.info(f"Estimated {tokens_per_haystack:.1f} tokens per haystack")
+    logger.info(f"Starting binary search with bounds: {lower_bound} to {upper_bound}")
+    while lower_bound <= upper_bound:
+        mid = (lower_bound + upper_bound) // 2
+        input_text, _answers = generate_input_output(mid)
+        total_tokens = len(TOKENIZER.text_to_tokens(input_text))
+
+        logger.info(f"Testing haystack size: {mid}, resulting tokens: {total_tokens}/{max_seq_length}")
+
+        if total_tokens <= max_seq_length:
+            # This size works, can we go larger?
+            optimal_num_haystack = mid
+            lower_bound = mid + 1
+        else:
+            # Too large, need to go smaller
+            upper_bound = mid - 1
+
+    num_haystack = optimal_num_haystack if optimal_num_haystack is not None else incremental
+    logger.info(f"Final optimal haystack size (number of haystack): {num_haystack}")
+
+    # Generate samples
+    for index in tqdm(range(num_samples)):
+        used_haystack = num_haystack
+        while True:
+            try:
+                input_text, answer = generate_input_output(used_haystack)
+                length = len(TOKENIZER.text_to_tokens(input_text))
+                assert length <= max_seq_length, f"{length} exceeds max_seq_length."
+                break
+            except AssertionError:
+                if used_haystack > incremental:
+                    used_haystack -= incremental
+                else:
+                    raise
+
+        formatted_output = {
+            "index": index,
+            "question": input_text,
+            "expected_answer": answer,
+            "length": length,
+        }
+        write_jsons.append(formatted_output)
+
+    return write_jsons
+
+
+def main():
+    output_file = Path(args.output_folder) / "test.jsonl"
+
+    write_jsons = generate_samples(
+        num_samples=args.num_samples,
+        max_seq_length=args.max_seq_length,
+    )
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in write_jsons:
+            fout.write(json.dumps(entry) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/sgl_eval/_vendored/nemo_skills/dataset/ruler2/prepare_qa.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/ruler2/prepare_qa.py
@@ -1,0 +1,392 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/ruler2/prepare_qa.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import argparse
+import json
+import logging
+import random
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from datasets import load_dataset
+from tqdm import tqdm
+
+from .tokenizer import select_tokenizer
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser()
+# Basic Configurations
+parser.add_argument("--output_folder", type=str)
+parser.add_argument("--tokenizer_type", type=str, default="hf", help="[Options] nemo, hf, openai.")
+parser.add_argument("--tokenizer_path", type=str, required=True, help="path to the tokenizer model")
+parser.add_argument(
+    "--max_seq_length",
+    type=int,
+    required=True,
+    help="max sequence length including all input tokens and generated tokens.",
+)
+parser.add_argument("--random_seed", type=int, default=42)
+parser.add_argument("--num_samples", type=int, default=500)
+parser.add_argument("--dataset", type=str, required=True, help="dataset file")
+parser.add_argument("--fewshot", type=int, default=0)
+parser.add_argument("--prompt_type", type=str, default="chat")
+parser.add_argument("--query_type", type=str, default="id", choices=["id", "doc", "question"])
+parser.add_argument("--algo_type", type=str, default="single", choices=["single", "2steps"])
+parser.add_argument("--task_type", type=str, default="retrieve", choices=["retrieve", "solve"])
+
+args = parser.parse_args()
+random.seed(args.random_seed)
+np.random.seed(args.random_seed)
+
+# Load Tokenizer
+TOKENIZER = select_tokenizer(args.tokenizer_type, args.tokenizer_path)
+
+
+TOTAL_PROMPT = """{context}\n\n{example}{problem}"""
+NEEDLE_PROMPT = "Document {i}:\n{text}"
+if args.task_type == "retrieve":
+    if args.query_type == "id":
+        CONTEXT_PROMPT = """Below are some documents. I will ask you to copy one of them. Please copy and paste the document you find.\n\n{needles}"""
+        PROBLEM_PROMPT = "Please copy the Document {i} from the context."
+        if args.fewshot > 0:
+            EXAMPLE_PROMPT = PROBLEM_PROMPT + "\nDocument {i}:\n{text}"
+        if args.prompt_type == "base":
+            PROBLEM_PROMPT += "\nDocument {i}:"
+
+    elif args.query_type == "doc" or args.query_type == "question":
+        if args.query_type == "doc":
+            CONTEXT_PROMPT = """Below are some documents. I will give you a text at the end. Please find the document index of the text. Only give me the index without any document contents.\n\n{needles}"""
+            PROBLEM_PROMPT = "Text: {text}\nMost relevant document index:"
+        elif args.query_type == "question":
+            # CONTEXT_PROMPT = """Below are some documents. I will give you a text at the end. Please find the document index most relevant to the text. Only give me the index without any document contents.\n\n{needles}"""
+            # PROBLEM_PROMPT = "Text: {question}\nMost relevant document index:"
+            CONTEXT_PROMPT = """Below are some documents. I will give you a question at the end. Please find the index of the most relevant document that can help answer the question. Only give me the index without any document contents.\n\n{needles}"""
+            PROBLEM_PROMPT = (
+                "Question: {question}\nIndex of the most relevant document that can help answer the question:"
+            )
+        if args.fewshot > 0:
+            EXAMPLE_PROMPT = PROBLEM_PROMPT + " {i}"
+elif args.task_type == "solve":
+    CONTEXT_PROMPT = """Below are some documents. I will ask you to answer a question based on the documents. Please answer the question.\n\n{needles}"""
+    if args.algo_type == "single":
+        PROBLEM_PROMPT = "Please answer the following question based on the documents.\n\nQuestion: {question}"
+        # PROBLEM_PROMPT = "Please answer the following question based on the documents. If the question is a yes/no question, please only answer yes or no. If your answer can be extracted from the documents, please directly copy the answer span as short as possible. Please put your answer inside \\boxed{{}}.\n\nQuestion: {question}"
+    elif args.algo_type == "2steps":
+        PROBLEM_PROMPT = "Please first find and copy paste the documents relevant to the following question and then answer it based on the documents you find.\n\nQuestion: {question}"
+    if args.fewshot > 0:
+        EXAMPLE_PROMPT = PROBLEM_PROMPT + "\nAnswer: {answer}"
+    if args.prompt_type == "base":
+        PROBLEM_PROMPT += "\nAnswer:"
+
+
+# Read SQuAD QA dataset
+def read_squad():
+    data = load_dataset("squad_v2")["train"]
+    haystack = [d["context"] for d in data]
+    haystack = list(set(haystack))
+    haystack = [{"text": d} for d in haystack]
+
+    data = load_dataset("squad_v2")["validation"]
+    title2context = defaultdict(set)
+    for d in data:
+        title2context[d["title"]].add(d["context"])
+
+    needle = [
+        {
+            "question": d["question"],
+            "answer": d["answers"]["text"],
+            "context": [{"text": d["context"]}],
+            "distractor": [{"text": t} for t in title2context[d["title"]] if t != d["context"]],
+        }
+        for d in data
+    ]
+    needle = [n for n in needle if len(n["answer"]) > 0]
+
+    return haystack, needle
+
+
+# Read Hotpot QA dataset
+def read_hotpotqa():
+    data = load_dataset("hotpotqa/hotpot_qa", "distractor")["train"]
+    haystack = [f"{t}\n{''.join(s)}" for d in data for t, s in zip(d["context"]["title"], d["context"]["sentences"])]
+    haystack = list(set(haystack))
+    haystack = [{"text": d} for d in haystack]
+
+    data = load_dataset("hotpotqa/hotpot_qa", "distractor")["validation"]
+    needle = [
+        {
+            "question": d["question"],
+            "answer": [d["answer"]],
+            "context": [
+                {"text": f"{t}\n{''.join(s)}"}
+                for t, s in zip(d["context"]["title"], d["context"]["sentences"])
+                if t in d["supporting_facts"]["title"]
+            ],
+            "distractor": [
+                {"text": f"{t}\n{''.join(s)}"}
+                for t, s in zip(d["context"]["title"], d["context"]["sentences"])
+                if t not in d["supporting_facts"]["title"]
+            ],
+        }
+        for d in data
+    ]
+    needle = [n for n in needle if len(n["answer"]) > 0]
+
+    return haystack, needle
+
+
+def read_musique():
+    data = load_dataset("dgslibisey/MuSiQue")["train"]
+    haystack = [f"{p['title']}\n{p['paragraph_text']}" for d in data for p in d["paragraphs"]]
+    haystack = list(set(haystack))
+    haystack = [{"text": d} for d in haystack]
+
+    data = load_dataset("dgslibisey/MuSiQue")["validation"]
+    needle = [
+        {
+            "question": d["question"],
+            "answer": [d["answer"]] + d["answer_aliases"],
+            "context": [
+                {"text": f"{p['title']}\n{p['paragraph_text']}"} for p in d["paragraphs"] if p["is_supporting"]
+            ],
+            "distractor": [
+                {"text": f"{p['title']}\n{p['paragraph_text']}"} for p in d["paragraphs"] if not p["is_supporting"]
+            ],
+        }
+        for d in data
+        if d["answerable"]
+    ]
+    needle = [n for n in needle if len(n["answer"]) > 0]
+
+    return haystack, needle
+
+
+# Download dataset
+if args.dataset == "squad":
+    haystack, needle = read_squad()
+elif args.dataset == "hotpotqa":
+    haystack, needle = read_hotpotqa()
+elif args.dataset == "musique":
+    haystack, needle = read_musique()
+else:
+    raise NotImplementedError(f"{args.dataset} is not implemented.")
+
+
+def generate_random_number(num_digits=7):
+    lower_bound = 10 ** (num_digits - 1)
+    upper_bound = 10**num_digits - 1
+    return str(random.randint(lower_bound, upper_bound))
+
+
+def generate_input_output(index, num_docs):
+    curr_needle = dict(needle[index])
+    curr_needle["context"] = [{**c, "random_index": generate_random_number()} for c in curr_needle["context"]]
+    curr_needle["distractor"] = [{**c, "random_index": generate_random_number()} for c in curr_needle["distractor"]]
+
+    if args.fewshot > 0:
+        fewshot_examples = random.sample([i for i in range(len(needle)) if i != index], args.fewshot)
+        fewshot_examples = [dict(needle[i]) for i in fewshot_examples]
+        for e in fewshot_examples:
+            e["context"] = [{**c, "random_index": generate_random_number()} for c in e["context"]]
+            e["distractor"] = [{**c, "random_index": generate_random_number()} for c in e["distractor"]]
+    else:
+        fewshot_examples = []
+
+    remaining_haystack_size = len(haystack) - len(
+        set(
+            [c["text"] for c in (curr_needle["context"] + curr_needle["distractor"])]
+            + [f["text"] for e in fewshot_examples for f in (e["context"] + e["distractor"])]
+        )
+    )
+    if remaining_haystack_size <= 0:
+        raise ValueError("No remaining haystack documents available after exclusions.")
+
+    if num_docs > remaining_haystack_size:
+        repeats = (num_docs + remaining_haystack_size - 1) // remaining_haystack_size  # Ceiling division
+    else:
+        repeats = 1
+
+    curr_context = random.sample([i for i in range(len(haystack)) for _ in range(repeats)], num_docs)
+    curr_context = [{**haystack[i], "random_index": generate_random_number()} for i in curr_context]
+    curr_context = (
+        curr_context + curr_needle["context"] + [item for example in fewshot_examples for item in example["context"]]
+    )
+    if num_docs > 0:
+        curr_context = (
+            curr_context
+            + curr_needle["distractor"]
+            + [item for example in fewshot_examples for item in example["distractor"]]
+        )
+    random.shuffle(curr_context)
+
+    needles = "\n\n".join([NEEDLE_PROMPT.format(i=c["random_index"], text=c["text"]) for c in curr_context])
+    if args.task_type == "retrieve":
+        if args.query_type == "id":
+            problem = PROBLEM_PROMPT.format(i=curr_needle["context"][0]["random_index"])
+        elif args.query_type == "doc":
+            problem = PROBLEM_PROMPT.format(text=curr_needle["context"][0]["text"])
+        elif args.query_type == "question":
+            problem = PROBLEM_PROMPT.format(question=curr_needle["question"])
+    elif args.task_type == "solve":
+        problem = PROBLEM_PROMPT.format(question=curr_needle["question"])
+
+    if args.fewshot > 0:
+        if args.task_type == "retrieve":
+            if args.query_type == "id":
+                example = "\n\n".join(
+                    [
+                        EXAMPLE_PROMPT.format(i=e["context"][0]["random_index"], text=e["context"][0]["text"])
+                        for e in fewshot_examples
+                    ]
+                )
+            elif args.query_type == "doc":
+                example = "\n\n".join(
+                    [
+                        EXAMPLE_PROMPT.format(i=e["context"][0]["random_index"], text=e["context"][0]["text"])
+                        for e in fewshot_examples
+                    ]
+                )
+            elif args.query_type == "question":
+                example = "\n\n".join(
+                    [
+                        EXAMPLE_PROMPT.format(
+                            i=random.sample(e["context"], 1)[0]["random_index"], question=e["question"]
+                        )
+                        for e in fewshot_examples
+                    ]
+                )
+
+        elif args.task_type == "solve":
+            example = "\n\n".join(
+                [
+                    EXAMPLE_PROMPT.format(answer=random.sample(e["answer"], 1)[0], question=e["question"])
+                    for e in fewshot_examples
+                ]
+            )
+
+        if args.prompt_type == "base":
+            example = f"{example}\n\n"
+        else:
+            example = f"Here are some examples to help you understand the task:\n\n{example}\n\nHere is the actual task you need to solve:\n\n"
+
+    else:
+        example = ""
+
+    context = CONTEXT_PROMPT.format(needles=needles)
+    input_text = TOTAL_PROMPT.format(context=context, problem=problem, example=example)
+    if args.task_type == "retrieve":
+        if args.query_type == "id":
+            expected_answer = {"expected_answer": [curr_needle["context"][0]["text"]]}
+        elif args.query_type == "doc":
+            expected_answer = {"expected_answer": [curr_needle["context"][0]["random_index"]]}
+        elif args.query_type == "question":
+            expected_answer = {"expected_answer": [c["random_index"] for c in curr_needle["context"]]}
+    elif args.task_type == "solve":
+        expected_answer = {"expected_answer": curr_needle["answer"]}
+
+    save_dict = {
+        "index": index,
+        "question": f"{context}\n\n{example}{problem}",
+        **expected_answer,
+    }
+    return input_text, save_dict
+
+
+def generate_samples(num_samples: int, max_seq_length: int, incremental: int = 5):
+    write_jsons = []
+
+    # Estimate tokens per question to determine reasonable upper bound
+    sample_input_text, _ = generate_input_output(0, incremental)
+    sample_tokens = len(TOKENIZER.text_to_tokens(sample_input_text))
+    tokens_per_doc = sample_tokens / incremental
+
+    if max_seq_length > 0:
+        # Let's do 3x to allow for some slack since we can get unlucky due to sampling.
+        # NOTE: We should test this for really large sequence lengths to make sure it's reasonable.
+        estimated_max_docs = int((max_seq_length / tokens_per_doc) * 3)
+
+        # Binary search for optimal haystack size
+        lower_bound = incremental
+        upper_bound = max(estimated_max_docs, incremental * 2)  # Ensure upper_bound is reasonable
+
+        optimal_num_docs = None
+
+        logger.info(f"Estimated {tokens_per_doc:.1f} tokens per doc")
+        logger.info(f"Starting binary search with bounds: {lower_bound} to {upper_bound}")
+
+        while lower_bound <= upper_bound:
+            mid = (lower_bound + upper_bound) // 2
+            input_text, save_dict = generate_input_output(0, mid)
+            total_tokens = len(TOKENIZER.text_to_tokens(input_text))
+
+            logger.info(f"Testing haystack size: {mid}, resulting tokens: {total_tokens}/{max_seq_length}")
+
+            if total_tokens <= max_seq_length:
+                # This size works, can we go larger?
+                optimal_num_docs = mid
+                lower_bound = mid + 1
+            else:
+                # Too large, need to go smaller
+                upper_bound = mid - 1
+
+        num_docs = optimal_num_docs if optimal_num_docs is not None else incremental
+        logger.info(f"Final optimal haystack size (number of docs): {num_docs}")
+    else:
+        num_docs = 0
+
+    # Generate samples
+    for index in tqdm(range(num_samples)):
+        used_docs = num_docs
+        while True:
+            try:
+                input_text, save_dict = generate_input_output(index, used_docs)
+                length = len(TOKENIZER.text_to_tokens(input_text))
+                if max_seq_length > 0:
+                    assert length <= max_seq_length, f"{length} exceeds max_seq_length."
+                break
+            except AssertionError:
+                if used_docs > incremental:
+                    used_docs -= incremental
+                else:
+                    raise
+
+        save_dict["length"] = length
+        formatted_output = save_dict
+        write_jsons.append(formatted_output)
+
+    return write_jsons
+
+
+def main():
+    output_file = Path(args.output_folder) / "test.jsonl"
+
+    write_jsons = generate_samples(
+        num_samples=args.num_samples,
+        max_seq_length=args.max_seq_length,
+    )
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in write_jsons:
+            fout.write(json.dumps(entry) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/sgl_eval/_vendored/nemo_skills/dataset/ruler2/ruler2_score.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/ruler2/ruler2_score.py
@@ -1,0 +1,48 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/ruler2/ruler2_score.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def compute_score(metrics: dict):
+    # just an average of all metrics. Here we assume that all tasks are present.
+    # if that's not the case, users shouldn't run as a group
+    tasks = [
+        "mk_niah_basic",
+        "mk_niah_easy",
+        "mk_niah_medium",
+        "mk_niah_hard",
+        "mv_niah_basic",
+        "mv_niah_easy",
+        "mv_niah_medium",
+        "mv_niah_hard",
+        "qa_basic",
+        "qa_easy",
+        "qa_medium",
+        "qa_hard",
+    ]
+    setup = list(metrics.keys())[0].rsplit(".", 1)[0]
+    metrics[setup] = {}
+
+    for aggregation in metrics[f"{setup}.mk_niah_basic"]:
+        total = 0
+        for task in tasks:
+            d = metrics[f"{setup}.{task}"][aggregation]
+            total += d["accuracy"] if "accuracy" in d else d["symbolic_correct"]
+        metrics[setup][aggregation] = {"accuracy": total / len(tasks)}
+
+    return metrics

--- a/sgl_eval/_vendored/nemo_skills/dataset/ruler2/tokenizer.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/ruler2/tokenizer.py
@@ -1,0 +1,74 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/ruler2/tokenizer.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from typing import List
+
+
+
+def select_tokenizer(tokenizer_type, tokenizer_path):
+    if tokenizer_type == "hf":
+        return HFTokenizer(model_path=tokenizer_path)
+    elif tokenizer_type == "openai":
+        return OpenAITokenizer(model_path=tokenizer_path)
+    elif tokenizer_type == "gemini":
+        return GeminiTokenizer(model_path=tokenizer_path)
+    else:
+        raise ValueError(f"Unknown tokenizer_type {tokenizer_type}")
+
+
+class HFTokenizer:
+    """
+    Tokenizer from HF models
+    """
+
+    def __init__(self, model_path) -> None:
+        from transformers import AutoTokenizer
+
+        self.tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+
+    def text_to_tokens(self, text: str) -> List[str]:
+        tokens = self.tokenizer.tokenize(text)
+        return tokens
+
+    def tokens_to_text(self, tokens: List[int]) -> str:
+        text = self.tokenizer.convert_tokens_to_string(tokens)
+        return text
+
+
+class OpenAITokenizer:
+    """
+    Tokenizer from tiktoken
+    """
+
+    def __init__(self, model_path="cl100k_base") -> None:
+        import tiktoken
+
+        self.tokenizer = tiktoken.get_encoding(model_path)
+
+    def text_to_tokens(self, text: str) -> List[int]:
+        tokens = self.tokenizer.encode(text)
+        return tokens
+
+    def tokens_to_text(self, tokens: List[int]) -> str:
+        text = self.tokenizer.decode(tokens)
+        return text
+
+

--- a/sgl_eval/_vendored/nemo_skills/evaluator/ruler.py
+++ b/sgl_eval/_vendored/nemo_skills/evaluator/ruler.py
@@ -1,0 +1,193 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/evaluation/evaluator/ruler.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import os
+import re
+
+import editdistance
+from tqdm import tqdm
+
+from sgl_eval._vendored.nemo_skills.evaluator.base import BaseEvaluatorConfig
+from sgl_eval._vendored.nemo_skills._utils import get_logger_name, nested_dataclass
+
+LOG = logging.getLogger(get_logger_name(__file__))
+
+
+@nested_dataclass(kw_only=True)
+class RulerEvaluatorConfig(BaseEvaluatorConfig):
+    parse_func: str = "default"
+    match_type: str
+
+
+def eval_ruler(cfg):
+    def default_parse(prediction):
+        prediction = prediction.strip()
+        # Remove all non-printable characters
+        np_pattern = re.compile(r"[\x00-\x1f]")
+        pp_predict = np_pattern.sub("\n", prediction).strip()
+        return pp_predict
+
+    def string_match_all_single(preds, refs):
+        """the metric function with input (predictions: [str], references: [[str]]) to compute score."""
+        preds = [preds]
+        refs = [refs]
+        score = [
+            sum([1.0 if r.lower() in pred.lower() else 0.0 for r in ref]) / len(ref) for pred, ref in zip(preds, refs)
+        ][0]
+        return score
+
+    def string_match_part_single(preds, refs):
+        preds = [preds]
+        refs = [refs]
+        score = [
+            sum([max([1.0 if r.lower() in pred.lower() else 0.0 for r in ref]) for pred, ref in zip(preds, refs)])
+        ][0]
+        return score
+
+    eval_config = RulerEvaluatorConfig(**cfg)
+
+    parse_funcs = {
+        "default": default_parse,
+    }
+    match_type_funcs = {
+        "all": string_match_all_single,
+        "part": string_match_part_single,
+    }
+
+    jsonl_file = eval_config.input_file
+    with open(jsonl_file, "rt", encoding="utf-8") as fin:
+        data = [json.loads(line) for line in fin]
+        for sample in tqdm(data):
+            parse_result = parse_funcs[eval_config.parse_func](sample["generation"])
+            sample["is_correct"] = match_type_funcs[eval_config.match_type](
+                sample["generation"], sample["expected_answer"]
+            )
+            sample["predicted_answer"] = parse_result
+
+    with open(jsonl_file + "-tmp", "wt", encoding="utf-8") as fout:
+        for sample in data:
+            fout.write(json.dumps(sample) + "\n")
+
+    os.replace(jsonl_file + "-tmp", jsonl_file)
+
+
+def eval_ruler2(cfg):
+    def default_parse(prediction):
+        prediction = prediction.strip()
+        # Remove all non-printable characters
+        np_pattern = re.compile(r"[\x00-\x1f]")
+        pp_predict = np_pattern.sub("\n", prediction).strip()
+        return pp_predict
+
+    def post_process_preds(preds):
+        return preds
+
+    def wer(hypotheses: list[str], references: list[str]) -> float:
+        scores = 0
+        words = 0
+        if len(hypotheses) != len(references):
+            raise ValueError(
+                "In word error rate calculation, hypotheses and reference"
+                " lists must have the same number of elements. But I got:"
+                "{0} and {1} correspondingly".format(len(hypotheses), len(references))
+            )
+        for h, r in zip(hypotheses, references):
+            h_list = h.split()
+            r_list = r.split()
+            words += len(r_list)
+            scores += editdistance.eval(h_list, r_list)
+        if words != 0:
+            wer = 1.0 * scores / words
+        else:
+            wer = float("inf")
+        return wer
+
+    def string_match_all_single(preds, refs):
+        """the metric function with input (predictions: [str], references: [[str]]) to compute score."""
+        preds = post_process_preds(preds)
+        preds = [preds]
+        refs = [refs]
+        score = [
+            sum([max(1.0 if r.lower() in pred.lower() else 0.0, 1 - wer([pred.lower()], [r.lower()])) for r in ref])
+            / len(ref)
+            for pred, ref in zip(preds, refs)
+        ][0]
+        return score
+
+    def string_match_2steps_single(preds, refs):
+        preds = post_process_preds(preds)
+        preds = preds.split("\n\n")[-1]
+        preds = [preds]
+        refs = [refs]
+        score = [
+            sum([max(1.0 if r.lower() in pred.lower() else 0.0, 1 - wer([pred.lower()], [r.lower()])) for r in ref])
+            / len(ref)
+            for pred, ref in zip(preds, refs)
+        ][0]
+        return score
+
+    def string_match_part_single(preds, refs):
+        preds = post_process_preds(preds)
+        preds = re.sub(r"Document \d+:(?:.*\n)+?\n", "", preds)
+
+        preds = [preds]
+        refs = [refs]
+        score = [
+            sum(
+                [
+                    max(
+                        [
+                            max(1.0 if r.lower() in pred.lower() else 0.0, 1 - wer([pred.lower()], [r.lower()]))
+                            for r in ref
+                        ]
+                    )
+                    for pred, ref in zip(preds, refs)
+                ]
+            )
+        ][0]
+        return score
+
+    eval_config = RulerEvaluatorConfig(**cfg)
+
+    parse_funcs = {
+        "default": default_parse,
+    }
+    match_type_funcs = {
+        "all": string_match_all_single,
+        "part": string_match_part_single,
+        "2steps": string_match_2steps_single,
+    }
+
+    jsonl_file = eval_config.input_file
+    with open(jsonl_file, "rt", encoding="utf-8") as fin:
+        data = [json.loads(line) for line in fin]
+        for sample in tqdm(data):
+            parse_result = parse_funcs[eval_config.parse_func](sample["generation"])
+            sample["is_correct"] = match_type_funcs[eval_config.match_type](
+                sample["generation"], sample["expected_answer"]
+            )
+            sample["predicted_answer"] = parse_result
+
+    with open(jsonl_file + "-tmp", "wt", encoding="utf-8") as fout:
+        for sample in data:
+            fout.write(json.dumps(sample) + "\n")
+
+    os.replace(jsonl_file + "-tmp", jsonl_file)

--- a/sgl_eval/_vendored/nemo_skills/prompts/default.yaml
+++ b/sgl_eval/_vendored/nemo_skills/prompts/default.yaml
@@ -1,0 +1,8 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/prompt/config/generic/default.yaml
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Default prompt that does not contain any extra instructions. Can be used for instruction following evals (e.g. ifeval)
+
+user: "{question}"

--- a/sgl_eval/_vendored/nemo_skills/ruler2_metrics.py
+++ b/sgl_eval/_vendored/nemo_skills/ruler2_metrics.py
@@ -1,0 +1,50 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/evaluation/metrics/ruler2_metrics.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sgl_eval._vendored.nemo_skills._metrics_base import BaseMetrics
+
+
+class Ruler2Metrics(BaseMetrics):
+    """Metrics for RULER v2 benchmarks.
+
+    RULER v2 tasks use two different correctness keys depending on the eval type:
+    - ``is_correct`` (float 0-1): soft string-match score used by tasks with
+      ``eval_type=ruler2`` (NIAH and QA variants).
+    - ``symbolic_correct`` (bool): exact-match score used by tasks with
+      ``eval_type=multichoice`` (mk_niah_hard, mk_niah_medium).
+    """
+
+    def _get_score_dict(self, prediction: dict) -> dict[str, bool | int | float]:
+        if "is_correct" in prediction:
+            return {"accuracy": prediction["is_correct"]}
+        return {"accuracy": prediction["symbolic_correct"]}
+
+    def update(self, predictions):
+        super().update(predictions)
+        self._compute_pass_at_k(predictions=predictions)
+
+    def get_incorrect_sample(self, prediction: dict) -> dict:
+        prediction = prediction.copy()
+        if "is_correct" in prediction:
+            prediction["is_correct"] = False
+        elif "symbolic_correct" in prediction:
+            prediction["symbolic_correct"] = False
+        else:
+            raise ValueError(f"expected 'is_correct' or 'symbolic_correct' to be in keys: {list(prediction.keys())=}")
+        return prediction

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -52,7 +52,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     add_preset_run_flag(p_run)
     _add_endpoint_args(p_run, base_url_required=False)
     p_run.add_argument("--num-examples", type=int, default=None)
-    p_run.add_argument("--num-threads", type=int, default=64)
+    p_run.add_argument(
+        "--num-threads",
+        type=int,
+        default=None,
+        help="concurrent requests (default: the benchmark's own ceiling, 64 for "
+        "most, lower for long-context)",
+    )
     p_run.add_argument("--n-repeats", type=int, default=None)
     p_run.add_argument("--max-tokens", type=int, default=None)
     p_run.add_argument("--temperature", type=float, default=None)
@@ -87,6 +93,15 @@ def main(argv: Optional[List[str]] = None) -> int:
         default=None,
         help="path to NS-shape jsonl ({id?, problem, expected_answer}); "
         "replaces the vendored dataset for this run",
+    )
+    p_run.add_argument(
+        "--bench-arg",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="benchmark-specific option, repeatable. ruler2: seq_len=N (required), "
+        "tokenizer=<hf-id|path>, tokenizer_type=hf|openai, dataset_size=N, "
+        "tasks=a,b,c",
     )
     p_run.set_defaults(func=cmd_run, dump_predictions=True)
 

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -22,7 +22,11 @@ from sgl_eval.types import GenConfig
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    argv = argv if argv is not None else sys.argv[1:]
+    args = build_parser().parse_args(argv if argv is not None else sys.argv[1:])
+    return args.func(args)
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="sgl-eval")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
@@ -94,16 +98,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="path to NS-shape jsonl ({id?, problem, expected_answer}); "
         "replaces the vendored dataset for this run",
     )
-    p_run.add_argument(
-        "--bench-arg",
-        action="append",
-        default=[],
-        metavar="KEY=VALUE",
-        help="benchmark-specific option, repeatable. ruler2: seq_len=N (required), "
-        "tokenizer=<hf-id|path>, tokenizer_type=hf|openai, dataset_size=N, "
-        "tasks=a,b,c",
-    )
     p_run.set_defaults(func=cmd_run, dump_predictions=True)
+
+    # Benchmarks contribute their own options, so argparse -- not a hand-rolled
+    # KEY=VALUE parser -- owns their types, choices and --help text.
+    for spec in list_evals():
+        if spec.add_arguments is not None:
+            spec.add_arguments(p_run.add_argument_group(f"{spec.name} options"))
 
     p_refresh = sub.add_parser(
         "refresh",
@@ -116,9 +117,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_refresh.set_defaults(func=cmd_refresh)
 
     register_preset_subcommand(sub)
-
-    args = parser.parse_args(argv)
-    return args.func(args)
+    return parser
 
 
 def _add_endpoint_args(p: argparse.ArgumentParser, *, base_url_required: bool = True) -> None:
@@ -149,6 +148,8 @@ def cmd_list(args: argparse.Namespace) -> int:
             print(f"  temperature : {gen.temperature}")
             print(f"  top_p       : {gen.top_p}")
             print(f"  max_tokens  : {gen.max_tokens}")
+            print(f"  min_p       : {gen.min_p}")
+            print(f"  rep_penalty : {gen.repetition_penalty}")
         return 0
     width = max(len(s.name) for s in specs)
     for s in specs:

--- a/sgl_eval/evals/_math.py
+++ b/sgl_eval/evals/_math.py
@@ -51,6 +51,17 @@ def make_score_one_fn(evaluator: MathEvaluator) -> ScoreOneFn:
     return score_one
 
 
+def aggregate_from_predictions(
+    results: List[ExampleResult], n_repeats: int
+) -> Optional[Dict[str, float]]:
+    """``sgl-eval refresh`` hook. pass@k / majority@k only exist for
+    k > 1; at k == 1 the plain sample-level mean refresh already computes
+    is the right answer, so decline by returning ``None``."""
+    if n_repeats == 1:
+        return None
+    return aggregate_with_math_metrics(results, n_repeats)
+
+
 def aggregate_with_math_metrics(results: List[ExampleResult], n_repeats: int) -> Dict[str, float]:
     if not results:
         return {"score": 0.0}

--- a/sgl_eval/evals/_multichoice.py
+++ b/sgl_eval/evals/_multichoice.py
@@ -71,6 +71,17 @@ def make_score_one_fn() -> ScoreOneFn:
     return score_one
 
 
+def aggregate_from_predictions(
+    results: List[ExampleResult], n_repeats: int
+) -> Optional[Dict[str, float]]:
+    """``sgl-eval refresh`` hook. pass@k / majority@k only exist for
+    k > 1; at k == 1 the plain sample-level mean refresh already computes
+    is the right answer, so decline by returning ``None``."""
+    if n_repeats == 1:
+        return None
+    return aggregate_with_math_metrics(results, n_repeats)
+
+
 def aggregate_with_math_metrics(results: List[ExampleResult], n_repeats: int) -> Dict[str, float]:
     if not results:
         return {"score": 0.0}

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -34,15 +34,18 @@ from __future__ import annotations
 
 import importlib
 from pathlib import Path
-from typing import Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Tuple
 
 from sgl_eval.evals._loader import load_bundled, load_via_prepare
+from sgl_eval.evals._math import aggregate_from_predictions as _math_aggregate
 from sgl_eval.evals._math import run_math_benchmark
 from sgl_eval.evals._mmmu_pro import load_mmmu_pro
+from sgl_eval.evals._multichoice import aggregate_from_predictions as _mcq_aggregate
 from sgl_eval.evals._multichoice import run_multichoice_benchmark
 from sgl_eval.evals._prompts import vendored_prompt
 from sgl_eval.evals._ruler2 import PRED_SCHEMA as _RULER2_PRED_SCHEMA
 from sgl_eval.evals._ruler2 import add_arguments as _add_ruler2_arguments
+from sgl_eval.evals._ruler2 import aggregate_from_predictions as _ruler2_aggregate
 from sgl_eval.evals._ruler2 import run_ruler2_benchmark
 from sgl_eval.predictions import PredSchema
 from sgl_eval.registry import EvalSpec, register
@@ -176,86 +179,101 @@ def _build_loader(entry: dict):
     raise ValueError(f"unknown loader kind: {kind!r}")
 
 
-def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Callable):
-    if metrics_type == "ruler2":
+# Per-category behavior, in one place. Every factory takes the same arguments so
+# the registration loop below stays free of benchmark names; a new category is a
+# new row here plus its runner module.
+def _math_run(name: str, _prompt_basename: str, loader: Callable):
+    def run(
+        *,
+        sampler,
+        gen,
+        n_repeats,
+        num_examples,
+        num_threads,
+        predictions_writer=None,
+        load_examples=None,
+        bench_args=None,
+    ):
+        return run_math_benchmark(
+            name=name,
+            sampler=sampler,
+            gen=gen,
+            n_repeats=n_repeats,
+            num_examples=num_examples,
+            num_threads=num_threads,
+            load_examples=load_examples or loader,
+            predictions_writer=predictions_writer,
+        )
 
-        def run(
-            *,
-            sampler,
-            gen,
-            n_repeats,
-            num_examples,
-            num_threads,
-            predictions_writer=None,
-            load_examples=None,
-            bench_args=None,
-        ):
-            return run_ruler2_benchmark(
-                name=name,
-                sampler=sampler,
-                gen=gen,
-                n_repeats=n_repeats,
-                num_examples=num_examples,
-                num_threads=num_threads,
-                predictions_writer=predictions_writer,
-                load_examples=load_examples,
-                bench_args=bench_args,
-            )
+    return run
 
-        return run
-    if metrics_type == "math":
 
-        def run(
-            *,
-            sampler,
-            gen,
-            n_repeats,
-            num_examples,
-            num_threads,
-            predictions_writer=None,
-            load_examples=None,
-            bench_args=None,
-        ):
-            return run_math_benchmark(
-                name=name,
-                sampler=sampler,
-                gen=gen,
-                n_repeats=n_repeats,
-                num_examples=num_examples,
-                num_threads=num_threads,
-                load_examples=load_examples or loader,
-                predictions_writer=predictions_writer,
-            )
+def _mcq_run(name: str, prompt_basename: str, loader: Callable):
+    prompt_yaml = _resolve_prompt(prompt_basename)
 
-        return run
-    if metrics_type == "multichoice":
-        prompt_yaml = _resolve_prompt(prompt_basename)
+    def run(
+        *,
+        sampler,
+        gen,
+        n_repeats,
+        num_examples,
+        num_threads,
+        predictions_writer=None,
+        load_examples=None,
+        bench_args=None,
+    ):
+        return run_multichoice_benchmark(
+            name=name,
+            sampler=sampler,
+            gen=gen,
+            n_repeats=n_repeats,
+            num_examples=num_examples,
+            num_threads=num_threads,
+            load_examples=load_examples or loader,
+            prompt_yaml=prompt_yaml,
+            predictions_writer=predictions_writer,
+        )
 
-        def run(
-            *,
-            sampler,
-            gen,
-            n_repeats,
-            num_examples,
-            num_threads,
-            predictions_writer=None,
-            load_examples=None,
-            bench_args=None,
-        ):
-            return run_multichoice_benchmark(
-                name=name,
-                sampler=sampler,
-                gen=gen,
-                n_repeats=n_repeats,
-                num_examples=num_examples,
-                num_threads=num_threads,
-                load_examples=load_examples or loader,
-                prompt_yaml=prompt_yaml,
-                predictions_writer=predictions_writer,
-            )
+    return run
 
-        return run
-    raise ValueError(f"unsupported upstream metrics_type: {metrics_type!r}")
+
+def _ruler2_run(name: str, _prompt_basename: str, _loader: Callable):
+    def run(
+        *,
+        sampler,
+        gen,
+        n_repeats,
+        num_examples,
+        num_threads,
+        predictions_writer=None,
+        load_examples=None,
+        bench_args=None,
+    ):
+        return run_ruler2_benchmark(
+            name=name,
+            sampler=sampler,
+            gen=gen,
+            n_repeats=n_repeats,
+            num_examples=num_examples,
+            num_threads=num_threads,
+            predictions_writer=predictions_writer,
+            load_examples=load_examples,
+            bench_args=bench_args,
+        )
+
+    return run
+
+
+_CATEGORIES: Dict[str, Dict[str, Any]] = {
+    "math": {"make_run": _math_run, "aggregate_predictions": _math_aggregate},
+    "multichoice": {"make_run": _mcq_run, "aggregate_predictions": _mcq_aggregate},
+    "ruler2": {
+        "make_run": _ruler2_run,
+        "aggregate_predictions": _ruler2_aggregate,
+        "pred_schema": _RULER2_PRED_SCHEMA,
+        "add_arguments": _add_ruler2_arguments,
+    },
+}
 
 
 for _entry in _TABLE:
@@ -265,8 +283,9 @@ for _entry in _TABLE:
         _prompt_basename = _entry["prompt"]
     else:
         _metrics_type, _prompt_basename = _resolve_upstream_metadata(_name)
-    _loader = _build_loader(_entry)
-    _run = _build_run(_name, _metrics_type, _prompt_basename, _loader)
+    if _metrics_type not in _CATEGORIES:
+        raise ValueError(f"unsupported metrics_type: {_metrics_type!r}")
+    _category = _CATEGORIES[_metrics_type]
     register(
         EvalSpec(
             name=_name,
@@ -274,9 +293,10 @@ for _entry in _TABLE:
             description=_entry["description"],
             default_gen=_build_default_gen(_entry["thinking"]),
             default_n_repeats=_entry["default_n_repeats"],
-            run=_run,
+            run=_category["make_run"](_name, _prompt_basename, _build_loader(_entry)),
             default_num_threads=_entry.get("default_num_threads", 64),
-            pred_schema=(_RULER2_PRED_SCHEMA if _metrics_type == "ruler2" else PredSchema()),
-            add_arguments=(_add_ruler2_arguments if _metrics_type == "ruler2" else None),
+            pred_schema=_category.get("pred_schema") or PredSchema(),
+            add_arguments=_category.get("add_arguments"),
+            aggregate_predictions=_category.get("aggregate_predictions"),
         )
     )

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -42,6 +42,7 @@ from sgl_eval.evals._mmmu_pro import load_mmmu_pro
 from sgl_eval.evals._multichoice import run_multichoice_benchmark
 from sgl_eval.evals._prompts import vendored_prompt
 from sgl_eval.evals._ruler2 import PRED_SCHEMA as _RULER2_PRED_SCHEMA
+from sgl_eval.evals._ruler2 import add_arguments as _add_ruler2_arguments
 from sgl_eval.evals._ruler2 import run_ruler2_benchmark
 from sgl_eval.predictions import PredSchema
 from sgl_eval.registry import EvalSpec, register
@@ -110,7 +111,7 @@ _TABLE = [
     {
         # Group benchmark: 12 subtasks scored separately, then averaged by
         # vendored ruler2_score.compute_score. Its dataset is generated per
-        # (tokenizer, seq length), so it needs --bench-arg seq_len=N and has
+        # (tokenizer, seq length), so it needs --ruler2-seq-len N and has
         # no upstream dataset/__init__.py metadata to derive from.
         "name": "ruler2",
         "metrics_type": "ruler2",
@@ -121,7 +122,7 @@ _TABLE = [
         # 64 concurrent 128k prompts is ~8M tokens in flight; the runner caps
         # request count, not tokens.
         "default_num_threads": 4,
-        "description": "RULER2 synthetic long-context, 12 subtasks (needs --bench-arg seq_len=N).",
+        "description": "RULER2 synthetic long-context, 12 subtasks (needs --ruler2-seq-len N).",
     },
 ]
 
@@ -276,5 +277,6 @@ for _entry in _TABLE:
             run=_run,
             default_num_threads=_entry.get("default_num_threads", 64),
             pred_schema=(_RULER2_PRED_SCHEMA if _metrics_type == "ruler2" else PredSchema()),
+            add_arguments=(_add_ruler2_arguments if _metrics_type == "ruler2" else None),
         )
     )

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -11,6 +11,8 @@ no new module. Each entry encodes only the things that genuinely differ:
   by default. True for reasoning benchmarks (aime / gpqa); off otherwise.
 - ``default_n_repeats``: per-example repeat count (sgl-eval choice; NS
   also leaves this to CLI via ``--benchmarks=name:N``).
+- ``default_num_threads``: concurrency ceiling, defaulting to 64. Long-context
+  benchmarks must lower it -- the runner limits requests, not tokens.
 - ``description``: human-readable one-liner.
 
 Sampling params (``temperature`` / ``top_p`` / ``max_tokens``) are **not**
@@ -23,7 +25,9 @@ single value here would encode a model-specific assumption.
 ``metrics_type`` and the prompt yaml basename are derived at registration
 time from the vendored ``dataset/<name>/__init__.py`` (``METRICS_TYPE`` +
 ``GENERATION_ARGS``), so we never hand-mirror upstream's per-benchmark
-choices.
+choices. Two rows opt out by declaring both explicitly: ``mmmu_pro`` (no
+upstream module) and ``ruler2`` (upstream ships no dataset metadata -- its
+subtasks only exist once generated).
 """
 
 from __future__ import annotations
@@ -37,6 +41,9 @@ from sgl_eval.evals._math import run_math_benchmark
 from sgl_eval.evals._mmmu_pro import load_mmmu_pro
 from sgl_eval.evals._multichoice import run_multichoice_benchmark
 from sgl_eval.evals._prompts import vendored_prompt
+from sgl_eval.evals._ruler2 import PRED_SCHEMA as _RULER2_PRED_SCHEMA
+from sgl_eval.evals._ruler2 import run_ruler2_benchmark
+from sgl_eval.predictions import PredSchema
 from sgl_eval.registry import EvalSpec, register
 from sgl_eval.types import GenConfig
 
@@ -100,6 +107,22 @@ _TABLE = [
         "default_n_repeats": 1,
         "description": "MMMU-Pro (multimodal, 10-choice, vision-dependent).",
     },
+    {
+        # Group benchmark: 12 subtasks scored separately, then averaged by
+        # vendored ruler2_score.compute_score. Its dataset is generated per
+        # (tokenizer, seq length), so it needs --bench-arg seq_len=N and has
+        # no upstream dataset/__init__.py metadata to derive from.
+        "name": "ruler2",
+        "metrics_type": "ruler2",
+        "prompt": "default",
+        "loader_fn": None,
+        "thinking": False,
+        "default_n_repeats": 1,
+        # 64 concurrent 128k prompts is ~8M tokens in flight; the runner caps
+        # request count, not tokens.
+        "default_num_threads": 4,
+        "description": "RULER2 synthetic long-context, 12 subtasks (needs --bench-arg seq_len=N).",
+    },
 ]
 
 
@@ -153,6 +176,32 @@ def _build_loader(entry: dict):
 
 
 def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Callable):
+    if metrics_type == "ruler2":
+
+        def run(
+            *,
+            sampler,
+            gen,
+            n_repeats,
+            num_examples,
+            num_threads,
+            predictions_writer=None,
+            load_examples=None,
+            bench_args=None,
+        ):
+            return run_ruler2_benchmark(
+                name=name,
+                sampler=sampler,
+                gen=gen,
+                n_repeats=n_repeats,
+                num_examples=num_examples,
+                num_threads=num_threads,
+                predictions_writer=predictions_writer,
+                load_examples=load_examples,
+                bench_args=bench_args,
+            )
+
+        return run
     if metrics_type == "math":
 
         def run(
@@ -164,6 +213,7 @@ def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Calla
             num_threads,
             predictions_writer=None,
             load_examples=None,
+            bench_args=None,
         ):
             return run_math_benchmark(
                 name=name,
@@ -189,6 +239,7 @@ def _build_run(name: str, metrics_type: str, prompt_basename: str, loader: Calla
             num_threads,
             predictions_writer=None,
             load_examples=None,
+            bench_args=None,
         ):
             return run_multichoice_benchmark(
                 name=name,
@@ -223,5 +274,7 @@ for _entry in _TABLE:
             default_gen=_build_default_gen(_entry["thinking"]),
             default_n_repeats=_entry["default_n_repeats"],
             run=_run,
+            default_num_threads=_entry.get("default_num_threads", 64),
+            pred_schema=(_RULER2_PRED_SCHEMA if _metrics_type == "ruler2" else PredSchema()),
         )
     )

--- a/sgl_eval/evals/_ruler2.py
+++ b/sgl_eval/evals/_ruler2.py
@@ -1,0 +1,482 @@
+"""Glue between sgl-eval's sampler/runner and the vendored NeMo-Skills RULER2
+pieces (``eval_ruler2`` / ``eval_mcq``, ``Ruler2Metrics``, ``compute_score``).
+
+RULER2 differs from the math/mcq benchmarks in three ways that shape this file:
+
+  - **The dataset is generated, not downloaded**, and is bound to a specific
+    (tokenizer, sequence length) pair -- so both are part of the cache key.
+  - **It is a group of 12 subtasks** whose graders differ. Which grader a
+    subtask uses is read back from the vendored ``prepare_task_for_ns`` rather
+    than duplicated here.
+  - **The prompt is pre-assembled** by the prepare scripts, so the prompt
+    config (``generic/default``) is a bare ``{question}`` passthrough.
+
+Pipeline mirror:
+  - Stage 1 (dataset): vendored ``prepare_<task>`` -> ``~/.cache/sgl_eval/ruler2/<setup>/``
+  - Stage 2a (prompt render): vendored ``prompts/default.yaml``
+  - Stage 2c (extract + score): vendored ``eval_ruler2`` or ``eval_mcq``
+  - Stage 4 (aggregate): vendored ``Ruler2Metrics`` per subtask, then vendored
+    ``ruler2_score.compute_score`` for the 12-task headline.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# Silence the vendored evaluators' tqdm bars before importing them (they run
+# once per sample, so the bar would be pure noise).
+import sgl_eval._vendored.nemo_skills.evaluator.mcq as _mcq_mod
+import sgl_eval._vendored.nemo_skills.evaluator.ruler as _ruler_mod
+
+_mcq_mod.tqdm = lambda iterable, **_kwargs: iterable
+_ruler_mod.tqdm = lambda iterable, **_kwargs: iterable
+
+from sgl_eval._vendored.nemo_skills.dataset.ruler2 import prepare as _prepare  # noqa: E402
+from sgl_eval._vendored.nemo_skills.dataset.ruler2.ruler2_score import (  # noqa: E402
+    compute_score,
+)
+from sgl_eval._vendored.nemo_skills.evaluator.mcq import eval_mcq  # noqa: E402
+from sgl_eval._vendored.nemo_skills.evaluator.ruler import eval_ruler2  # noqa: E402
+from sgl_eval._vendored.nemo_skills.ruler2_metrics import Ruler2Metrics  # noqa: E402
+from sgl_eval.evals._prompts import render_prompt, vendored_prompt  # noqa: E402
+from sgl_eval.predictions import PredictionsWriter, PredSchema, sample_to_pred  # noqa: E402
+from sgl_eval.runner import _finish_reason_rates, run_examples  # noqa: E402
+from sgl_eval.sampler import ChatCompletionSampler  # noqa: E402
+from sgl_eval.types import (  # noqa: E402
+    Example,
+    ExampleResult,
+    GenConfig,
+    RunResult,
+    Sample,
+)
+
+_CACHE_ROOT = Path.home() / ".cache" / "sgl_eval" / "ruler2"
+
+# Order and membership must match the vendored ``compute_score``, which
+# KeyErrors on a missing task. Each name also has to resolve to a
+# ``prepare_<task>`` in the vendored prepare module -- both are asserted by
+# tests/test_ruler2.py rather than trusted.
+ALL_TASKS: Tuple[str, ...] = (
+    "mk_niah_basic",
+    "mk_niah_easy",
+    "mk_niah_medium",
+    "mk_niah_hard",
+    "mv_niah_basic",
+    "mv_niah_easy",
+    "mv_niah_medium",
+    "mv_niah_hard",
+    "qa_basic",
+    "qa_easy",
+    "qa_medium",
+    "qa_hard",
+)
+
+# RULER2's prompts hold ~500KB of context each; ``PredSchema`` defaults would
+# echo them into output-rs*.jsonl and stringify the list-valued answer.
+PRED_SCHEMA = PredSchema(
+    stringify_target=False,
+    include_prompt=False,
+    score_field="is_correct",
+    binary_score=False,
+)
+
+_MISSING_DEPS_HINT = (
+    "RULER2 dataset generation needs the `longcontext` extra:\n"
+    "    pip install 'sgl-eval[longcontext]'\n"
+    "(transformers, nltk, wonderwords, inflect). Scoring an already-generated "
+    "dataset does not need them."
+)
+
+
+@dataclass(frozen=True)
+class Ruler2Config:
+    """Generation-side knobs. Every field is passed straight through to the
+    vendored ``prepare_<task>``, so a given config reproduces NeMo-Skills'
+    dataset byte for byte (its ``random_seed`` is fixed at 42 upstream).
+
+    sgl-eval deliberately adds no knob that changes the produced data:
+    ``max_seq_length`` decides the dataset and therefore the score, which puts
+    it under the vendoring rule. Fitting the prompts into a server is the
+    preflight check's job, not the dataset's.
+    """
+
+    max_seq_length: int
+    tokenizer_path: str
+    tokenizer_type: str = "hf"
+    dataset_size: int = 100
+    tasks: Tuple[str, ...] = ALL_TASKS
+
+    @property
+    def setup_slug(self) -> str:
+        tok = re.sub(r"[^A-Za-z0-9._-]+", "-", self.tokenizer_path).strip("-")
+        return f"{tok}_{self.max_seq_length}_n{self.dataset_size}"
+
+    @property
+    def cache_dir(self) -> Path:
+        return _CACHE_ROOT / self.setup_slug
+
+    @classmethod
+    def from_bench_args(cls, bench_args: Optional[Dict[str, str]], *, model: str) -> "Ruler2Config":
+        args = dict(bench_args or {})
+        raw_seq_len = args.pop("seq_len", None)
+        if raw_seq_len is None:
+            sys.exit(
+                "error: ruler2 requires a target sequence length, e.g.\n"
+                "    --bench-arg seq_len=131072\n"
+                "It has no default: the dataset is generated per length."
+            )
+        # Defaults to the served model id, which is a HF repo id for most
+        # SGLang deployments; override for local paths or gated repos.
+        tokenizer_path = args.pop("tokenizer", model)
+        tokenizer_type = args.pop("tokenizer_type", "hf")
+        if tokenizer_type not in ("hf", "openai"):
+            sys.exit(
+                f"error: --bench-arg tokenizer_type={tokenizer_type!r} unsupported "
+                "(hf | openai; the vendored gemini tokenizer is dropped)."
+            )
+        dataset_size = _positive_int(args.pop("dataset_size", 100), "dataset_size")
+        raw_tasks = args.pop("tasks", None)
+        tasks = ALL_TASKS
+        if raw_tasks:
+            tasks = tuple(t.strip() for t in raw_tasks.split(",") if t.strip())
+            unknown = [t for t in tasks if t not in ALL_TASKS]
+            if unknown:
+                sys.exit(
+                    f"error: unknown ruler2 task(s) {unknown}. "
+                    f"Available: {', '.join(ALL_TASKS)}"
+                )
+        if args:
+            sys.exit(
+                f"error: unknown ruler2 --bench-arg key(s): {sorted(args)}. "
+                "Known: seq_len, tokenizer, tokenizer_type, dataset_size, tasks"
+            )
+        return cls(
+            max_seq_length=_positive_int(raw_seq_len, "seq_len"),
+            tokenizer_path=tokenizer_path,
+            tokenizer_type=tokenizer_type,
+            dataset_size=dataset_size,
+            tasks=tasks,
+        )
+
+
+def _positive_int(raw: Any, label: str) -> int:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        sys.exit(f"error: --bench-arg {label}={raw!r} is not an integer")
+    if value <= 0:
+        sys.exit(f"error: --bench-arg {label}={value} must be positive")
+    return value
+
+
+def _grader_for(cfg: Ruler2Config, task: str) -> Tuple[str, str]:
+    """``(eval_type, match_type)`` for one subtask, read back from the vendored
+    ``prepare_task_for_ns`` so the grader mapping is never duplicated here."""
+    _prepare.prepare_task_for_ns(str(cfg.cache_dir), task)
+    init_py = cfg.cache_dir / task / "__init__.py"
+    namespace: Dict[str, Any] = {}
+    exec(compile(init_py.read_text(), str(init_py), "exec"), namespace)  # noqa: S102
+    gen_args: str = namespace["GENERATION_ARGS"]
+    parsed = dict(
+        tok[2:].split("=", 1) for tok in gen_args.split() if tok.startswith("++") and "=" in tok
+    )
+    eval_type = parsed.get("eval_type", "")
+    if eval_type not in ("ruler2", "multichoice"):
+        raise RuntimeError(f"vendored ruler2 task {task!r}: unexpected ++eval_type={eval_type!r}")
+    return eval_type, parsed.get("eval_config.match_type", "")
+
+
+def _ensure_task_data(cfg: Ruler2Config, task: str) -> Path:
+    """Generate ``<cache>/<task>/test.jsonl`` once. Calls the per-task
+    ``prepare_<task>`` directly: ``prepare_dataset`` hardcodes its output to
+    ``Path(__file__).parent / setup``, i.e. inside ``_vendored``."""
+    task_dir = cfg.cache_dir / task
+    out_path = task_dir / "test.jsonl"
+    if out_path.exists():
+        return out_path
+    task_dir.mkdir(parents=True, exist_ok=True)
+    prepare_fn: Callable[..., None] = getattr(_prepare, f"prepare_{task}")
+    print(
+        f"  generating ruler2/{task} at {cfg.max_seq_length} tokens "
+        f"({cfg.dataset_size} samples)...",
+        flush=True,
+    )
+    try:
+        prepare_fn(
+            str(task_dir),
+            cfg.tokenizer_type,
+            cfg.tokenizer_path,
+            cfg.max_seq_length,
+            cfg.dataset_size,
+        )
+    except subprocess.CalledProcessError as e:
+        sys.exit(
+            f"error: ruler2 {task} generation failed (exit {e.returncode}).\n{_MISSING_DEPS_HINT}"
+        )
+    if not out_path.exists():
+        sys.exit(f"error: ruler2 {task} generation produced no {out_path}")
+    return out_path
+
+
+def _load_task(path: Path, task: str, num_examples: Optional[int]) -> List[Example]:
+    """Rows carry ``question`` (the assembled long prompt) and
+    ``expected_answer`` (a list for ruler2 graders, a letter for multichoice)."""
+    examples: List[Example] = []
+    with path.open("rt", encoding="utf-8") as f:
+        for i, line in enumerate(f):
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            examples.append(
+                Example(
+                    id=f"{task}-{row.get('index', i)}",
+                    inputs={"question": row["question"]},
+                    target=row["expected_answer"],
+                    meta={"task": task, "length": row.get("length")},
+                )
+            )
+            if num_examples and len(examples) >= num_examples:
+                break
+    return examples
+
+
+def _make_sample_fn(sampler: ChatCompletionSampler, gen: GenConfig, prompt_yaml: Path):
+    def sample_fn(ex: Example, _rep_idx: int) -> Sample:
+        text = render_prompt(prompt_yaml, problem="", question=ex.inputs["question"])
+        return sampler([{"role": "user", "content": text}], gen)
+
+    return sample_fn
+
+
+def _score_via(evaluator: Callable[[Dict[str, Any]], None], row: Dict[str, Any]) -> Dict[str, Any]:
+    """Both vendored evaluators are file-batch only; feed a 1-row jsonl."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        f.write(json.dumps(row) + "\n")
+        tmp_path = Path(f.name)
+    try:
+        evaluator({"input_file": str(tmp_path)})
+        with tmp_path.open() as f:
+            return json.loads(f.readline())
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _make_score_one_fn(eval_type: str, match_type: str):
+    def score_one(ex: Example, sample: Sample) -> Tuple[float, Optional[str]]:
+        row = {"generation": sample.text, **sample_to_pred(sample, ex, PRED_SCHEMA)}
+        if eval_type == "multichoice":
+            scored = _score_via(eval_mcq, row)
+            return (1.0 if scored.get("symbolic_correct") else 0.0), scored.get("predicted_answer")
+        scored = _score_via(lambda cfg: eval_ruler2({**cfg, "match_type": match_type}), row)
+        return float(scored.get("is_correct") or 0.0), scored.get("predicted_answer")
+
+    return score_one
+
+
+def _task_metrics(results: List[ExampleResult], n_repeats: int, eval_type: str) -> Dict[str, Any]:
+    """Vendored ``Ruler2Metrics`` over one subtask. It reads ``is_correct``
+    (float) or ``symbolic_correct`` (bool) depending on the grader, so the
+    score field has to match what that subtask's evaluator produced."""
+    metrics = Ruler2Metrics()
+    for r in results:
+        preds = []
+        for sample, score, extracted in zip(r.samples, r.scores, r.extracted):
+            pred = sample_to_pred(sample, r.example, PRED_SCHEMA)
+            pred["predicted_answer"] = extracted
+            if eval_type == "multichoice":
+                pred["symbolic_correct"] = bool(score)
+            else:
+                pred["is_correct"] = float(score)
+            preds.append(pred)
+        while len(preds) < n_repeats:
+            preds.append(dict(preds[-1]))
+        metrics.update(preds)
+    return metrics.get_metrics()
+
+
+def _headline(per_task: Dict[str, Dict[str, Any]], k: int, *, namespace: str) -> Dict[str, float]:
+    """Flatten to the ``Dict[str, float]`` shape ``format_summary`` renders.
+
+    The full-group average comes from vendored ``compute_score``, which raises on
+    a missing task; anything short of 12 is averaged here and flagged
+    ``partial_group``. Gate on what completed, not what was requested -- a run
+    aborted at task 5 needs the same fallback as ``tasks=a,b``.
+    """
+    agg_key = "pass@1" if k == 1 else f"pass@1[avg-of-{k}]"
+    flat: Dict[str, float] = {}
+    for task, raw in per_task.items():
+        flat[f"task.{task}"] = raw.get(agg_key, {}).get("accuracy", 0.0) / 100.0
+
+    if set(per_task) == set(ALL_TASKS):
+        namespaced = {f"{namespace}.{task}": raw for task, raw in per_task.items()}
+        scored = compute_score(namespaced)
+        flat["score"] = scored[namespace][agg_key]["accuracy"] / 100.0
+    else:
+        scores = [flat[f"task.{task}"] for task in per_task]
+        flat["score"] = sum(scores) / len(scores) if scores else 0.0
+        flat["partial_group"] = 1.0
+
+    if k > 1:
+        flat["pass@1"] = flat["score"]
+    return flat
+
+
+def aggregate_from_predictions(
+    per_example: List[ExampleResult], n_repeats: int
+) -> Dict[str, float]:
+    """Rebuild the group headline from dumped predictions (``sgl-eval refresh``).
+
+    Subtask comes back from the id (``<task>-<index>``); no task name contains
+    ``-``. Every row carries the float ``is_correct`` whichever grader ran, so
+    all 12 re-aggregate through the ``ruler2`` branch -- for the multichoice
+    pair that is the same number, under the other key ``Ruler2Metrics`` takes.
+    """
+    by_task: Dict[str, List[ExampleResult]] = {}
+    for result in per_example:
+        by_task.setdefault(result.example.id.rsplit("-", 1)[0], []).append(result)
+
+    unknown = sorted(set(by_task) - set(ALL_TASKS))
+    if unknown:
+        sys.exit(
+            f"error: ruler2 predictions contain unrecognized subtask(s) {unknown}. "
+            "Expected ids shaped <task>-<index>; refusing to guess a headline."
+        )
+    per_task = {task: _task_metrics(rs, n_repeats, "ruler2") for task, rs in by_task.items()}
+    return _headline(per_task, n_repeats, namespace="ruler2")
+
+
+# Minimum room the endpoint must leave for the answer when ``max_tokens`` is
+# unset. This is a PREFLIGHT THRESHOLD, not a dataset knob: it never changes
+# what gets generated, it only decides whether we refuse to start. RULER2
+# answers are short (a needle, a letter, a span), so this is generous.
+_MIN_GEN_BUDGET = 512
+
+
+def _preflight_context_length(
+    sampler: ChatCompletionSampler, cfg: Ruler2Config, gen: GenConfig
+) -> None:
+    """Refuse to spend hours on a server that cannot hold prompt + answer.
+
+    Two ways this bites, both silent: a window below ``seq_len`` makes every
+    request 400, and a window equal to ``seq_len`` leaves zero room to generate
+    when ``max_tokens`` is None. The sampler turns both into empty samples
+    scoring 0, so the run completes with all-zero metrics and exit code 0.
+
+    Warn (do not fail) when the endpoint does not expose its limit -- refusing
+    to run against a server we cannot introspect would be worse.
+    """
+    import httpx
+
+    gen_budget = gen.max_tokens or _MIN_GEN_BUDGET
+    needed = cfg.max_seq_length + gen_budget
+
+    base = str(sampler.client.base_url).rstrip("/")
+    root = base[: -len("/v1")] if base.endswith("/v1") else base
+    try:
+        resp = httpx.get(f"{root}/get_model_info", timeout=10)
+        info = resp.json() if resp.status_code == 200 else {}
+    except Exception:
+        info = {}
+
+    for key in ("max_context_length", "context_length", "max_model_len"):
+        raw = info.get(key)
+        if raw is None:
+            continue
+        limit = int(raw)
+        if limit < needed:
+            sys.exit(
+                f"error: endpoint reports {key}={limit}, but ruler2 at "
+                f"seq_len={cfg.max_seq_length} needs {needed} "
+                f"(prompt + {gen_budget} to generate).\n"
+                f"Every request would 400 or have no room to answer, scoring 0 "
+                f"with a successful exit code.\n"
+                f"Fix: serve with a larger --context-length, or lower "
+                f"--bench-arg seq_len (RULER2 is meant to be swept over "
+                f"lengths below the window)."
+            )
+        print(f"Preflight: endpoint {key}={limit} >= {needed} (seq_len + gen budget)")
+        return
+
+    print(
+        f"WARNING: could not read the endpoint's context length; ruler2 at "
+        f"seq_len={cfg.max_seq_length} needs {needed} tokens including room to "
+        f"answer. Too small shows up as error_rate near 100%.",
+        file=sys.stderr,
+    )
+
+
+def run_ruler2_benchmark(
+    *,
+    name: str,
+    sampler: ChatCompletionSampler,
+    gen: GenConfig,
+    n_repeats: int,
+    num_examples: Optional[int],
+    num_threads: int,
+    predictions_writer: Optional[PredictionsWriter] = None,
+    load_examples: Optional[Callable[[Optional[int]], List[Example]]] = None,
+    bench_args: Optional[Dict[str, str]] = None,
+) -> RunResult:
+    if load_examples is not None:
+        sys.exit(
+            "error: --from-dataset is not supported for ruler2; it is a group of "
+            "12 generated subtasks. Point --bench-arg tokenizer/seq_len instead."
+        )
+    cfg = Ruler2Config.from_bench_args(bench_args, model=sampler.model)
+    _preflight_context_length(sampler, cfg, gen)
+
+    prompt_yaml = vendored_prompt("default")
+    sample_fn = _make_sample_fn(sampler, gen, prompt_yaml)
+
+    per_task_raw: Dict[str, Dict[str, Any]] = {}
+    merged: List[ExampleResult] = []
+    planned = 0
+    partial = False
+    start = time.time()
+
+    for task in cfg.tasks:
+        data_path = _ensure_task_data(cfg, task)
+        examples = _load_task(data_path, task, num_examples)
+        eval_type, match_type = _grader_for(cfg, task)
+        result = run_examples(
+            name=f"{name}.{task}",
+            examples=examples,
+            sample_fn=sample_fn,
+            score_one_fn=_make_score_one_fn(eval_type, match_type),
+            num_threads=num_threads,
+            n_repeats=n_repeats,
+            aggregate_fn=None,
+            on_sample_scored=predictions_writer,
+        )
+        per_task_raw[task] = _task_metrics(result.per_example, n_repeats, eval_type)
+        merged.extend(result.per_example)
+        planned += result.planned_examples
+        partial = partial or result.partial
+        if sampler.aborted:
+            break
+
+    aggregate = _headline(per_task_raw, n_repeats, namespace=cfg.setup_slug)
+    for key, value in _finish_reason_rates(merged).items():
+        aggregate.setdefault(key, value)
+
+    return RunResult(
+        name=name,
+        per_example=merged,
+        aggregate=aggregate,
+        latency=time.time() - start,
+        num_examples=len(merged),
+        n_repeats=n_repeats,
+        total_completion_tokens=sum(s.completion_tokens or 0 for r in merged for s in r.samples),
+        total_prompt_tokens=sum(s.prompt_tokens or 0 for r in merged for s in r.samples),
+        partial=partial,
+        planned_examples=planned,
+    )

--- a/sgl_eval/evals/_ruler2.py
+++ b/sgl_eval/evals/_ruler2.py
@@ -21,8 +21,10 @@ Pipeline mirror:
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -124,57 +126,71 @@ class Ruler2Config:
         return _CACHE_ROOT / self.setup_slug
 
     @classmethod
-    def from_bench_args(cls, bench_args: Optional[Dict[str, str]], *, model: str) -> "Ruler2Config":
+    def from_bench_args(cls, bench_args: Optional[Dict[str, Any]], *, model: str) -> "Ruler2Config":
+        """Values arrive already typed and range-checked by ``add_arguments``.
+        The one rule argparse cannot express is "required, but only when this
+        benchmark is the one being run"."""
         args = dict(bench_args or {})
-        raw_seq_len = args.pop("seq_len", None)
-        if raw_seq_len is None:
+        if args.get("seq_len") is None:
             sys.exit(
                 "error: ruler2 requires a target sequence length, e.g.\n"
-                "    --bench-arg seq_len=131072\n"
+                "    --ruler2-seq-len 131072\n"
                 "It has no default: the dataset is generated per length."
             )
-        # Defaults to the served model id, which is a HF repo id for most
-        # SGLang deployments; override for local paths or gated repos.
-        tokenizer_path = args.pop("tokenizer", model)
-        tokenizer_type = args.pop("tokenizer_type", "hf")
-        if tokenizer_type not in ("hf", "openai"):
-            sys.exit(
-                f"error: --bench-arg tokenizer_type={tokenizer_type!r} unsupported "
-                "(hf | openai; the vendored gemini tokenizer is dropped)."
-            )
-        dataset_size = _positive_int(args.pop("dataset_size", 100), "dataset_size")
-        raw_tasks = args.pop("tasks", None)
-        tasks = ALL_TASKS
-        if raw_tasks:
-            tasks = tuple(t.strip() for t in raw_tasks.split(",") if t.strip())
-            unknown = [t for t in tasks if t not in ALL_TASKS]
-            if unknown:
-                sys.exit(
-                    f"error: unknown ruler2 task(s) {unknown}. "
-                    f"Available: {', '.join(ALL_TASKS)}"
-                )
-        if args:
-            sys.exit(
-                f"error: unknown ruler2 --bench-arg key(s): {sorted(args)}. "
-                "Known: seq_len, tokenizer, tokenizer_type, dataset_size, tasks"
-            )
         return cls(
-            max_seq_length=_positive_int(raw_seq_len, "seq_len"),
-            tokenizer_path=tokenizer_path,
-            tokenizer_type=tokenizer_type,
-            dataset_size=dataset_size,
-            tasks=tasks,
+            max_seq_length=args["seq_len"],
+            # The served model id is a HF repo id for most SGLang deployments;
+            # override for local paths or gated repos.
+            tokenizer_path=args.get("tokenizer") or model,
+            tokenizer_type=args.get("tokenizer_type") or "hf",
+            dataset_size=args.get("dataset_size") or 100,
+            tasks=tuple(args["tasks"]) if args.get("tasks") else ALL_TASKS,
         )
 
 
-def _positive_int(raw: Any, label: str) -> int:
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        sys.exit(f"error: --bench-arg {label}={raw!r} is not an integer")
+def _positive_int(raw: str) -> int:
+    """argparse ``type``: rejects 0 and negatives at parse time."""
+    value = int(raw)
     if value <= 0:
-        sys.exit(f"error: --bench-arg {label}={value} must be positive")
+        raise argparse.ArgumentTypeError(f"must be positive, got {value}")
     return value
+
+
+def add_arguments(group: Any) -> None:
+    """ruler2's own CLI surface. Wired via ``EvalSpec.add_arguments``, so
+    ``sgl-eval run --help`` documents these and argparse rejects a bad value
+    before a run starts."""
+    group.add_argument(
+        "--ruler2-seq-len",
+        type=_positive_int,
+        metavar="N",
+        help="target context length; required, as the dataset is generated per length",
+    )
+    group.add_argument(
+        "--ruler2-tokenizer",
+        metavar="HF_ID_OR_PATH",
+        help="tokenizer used to size samples (default: the served model id)",
+    )
+    group.add_argument(
+        "--ruler2-tokenizer-type",
+        choices=("hf", "openai"),
+        default="hf",
+        help="the vendored gemini tokenizer is dropped, so it is not offered",
+    )
+    group.add_argument(
+        "--ruler2-dataset-size",
+        type=_positive_int,
+        default=100,
+        metavar="N",
+        help="samples per subtask (default: 100)",
+    )
+    group.add_argument(
+        "--ruler2-tasks",
+        nargs="+",
+        choices=ALL_TASKS,
+        metavar="TASK",
+        help=f"subset of the 12 subtasks, scored as a flagged partial average ({', '.join(ALL_TASKS)})",
+    )
 
 
 def _grader_for(cfg: Ruler2Config, task: str) -> Tuple[str, str]:
@@ -202,7 +218,11 @@ def _ensure_task_data(cfg: Ruler2Config, task: str) -> Path:
     out_path = task_dir / "test.jsonl"
     if out_path.exists():
         return out_path
-    task_dir.mkdir(parents=True, exist_ok=True)
+    # Generate into a staging dir and rename, so a kill mid-write cannot leave a
+    # truncated test.jsonl that later runs would accept as a complete dataset.
+    staging = cfg.cache_dir / f"{task}.partial"
+    shutil.rmtree(staging, ignore_errors=True)
+    staging.mkdir(parents=True, exist_ok=True)
     prepare_fn: Callable[..., None] = getattr(_prepare, f"prepare_{task}")
     print(
         f"  generating ruler2/{task} at {cfg.max_seq_length} tokens "
@@ -211,7 +231,7 @@ def _ensure_task_data(cfg: Ruler2Config, task: str) -> Path:
     )
     try:
         prepare_fn(
-            str(task_dir),
+            str(staging),
             cfg.tokenizer_type,
             cfg.tokenizer_path,
             cfg.max_seq_length,
@@ -221,8 +241,12 @@ def _ensure_task_data(cfg: Ruler2Config, task: str) -> Path:
         sys.exit(
             f"error: ruler2 {task} generation failed (exit {e.returncode}).\n{_MISSING_DEPS_HINT}"
         )
-    if not out_path.exists():
-        sys.exit(f"error: ruler2 {task} generation produced no {out_path}")
+    staged = staging / "test.jsonl"
+    if not staged.exists():
+        sys.exit(f"error: ruler2 {task} generation produced no {staged}")
+    task_dir.mkdir(parents=True, exist_ok=True)
+    staged.replace(out_path)
+    shutil.rmtree(staging, ignore_errors=True)
     return out_path
 
 
@@ -400,7 +424,7 @@ def _preflight_context_length(
                 f"Every request would 400 or have no room to answer, scoring 0 "
                 f"with a successful exit code.\n"
                 f"Fix: serve with a larger --context-length, or lower "
-                f"--bench-arg seq_len (RULER2 is meant to be swept over "
+                f"--ruler2-seq-len (RULER2 is meant to be swept over "
                 f"lengths below the window)."
             )
         print(f"Preflight: endpoint {key}={limit} >= {needed} (seq_len + gen budget)")
@@ -424,12 +448,12 @@ def run_ruler2_benchmark(
     num_threads: int,
     predictions_writer: Optional[PredictionsWriter] = None,
     load_examples: Optional[Callable[[Optional[int]], List[Example]]] = None,
-    bench_args: Optional[Dict[str, str]] = None,
+    bench_args: Optional[Dict[str, Any]] = None,
 ) -> RunResult:
     if load_examples is not None:
         sys.exit(
             "error: --from-dataset is not supported for ruler2; it is a group of "
-            "12 generated subtasks. Point --bench-arg tokenizer/seq_len instead."
+            "12 generated subtasks. Point --ruler2-tokenizer / --ruler2-seq-len instead."
         )
     cfg = Ruler2Config.from_bench_args(bench_args, model=sampler.model)
     _preflight_context_length(sampler, cfg, gen)

--- a/sgl_eval/metrics.py
+++ b/sgl_eval/metrics.py
@@ -124,4 +124,13 @@ def _build_rows(agg: Dict[str, float], k: int) -> List[Tuple[bool, str, str, Opt
     if error_rate is not None:
         note = "warn: request errors" if error_rate >= 0.01 else None
         rows.append((False, "error_rate", f"{error_rate * 100:.2f}%", note))
+
+    # Group benchmarks (ruler2) publish per-subtask scores as ``task.<name>``;
+    # the headline averages them, so the breakdown says which one moved.
+    task_keys = sorted(k for k in agg if k.startswith("task."))
+    if task_keys:
+        if agg.get("partial_group"):
+            rows.append((False, "group", "PARTIAL (task subset, not the full group)", None))
+        for key in task_keys:
+            rows.append((False, f"  {key[len('task.'):]}", f"{agg[key] * 100:.2f}%", None))
     return rows

--- a/sgl_eval/metrics.py
+++ b/sgl_eval/metrics.py
@@ -127,7 +127,7 @@ def _build_rows(agg: Dict[str, float], k: int) -> List[Tuple[bool, str, str, Opt
 
     # Group benchmarks (ruler2) publish per-subtask scores as ``task.<name>``;
     # the headline averages them, so the breakdown says which one moved.
-    task_keys = sorted(k for k in agg if k.startswith("task."))
+    task_keys = sorted(key for key in agg if key.startswith("task."))
     if task_keys:
         if agg.get("partial_group"):
             rows.append((False, "group", "PARTIAL (task subset, not the full group)", None))

--- a/sgl_eval/pipeline/refresh.py
+++ b/sgl_eval/pipeline/refresh.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from sgl_eval.metrics import dump_run, format_summary
 from sgl_eval.pipeline.report import _format_partial_summary, _partial_stats
 from sgl_eval.predictions import PredictionsReader, PredSchema
-from sgl_eval.registry import get
+from sgl_eval.registry import EvalSpec, get
 from sgl_eval.types import Example, ExampleResult, RunResult, Sample
 
 # dump_run sets these from ``RunResult``; must not appear in run_meta
@@ -67,7 +67,7 @@ def cmd_refresh(args: argparse.Namespace) -> int:
 
     per_example = _build_per_example(reader, spec.pred_schema)
     n_repeats = reader.n_repeats
-    aggregate = _aggregate(spec.category, per_example, n_repeats)
+    aggregate = _aggregate(spec, per_example, n_repeats)
 
     completed_samples = sum(len(r.samples) for r in per_example)
     planned_examples = _resolve_planned_examples(old_payload, per_example)
@@ -191,22 +191,16 @@ def _build_per_example(reader: PredictionsReader, schema: PredSchema) -> List[Ex
     ]
 
 
-def _aggregate(category: str, per_example: List[ExampleResult], n_repeats: int) -> Dict[str, float]:
-    # Needed at every k: the headline is a mean of per-subtask means, which the
-    # sample-level fallback below only matches when subtask counts are equal.
-    if category == "ruler2":
-        from sgl_eval.evals._ruler2 import aggregate_from_predictions
-
-        return aggregate_from_predictions(per_example, n_repeats)
-    if n_repeats > 1:
-        if category == "math":
-            from sgl_eval.evals._math import aggregate_with_math_metrics
-
-            return aggregate_with_math_metrics(per_example, n_repeats)
-        if category == "multichoice":
-            from sgl_eval.evals._multichoice import aggregate_with_math_metrics
-
-            return aggregate_with_math_metrics(per_example, n_repeats)
+def _aggregate(
+    spec: EvalSpec, per_example: List[ExampleResult], n_repeats: int
+) -> Dict[str, float]:
+    """A benchmark that needs more than a sample-level mean -- pass@k, or a
+    group headline built from per-subtask means -- supplies its own rebuild via
+    ``EvalSpec.aggregate_predictions``. ``None`` means the mean below is right."""
+    if spec.aggregate_predictions is not None:
+        rebuilt = spec.aggregate_predictions(per_example, n_repeats)
+        if rebuilt is not None:
+            return rebuilt
     if not per_example:
         return {"score": 0.0}
     means = [sum(r.scores) / len(r.scores) for r in per_example if r.scores]

--- a/sgl_eval/pipeline/refresh.py
+++ b/sgl_eval/pipeline/refresh.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sgl_eval.metrics import dump_run, format_summary
 from sgl_eval.pipeline.report import _format_partial_summary, _partial_stats
-from sgl_eval.predictions import PredictionsReader
+from sgl_eval.predictions import PredictionsReader, PredSchema
 from sgl_eval.registry import get
 from sgl_eval.types import Example, ExampleResult, RunResult, Sample
 
@@ -65,7 +65,7 @@ def cmd_refresh(args: argparse.Namespace) -> int:
     if reader.n_repeats == 0:
         sys.exit(f"error: no output-rs*.jsonl found in {run_dir}")
 
-    per_example = _build_per_example(reader)
+    per_example = _build_per_example(reader, spec.pred_schema)
     n_repeats = reader.n_repeats
     aggregate = _aggregate(spec.category, per_example, n_repeats)
 
@@ -145,7 +145,10 @@ def _resolve_planned_examples(
     return len(per_example)
 
 
-def _build_per_example(reader: PredictionsReader) -> List[ExampleResult]:
+def _build_per_example(reader: PredictionsReader, schema: PredSchema) -> List[ExampleResult]:
+    """``schema`` names the score field the run dumped -- a fixed
+    ``symbolic_correct`` scores every row 0 for ruler2, which writes
+    ``is_correct``."""
     by_id: Dict[str, Dict[str, Any]] = {}
     for _rep, row in reader.iter_all():
         ex_id = row["id"]
@@ -171,7 +174,11 @@ def _build_per_example(reader: PredictionsReader) -> List[ExampleResult]:
                 generation_end_time=row.get("generation_end_time"),
             )
         )
-        slot["scores"].append(1.0 if row.get("symbolic_correct") else 0.0)
+        raw_score = row.get(schema.score_field)
+        if schema.binary_score:
+            slot["scores"].append(1.0 if raw_score else 0.0)
+        else:
+            slot["scores"].append(float(raw_score or 0.0))
         slot["extracted"].append(row.get("predicted_answer"))
     return [
         ExampleResult(
@@ -185,6 +192,12 @@ def _build_per_example(reader: PredictionsReader) -> List[ExampleResult]:
 
 
 def _aggregate(category: str, per_example: List[ExampleResult], n_repeats: int) -> Dict[str, float]:
+    # Needed at every k: the headline is a mean of per-subtask means, which the
+    # sample-level fallback below only matches when subtask counts are equal.
+    if category == "ruler2":
+        from sgl_eval.evals._ruler2 import aggregate_from_predictions
+
+        return aggregate_from_predictions(per_example, n_repeats)
     if n_repeats > 1:
         if category == "math":
             from sgl_eval.evals._math import aggregate_with_math_metrics

--- a/sgl_eval/pipeline/report.py
+++ b/sgl_eval/pipeline/report.py
@@ -69,7 +69,7 @@ def render(result: RunResult, ctx: RunContext) -> int:
 
 
 def _build_run_meta(ctx: RunContext) -> Dict[str, Any]:
-    return {
+    meta: Dict[str, Any] = {
         "timestamp": ctx.stamp,
         "model": ctx.sampler.model,
         "base_url": ctx.inputs.base_url,
@@ -78,6 +78,11 @@ def _build_run_meta(ctx: RunContext) -> Dict[str, Any]:
         "sgl_eval_version": _SGL_EVAL_VERSION,
         "ns_commit_sha": _read_ns_commit_sha(),
     }
+    # Benchmarks whose dataset is generated (ruler2) are only identified by
+    # these -- without them a metrics.json cannot say which setup it scored.
+    if ctx.bench_args:
+        meta["bench_args"] = dict(ctx.bench_args)
+    return meta
 
 
 def _read_ns_commit_sha() -> Optional[str]:

--- a/sgl_eval/pipeline/run.py
+++ b/sgl_eval/pipeline/run.py
@@ -18,6 +18,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             num_threads=ctx.num_threads,
             predictions_writer=ctx.writer,
             load_examples=ctx.load_examples,
+            bench_args=ctx.bench_args,
         )
     finally:
         setup.teardown(ctx)

--- a/sgl_eval/pipeline/setup.py
+++ b/sgl_eval/pipeline/setup.py
@@ -33,7 +33,7 @@ class RunContext:
     num_threads: int
     args: argparse.Namespace
     load_examples: Optional[Callable[[Optional[int]], List[Example]]]
-    bench_args: Dict[str, str]
+    bench_args: Dict[str, Any]
     _prev_sigint_handler: Any
 
 
@@ -71,19 +71,21 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
         num_threads=num_threads,
         args=args,
         load_examples=load_examples,
-        bench_args=_parse_bench_args(getattr(args, "bench_arg", []) or []),
+        bench_args=_collect_bench_args(args, spec.name),
         _prev_sigint_handler=prev_sigint,
     )
 
 
-def _parse_bench_args(pairs: List[str]) -> Dict[str, str]:
-    parsed: Dict[str, str] = {}
-    for item in pairs:
-        if "=" not in item:
-            sys.exit(f"error: --bench-arg expects KEY=VALUE, got {item!r}")
-        key, value = item.split("=", 1)
-        parsed[key.strip()] = value.strip()
-    return parsed
+def _collect_bench_args(args: argparse.Namespace, name: str) -> Dict[str, Any]:
+    """Gather the running benchmark's own ``--<name>-*`` options, prefix
+    stripped. Feeds the run fn and ``metrics.json`` provenance -- a generated
+    dataset is identified by nothing else."""
+    prefix = f"{name}_"
+    return {
+        key[len(prefix) :]: value
+        for key, value in vars(args).items()
+        if key.startswith(prefix) and value is not None
+    }
 
 
 def teardown(ctx: RunContext) -> None:

--- a/sgl_eval/pipeline/setup.py
+++ b/sgl_eval/pipeline/setup.py
@@ -10,7 +10,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from sgl_eval.evals._loader import load_from_path
 from sgl_eval.predictions import PredictionsWriter
@@ -33,6 +33,7 @@ class RunContext:
     num_threads: int
     args: argparse.Namespace
     load_examples: Optional[Callable[[Optional[int]], List[Example]]]
+    bench_args: Dict[str, str]
     _prev_sigint_handler: Any
 
 
@@ -50,9 +51,15 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
     run_dir.mkdir(parents=True, exist_ok=True)
     print(f"Run directory: {run_dir}")
 
-    writer = PredictionsWriter(run_dir, inputs.n_repeats) if args.dump_predictions else None
+    writer = (
+        PredictionsWriter(run_dir, inputs.n_repeats, spec.pred_schema)
+        if args.dump_predictions
+        else None
+    )
     prev_sigint = signal.signal(signal.SIGINT, _make_sigint_handler(sampler))
     load_examples = load_from_path(args.from_dataset) if args.from_dataset else None
+
+    num_threads = args.num_threads if args.num_threads is not None else spec.default_num_threads
 
     return RunContext(
         inputs=inputs,
@@ -61,11 +68,22 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
         run_dir=run_dir,
         writer=writer,
         stamp=stamp,
-        num_threads=args.num_threads,
+        num_threads=num_threads,
         args=args,
         load_examples=load_examples,
+        bench_args=_parse_bench_args(getattr(args, "bench_arg", []) or []),
         _prev_sigint_handler=prev_sigint,
     )
+
+
+def _parse_bench_args(pairs: List[str]) -> Dict[str, str]:
+    parsed: Dict[str, str] = {}
+    for item in pairs:
+        if "=" not in item:
+            sys.exit(f"error: --bench-arg expects KEY=VALUE, got {item!r}")
+        key, value = item.split("=", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed
 
 
 def teardown(ctx: RunContext) -> None:

--- a/sgl_eval/predictions.py
+++ b/sgl_eval/predictions.py
@@ -8,26 +8,48 @@ from __future__ import annotations
 
 import json
 import threading
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional, Tuple
 
 from sgl_eval.types import Example, Sample
 
 
-def sample_to_pred(sample: Sample, example: Example) -> Dict[str, Any]:
+@dataclass(frozen=True)
+class PredSchema:
+    """How a scored sample becomes an NS prediction dict.
+
+    Defaults are the math/mcq shape. RULER2 flips every field: its grader
+    iterates ``expected_answer`` as a list (stringified, it walks the repr
+    character by character and scores almost everything correct), its score is a
+    float, and echoing the ~500KB prompt would dwarf the run.
+    """
+
+    stringify_target: bool = True
+    include_prompt: bool = True
+    score_field: str = "symbolic_correct"
+    binary_score: bool = True
+
+
+_DEFAULT_SCHEMA = PredSchema()
+
+
+def sample_to_pred(
+    sample: Sample, example: Example, schema: PredSchema = _DEFAULT_SCHEMA
+) -> Dict[str, Any]:
     completion = sample.completion_tokens or 0
     reasoning = sample.reasoning_tokens or 0
     # ``id`` mirrors NS native row shape and is the per-problem key for
     # partial-resume / sub-sampling on top of the JSONL dumps.
     pred: Dict[str, Any] = {
         "id": example.id,
-        "expected_answer": str(example.target),
+        "expected_answer": str(example.target) if schema.stringify_target else example.target,
         "num_generated_tokens": completion,
         "num_reasoning_tokens": reasoning,
         "num_answer_tokens": max(completion - reasoning, 0),
         # Generation stop reason ("stop" / "length" / "error").
         "finish_reason": sample.finish_reason,
-        "problem": example.inputs.get("problem", ""),
+        "problem": example.inputs.get("problem", "") if schema.include_prompt else "",
     }
     # NS ``BaseMetrics.update`` skips entries missing these keys; only set
     # when valid so min(...) doesn't collapse to 0.
@@ -43,12 +65,13 @@ class PredictionsWriter:
     a Ctrl-C / crash leaves all already-scored samples on disk. Thread-safe
     via a single lock (negligible contention vs LLM RTT)."""
 
-    def __init__(self, out_dir: Path, n_repeats: int) -> None:
+    def __init__(self, out_dir: Path, n_repeats: int, schema: PredSchema = _DEFAULT_SCHEMA) -> None:
         out_dir.mkdir(parents=True, exist_ok=True)
         self._files = [
             (out_dir / f"output-rs{i}.jsonl").open("w", encoding="utf-8") for i in range(n_repeats)
         ]
         self._lock = threading.Lock()
+        self._schema = schema
 
     def __call__(
         self,
@@ -60,9 +83,9 @@ class PredictionsWriter:
     ) -> None:
         pred: Dict[str, Any] = {
             "generation": sample.text,
-            **sample_to_pred(sample, ex),
+            **sample_to_pred(sample, ex, self._schema),
             "predicted_answer": extracted,
-            "symbolic_correct": bool(score),
+            self._schema.score_field: bool(score) if self._schema.binary_score else score,
         }
         line = json.dumps(pred, ensure_ascii=False) + "\n"
         with self._lock:

--- a/sgl_eval/registry.py
+++ b/sgl_eval/registry.py
@@ -9,9 +9,12 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
 from sgl_eval.predictions import PredSchema
-from sgl_eval.types import GenConfig, RunResult
+from sgl_eval.types import ExampleResult, GenConfig, RunResult
 
 EvalRunFn = Callable[..., RunResult]
+# ``sgl-eval refresh`` hook: rebuild the aggregate from dumped predictions.
+# Returning ``None`` means the sample-level mean is already correct.
+AggregateFromPredictions = Callable[[List[ExampleResult], int], Optional[Dict[str, float]]]
 
 
 @dataclass
@@ -32,6 +35,9 @@ class EvalSpec:
     # their types, choices and --help instead of a stringly-typed side channel.
     # Names must be prefixed ``--<benchmark>-*``; ``prepare_run`` collects them.
     add_arguments: Optional[Callable[[Any], None]] = None
+    # Lets refresh rebuild pass@k / group headlines without knowing which
+    # benchmark it is looking at.
+    aggregate_predictions: Optional[AggregateFromPredictions] = None
 
 
 _REGISTRY: Dict[str, EvalSpec] = {}

--- a/sgl_eval/registry.py
+++ b/sgl_eval/registry.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Dict, List
 
+from sgl_eval.predictions import PredSchema
 from sgl_eval.types import GenConfig, RunResult
 
 EvalRunFn = Callable[..., RunResult]
@@ -21,6 +22,12 @@ class EvalSpec:
     default_gen: GenConfig
     default_n_repeats: int
     run: EvalRunFn
+    # Concurrency the benchmark is safe at by default. The runner limits by
+    # request count, not token budget, so a long-context benchmark has to ask
+    # for a lower ceiling than the 64 that suits short prompts.
+    default_num_threads: int = 64
+    # How a scored sample is written to output-rs*.jsonl.
+    pred_schema: PredSchema = field(default_factory=PredSchema)
 
 
 _REGISTRY: Dict[str, EvalSpec] = {}

--- a/sgl_eval/registry.py
+++ b/sgl_eval/registry.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import importlib
 import pkgutil
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from sgl_eval.predictions import PredSchema
 from sgl_eval.types import GenConfig, RunResult
@@ -28,6 +28,10 @@ class EvalSpec:
     default_num_threads: int = 64
     # How a scored sample is written to output-rs*.jsonl.
     pred_schema: PredSchema = field(default_factory=PredSchema)
+    # Lets a benchmark add its own options to ``sgl-eval run``, so argparse owns
+    # their types, choices and --help instead of a stringly-typed side channel.
+    # Names must be prefixed ``--<benchmark>-*``; ``prepare_run`` collects them.
+    add_arguments: Optional[Callable[[Any], None]] = None
 
 
 _REGISTRY: Dict[str, EvalSpec] = {}

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -134,3 +134,29 @@ def test_refresh_partial_emits_score_bounds(tmp_path: Path) -> None:
     # 1 correct of 3 planned -> worst 1/3, best (1+2)/3 = 1.0
     assert payload["score_lower_bound"] == pytest.approx(1 / 3)
     assert payload["score_upper_bound"] == pytest.approx(1.0)
+
+
+def test_refresh_rebuilds_pass_at_k_through_the_spec_hook(tmp_path: Path) -> None:
+    """k > 1 has to go through the benchmark's own rebuild (``MathMetrics``),
+    not the sample-level mean -- otherwise pass@k / majority@k vanish on
+    refresh. Refresh itself knows nothing about which benchmark this is."""
+    run_dir = tmp_path / "sgl_eval_aime24_20260502-120000"
+    run_dir.mkdir()
+    _write_jsonl(run_dir / "output-rs0.jsonl", [_row("aime24-0", True), _row("aime24-1", False)])
+    _write_jsonl(run_dir / "output-rs1.jsonl", [_row("aime24-0", False), _row("aime24-1", False)])
+
+    assert cmd_refresh(SimpleNamespace(run_dir=str(run_dir))) == 0
+
+    agg = json.loads((run_dir / "metrics.json").read_text())["aggregate"]
+    assert "pass@1" in agg and "pass@2" in agg
+    assert agg["pass@1"] == pytest.approx(0.25)  # 1 of 4 samples correct
+    assert agg["pass@2"] == pytest.approx(0.5)  # example 0 correct in one repeat
+
+
+def test_every_benchmark_can_rebuild_its_aggregate() -> None:
+    """A new category must not land without a refresh path: refresh dispatches
+    purely on this hook, so a missing one silently degrades to a plain mean."""
+    from sgl_eval.registry import list_evals
+
+    missing = [s.name for s in list_evals() if s.aggregate_predictions is None]
+    assert missing == []

--- a/tests/test_ruler2.py
+++ b/tests/test_ruler2.py
@@ -309,40 +309,84 @@ def test_setup_slug_separates_every_generation_input():
     assert "/" not in base.setup_slug
 
 
+def _parse_run(*extra: str):
+    """Parse a ``sgl-eval run ruler2`` invocation the way the CLI would."""
+    from sgl_eval.cli import build_parser
+
+    return build_parser().parse_args(["run", "ruler2", "--base-url", "http://x/v1", *extra])
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--ruler2-tokenizer-type", "gemini"],  # dropped from the vendored slice
+        ["--ruler2-tasks", "bogus"],
+        ["--ruler2-seq-len", "0"],
+        ["--ruler2-seq-len", "not-a-number"],
+        ["--ruler2-headroom", "512"],  # removed knob: it shrank the dataset
+        ["--bench-arg", "seq_len=131072"],  # retired KEY=VALUE channel
+    ],
+)
+def test_argparse_rejects_bad_ruler2_options(flags):
+    """These used to be hand-rolled checks inside ``from_bench_args``. argparse
+    owns them now -- including the two flags that must stay gone."""
+    with pytest.raises(SystemExit):
+        _parse_run(*flags)
+
+
+def test_parsed_ruler2_options_are_already_typed():
+    args = _parse_run("--ruler2-seq-len", "131072", "--ruler2-tasks", "qa_basic", "qa_easy")
+    assert args.ruler2_seq_len == 131072
+    assert args.ruler2_tasks == ["qa_basic", "qa_easy"]
+    assert args.ruler2_dataset_size == 100
+
+
+def test_collect_bench_args_strips_the_prefix():
+    """``metrics.json`` records these, so only options actually chosen belong in
+    the dict -- an unset tokenizer must not show up as null."""
+    from sgl_eval.pipeline.setup import _collect_bench_args
+
+    args = _parse_run("--ruler2-seq-len", "131072", "--ruler2-tasks", "qa_basic")
+    assert _collect_bench_args(args, "ruler2") == {
+        "seq_len": 131072,
+        "tokenizer_type": "hf",
+        "dataset_size": 100,
+        "tasks": ["qa_basic"],
+    }
+
+
 def test_from_bench_args_requires_seq_len():
     with pytest.raises(SystemExit):
         Ruler2Config.from_bench_args({}, model="m")
 
 
 def test_from_bench_args_defaults_tokenizer_to_model():
-    cfg = Ruler2Config.from_bench_args({"seq_len": "8192"}, model="Qwen/Qwen3-8B")
+    cfg = Ruler2Config.from_bench_args({"seq_len": 8192}, model="Qwen/Qwen3-8B")
     assert cfg.tokenizer_path == "Qwen/Qwen3-8B"
     assert cfg.tasks == ALL_TASKS
 
 
-def test_from_bench_args_rejects_unknown_keys():
-    with pytest.raises(SystemExit):
-        Ruler2Config.from_bench_args({"seq_len": "8192", "nope": "1"}, model="m")
+def test_generation_stages_through_a_partial_dir(tmp_path, monkeypatch):
+    """A kill mid-write must not leave a truncated test.jsonl that later runs
+    accept as complete, so generation lands in ``<task>.partial`` and renames."""
+    import sgl_eval.evals._ruler2 as mod
 
+    monkeypatch.setattr(mod, "_CACHE_ROOT", tmp_path)
+    cfg = Ruler2Config(max_seq_length=4096, tokenizer_path="t")
+    seen = {}
 
-def test_from_bench_args_rejects_unknown_task():
-    with pytest.raises(SystemExit):
-        Ruler2Config.from_bench_args({"seq_len": "8192", "tasks": "qa_basic,bogus"}, model="m")
+    def fake_prepare(out_folder, *_args):
+        seen["folder"] = out_folder
+        Path(out_folder).mkdir(parents=True, exist_ok=True)
+        (Path(out_folder) / "test.jsonl").write_text(
+            json.dumps({"index": 0, "question": "q", "expected_answer": ["a"]}) + "\n"
+        )
 
-
-def test_from_bench_args_rejects_gemini_tokenizer():
-    """``GeminiTokenizer`` is dropped from the vendored slice, so selecting it
-    would NameError deep inside generation."""
-    with pytest.raises(SystemExit):
-        Ruler2Config.from_bench_args({"seq_len": "8192", "tokenizer_type": "gemini"}, model="m")
-
-
-def test_from_bench_args_rejects_headroom_knob():
-    """``headroom`` was removed on purpose: it shrank the dataset and made our
-    scores incomparable with NeMo-Skills. Rejecting it loudly beats silently
-    ignoring a flag someone copied from an older invocation."""
-    with pytest.raises(SystemExit):
-        Ruler2Config.from_bench_args({"seq_len": "8192", "headroom": "512"}, model="m")
+    monkeypatch.setattr(mod._prepare, "prepare_qa_basic", fake_prepare)
+    out = mod._ensure_task_data(cfg, "qa_basic")
+    assert seen["folder"].endswith("qa_basic.partial")
+    assert out == cfg.cache_dir / "qa_basic" / "test.jsonl" and out.exists()
+    assert not (cfg.cache_dir / "qa_basic.partial").exists()
 
 
 # --- preflight ------------------------------------------------------------

--- a/tests/test_ruler2.py
+++ b/tests/test_ruler2.py
@@ -1,0 +1,484 @@
+"""RULER2 glue tests. No generation and no server: everything here is either
+a vendored-consistency assertion or a scoring path driven by hand-built rows.
+
+The dataset itself cannot be built in CI (it needs a tokenizer, HF downloads,
+and minutes per subtask), so the invariants that would otherwise only surface
+at runtime are asserted statically instead.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sgl_eval.evals._ruler2 import (
+    ALL_TASKS,
+    PRED_SCHEMA,
+    Ruler2Config,
+    _grader_for,
+    _headline,
+    _load_task,
+    _make_score_one_fn,
+    _task_metrics,
+)
+from sgl_eval.types import Example, ExampleResult, GenConfig, Sample
+
+# --- vendored consistency -------------------------------------------------
+
+
+def test_all_tasks_matches_vendored_compute_score():
+    """``compute_score`` KeyErrors on a task it does not know, and silently
+    under-averages if we omit one. Pin our list against its source."""
+    import inspect
+
+    from sgl_eval._vendored.nemo_skills.dataset.ruler2 import ruler2_score
+
+    src = inspect.getsource(ruler2_score.compute_score)
+    for task in ALL_TASKS:
+        assert f'"{task}"' in src, f"{task} missing from vendored compute_score"
+    # And the reverse: no task in its list that we do not run.
+    listed = [line.strip().strip('",') for line in src.splitlines() if line.strip().startswith('"')]
+    assert set(listed) == set(ALL_TASKS)
+
+
+def test_every_task_has_a_vendored_prepare_fn():
+    from sgl_eval._vendored.nemo_skills.dataset.ruler2 import prepare
+
+    for task in ALL_TASKS:
+        assert callable(getattr(prepare, f"prepare_{task}", None)), task
+
+
+def test_ruler2_registered_with_lowered_concurrency():
+    from sgl_eval.registry import get
+
+    spec = get("ruler2")
+    assert spec.category == "ruler2"
+    # 64 concurrent 128k prompts would be ~8M tokens in flight.
+    assert spec.default_num_threads < 64
+    assert spec.pred_schema == PRED_SCHEMA
+
+
+@pytest.mark.parametrize(
+    "task, eval_type, match_type",
+    [
+        ("mk_niah_basic", "ruler2", "all"),
+        ("mk_niah_medium", "multichoice", ""),
+        ("mk_niah_hard", "multichoice", ""),
+        ("mv_niah_medium", "ruler2", "2steps"),
+        ("qa_hard", "ruler2", "part"),
+    ],
+)
+def test_grader_read_back_from_vendored_prepare(tmp_path, monkeypatch, task, eval_type, match_type):
+    """The grader mapping lives in vendored ``prepare_task_for_ns``; this
+    checks we read it rather than having drifted from a local copy."""
+    import sgl_eval.evals._ruler2 as mod
+
+    monkeypatch.setattr(mod, "_CACHE_ROOT", tmp_path)
+    cfg = Ruler2Config(max_seq_length=4096, tokenizer_path="dummy/tok")
+    assert _grader_for(cfg, task) == (eval_type, match_type)
+
+
+@pytest.mark.parametrize("task", ["mk_niah_medium", "mk_niah_hard"])
+def test_ruler2_metrics_matches_upstreams_multichoice_number(tmp_path, monkeypatch, task):
+    """Upstream marks these two ``METRICS_TYPE=multichoice`` (i.e. MathMetrics)
+    while we run all 12 subtasks through ``Ruler2Metrics``. The two publish the
+    same value under different keys -- ``accuracy`` vs ``symbolic_correct`` --
+    which is why vendored ``compute_score`` accepts either. Pin both halves so
+    a future NS bump cannot turn this into a silent scoring difference."""
+    import sgl_eval.evals._ruler2 as mod
+    from sgl_eval._vendored.nemo_skills.dataset.ruler2 import prepare
+    from sgl_eval._vendored.nemo_skills.math_metrics import MathMetrics
+    from sgl_eval._vendored.nemo_skills.ruler2_metrics import Ruler2Metrics
+
+    monkeypatch.setattr(mod, "_CACHE_ROOT", tmp_path)
+    prepare.prepare_task_for_ns(str(tmp_path), task)
+    assert 'METRICS_TYPE = "multichoice"' in (tmp_path / task / "__init__.py").read_text()
+
+    rows = [
+        [{"symbolic_correct": correct, "predicted_answer": "A", "expected_answer": "A"}]
+        for correct in (True, False, True, True, False, True, True)
+    ]
+    ours, upstreams = Ruler2Metrics(), MathMetrics()
+    for row in rows:
+        ours.update(row)
+        upstreams.update(row)
+    assert (
+        ours.get_metrics()["pass@1"]["accuracy"]
+        == upstreams.get_metrics()["pass@1"]["symbolic_correct"]
+    )
+
+
+# --- the stringified-answer regression ------------------------------------
+
+
+def test_pred_schema_keeps_list_expected_answer():
+    """Stringifying a list-valued answer makes ``eval_ruler2`` walk the repr
+    character by character, scoring nearly everything correct."""
+    from sgl_eval.predictions import sample_to_pred
+
+    ex = Example(id="x", inputs={"question": "q"}, target=["alpha", "beta"])
+    pred = sample_to_pred(Sample(text="out"), ex, PRED_SCHEMA)
+    assert pred["expected_answer"] == ["alpha", "beta"]
+    # And the default schema still stringifies, for math/mcq.
+    assert sample_to_pred(Sample(text="out"), ex)["expected_answer"] == "['alpha', 'beta']"
+
+
+def test_pred_schema_omits_the_prompt():
+    """RULER2 prompts are ~500KB; echoing them into output-rs*.jsonl would
+    write hundreds of MB per repeat."""
+    from sgl_eval.predictions import sample_to_pred
+
+    ex = Example(id="x", inputs={"problem": "P" * 1000}, target=["a"])
+    assert sample_to_pred(Sample(text="o"), ex, PRED_SCHEMA)["problem"] == ""
+
+
+def test_stringified_target_would_destroy_the_signal():
+    """Quantifies why PRED_SCHEMA exists. With the default (stringifying)
+    schema, ``eval_ruler2`` iterates the repr's characters, so a wrong answer
+    and the right one land on the SAME score -- the grader stops discriminating
+    while still reporting a plausible-looking number."""
+    from sgl_eval._vendored.nemo_skills.evaluator.ruler import eval_ruler2
+    from sgl_eval.evals._ruler2 import _score_via
+    from sgl_eval.predictions import PredSchema, sample_to_pred
+
+    ex = Example(id="x", inputs={"question": "q"}, target=["4656572173"])
+    right = "The special magic number is 4656572173."
+    wrong = "The special magic number for the key is 1234567890."
+
+    def score(schema, gen):
+        row = {"generation": gen, **sample_to_pred(Sample(text=gen), ex, schema)}
+        return _score_via(lambda c: eval_ruler2({**c, "match_type": "all"}), row)["is_correct"]
+
+    assert score(PRED_SCHEMA, right) == pytest.approx(1.0)
+    assert score(PRED_SCHEMA, wrong) == pytest.approx(0.0)
+    # Stringified: identical scores for a correct and an incorrect answer.
+    assert score(PredSchema(), right) == pytest.approx(score(PredSchema(), wrong))
+
+
+def test_score_one_ruler2_soft_match_is_not_character_wise():
+    """A wrong answer must score 0, not ~1 via per-character substring hits."""
+    score_one = _make_score_one_fn("ruler2", "all")
+    ex = Example(id="x", inputs={"question": "q"}, target=["alpha", "beta"])
+
+    hit, _ = score_one(ex, Sample(text="the answers are alpha and beta"))
+    miss, _ = score_one(ex, Sample(text="zzzzzz"))
+    assert hit == pytest.approx(1.0)
+    assert miss < 0.5
+
+
+def test_score_one_ruler2_partial_credit():
+    """``match_type=all`` averages over the reference list."""
+    score_one = _make_score_one_fn("ruler2", "all")
+    ex = Example(id="x", inputs={"question": "q"}, target=["alpha", "beta"])
+    half, _ = score_one(ex, Sample(text="only alpha here"))
+    assert 0.0 < half < 1.0
+
+
+def test_score_one_multichoice_path():
+    score_one = _make_score_one_fn("multichoice", "")
+    ex = Example(id="x", inputs={"question": "q"}, target="B")
+    good, letter = score_one(ex, Sample(text="The final answer is \\boxed{B}"))
+    bad, _ = score_one(ex, Sample(text="The final answer is \\boxed{C}"))
+    assert good == 1.0 and letter == "B"
+    assert bad == 0.0
+
+
+# --- loader ---------------------------------------------------------------
+
+
+def test_load_task_reads_question_field(tmp_path):
+    """Rows use ``question``, not ``problem`` -- the field the generic loader
+    hardcodes."""
+    path = tmp_path / "test.jsonl"
+    path.write_text(
+        json.dumps({"index": 7, "question": "long ctx", "expected_answer": ["a"], "length": 4000})
+        + "\n"
+    )
+    (ex,) = _load_task(path, "qa_basic", None)
+    assert ex.inputs["question"] == "long ctx"
+    assert ex.target == ["a"]
+    assert ex.id == "qa_basic-7"
+    assert ex.meta["task"] == "qa_basic"
+
+
+def test_load_task_respects_num_examples(tmp_path):
+    path = tmp_path / "test.jsonl"
+    path.write_text(
+        "".join(
+            json.dumps({"index": i, "question": f"q{i}", "expected_answer": ["a"]}) + "\n"
+            for i in range(5)
+        )
+    )
+    assert len(_load_task(path, "qa_basic", 2)) == 2
+
+
+# --- aggregation ----------------------------------------------------------
+
+
+def _results(scores):
+    out = []
+    for i, s in enumerate(scores):
+        ex = Example(id=f"e{i}", inputs={"question": "q"}, target=["a"])
+        out.append(
+            ExampleResult(example=ex, samples=[Sample(text="t")], scores=[s], extracted=["t"])
+        )
+    return out
+
+
+def test_headline_full_group_uses_vendored_compute_score():
+    """All 12 present -> the average comes from vendored ``compute_score``."""
+    per_task = {task: _task_metrics(_results([1.0, 0.0]), 1, "ruler2") for task in ALL_TASKS}
+    flat = _headline(per_task, 1, namespace="setup")
+    assert flat["score"] == pytest.approx(0.5)
+    assert len({k for k in flat if k.startswith("task.")}) == 12
+    assert "partial_group" not in flat
+
+
+def test_headline_subset_is_flagged():
+    """A task subset cannot use ``compute_score`` (it KeyErrors on a partial
+    group), so the local average has to announce itself."""
+    per_task = {
+        "qa_basic": _task_metrics(_results([1.0]), 1, "ruler2"),
+        "qa_easy": _task_metrics(_results([0.0]), 1, "ruler2"),
+    }
+    flat = _headline(per_task, 1, namespace="setup")
+    assert flat["score"] == pytest.approx(0.5)
+    assert flat["partial_group"] == 1.0
+
+
+@pytest.mark.parametrize("completed", [11, 5, 1, 0])
+def test_headline_survives_an_aborted_full_group(completed):
+    """Ctrl-C during a full-group run leaves fewer subtasks than were asked
+    for. Gating on the requested set sent this into vendored ``compute_score``,
+    which raised (KeyError on the first missing task, IndexError when nothing
+    finished) and took the whole partial-metrics dump with it."""
+    per_task = {t: _task_metrics(_results([1.0]), 1, "ruler2") for t in ALL_TASKS[:completed]}
+    flat = _headline(per_task, 1, namespace="setup")
+    assert flat["score"] == pytest.approx(1.0 if completed else 0.0)
+    assert flat["partial_group"] == 1.0
+    assert len({k for k in flat if k.startswith("task.")}) == completed
+
+
+def test_task_metrics_accepts_float_scores():
+    """RULER2 scores are floats; ``Ruler2Metrics`` must not binarize them."""
+    raw = _task_metrics(_results([0.25, 0.75]), 1, "ruler2")
+    assert raw["pass@1"]["accuracy"] == pytest.approx(50.0)
+
+
+# --- config ---------------------------------------------------------------
+
+
+def test_seq_len_reaches_prepare_unchanged(tmp_path, monkeypatch):
+    """NS口径: ``seq_len`` is the dataset definition and must be handed to the
+    vendored generator verbatim. sgl-eval adds no knob that shrinks it -- doing
+    so would make our numbers incomparable with any published RULER2 result."""
+    import sgl_eval.evals._ruler2 as mod
+
+    monkeypatch.setattr(mod, "_CACHE_ROOT", tmp_path)
+    seen = {}
+
+    def fake_prepare(out_folder, tok_type, tok_path, seq_len, size):
+        seen.update(seq_len=seq_len, size=size, tok_type=tok_type, tok_path=tok_path)
+        Path(out_folder).mkdir(parents=True, exist_ok=True)
+        (Path(out_folder) / "test.jsonl").write_text(
+            json.dumps({"index": 0, "question": "q", "expected_answer": ["a"]}) + "\n"
+        )
+
+    monkeypatch.setattr(mod._prepare, "prepare_qa_basic", fake_prepare)
+    cfg = Ruler2Config(max_seq_length=131072, tokenizer_path="some/tok", dataset_size=100)
+    mod._ensure_task_data(cfg, "qa_basic")
+    assert seen == {
+        "seq_len": 131072,
+        "size": 100,
+        "tok_type": "hf",
+        "tok_path": "some/tok",
+    }
+
+
+def test_setup_slug_separates_every_generation_input():
+    base = Ruler2Config(max_seq_length=4096, tokenizer_path="a/b")
+    variants = [
+        Ruler2Config(max_seq_length=8192, tokenizer_path="a/b"),
+        Ruler2Config(max_seq_length=4096, tokenizer_path="c/d"),
+        Ruler2Config(max_seq_length=4096, tokenizer_path="a/b", dataset_size=50),
+    ]
+    slugs = {base.setup_slug} | {v.setup_slug for v in variants}
+    assert len(slugs) == 4
+    assert "/" not in base.setup_slug
+
+
+def test_from_bench_args_requires_seq_len():
+    with pytest.raises(SystemExit):
+        Ruler2Config.from_bench_args({}, model="m")
+
+
+def test_from_bench_args_defaults_tokenizer_to_model():
+    cfg = Ruler2Config.from_bench_args({"seq_len": "8192"}, model="Qwen/Qwen3-8B")
+    assert cfg.tokenizer_path == "Qwen/Qwen3-8B"
+    assert cfg.tasks == ALL_TASKS
+
+
+def test_from_bench_args_rejects_unknown_keys():
+    with pytest.raises(SystemExit):
+        Ruler2Config.from_bench_args({"seq_len": "8192", "nope": "1"}, model="m")
+
+
+def test_from_bench_args_rejects_unknown_task():
+    with pytest.raises(SystemExit):
+        Ruler2Config.from_bench_args({"seq_len": "8192", "tasks": "qa_basic,bogus"}, model="m")
+
+
+def test_from_bench_args_rejects_gemini_tokenizer():
+    """``GeminiTokenizer`` is dropped from the vendored slice, so selecting it
+    would NameError deep inside generation."""
+    with pytest.raises(SystemExit):
+        Ruler2Config.from_bench_args({"seq_len": "8192", "tokenizer_type": "gemini"}, model="m")
+
+
+def test_from_bench_args_rejects_headroom_knob():
+    """``headroom`` was removed on purpose: it shrank the dataset and made our
+    scores incomparable with NeMo-Skills. Rejecting it loudly beats silently
+    ignoring a flag someone copied from an older invocation."""
+    with pytest.raises(SystemExit):
+        Ruler2Config.from_bench_args({"seq_len": "8192", "headroom": "512"}, model="m")
+
+
+# --- preflight ------------------------------------------------------------
+
+
+class _StubClient:
+    def __init__(self, url):
+        self.base_url = url
+
+
+class _StubSampler:
+    model = "m"
+
+    def __init__(self, url="http://host:30000/v1"):
+        self.client = _StubClient(url)
+
+
+def _stub_model_info(monkeypatch, payload):
+    import httpx
+
+    class _Resp:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return payload
+
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: _Resp())
+
+
+def test_preflight_requires_room_for_the_answer(monkeypatch, capsys):
+    """A window exactly equal to seq_len leaves nothing to generate when
+    max_tokens is None -- every sample comes back empty and scores 0."""
+    from sgl_eval.evals._ruler2 import _preflight_context_length
+
+    _stub_model_info(monkeypatch, {"max_context_length": 131072})
+    with pytest.raises(SystemExit):
+        _preflight_context_length(
+            _StubSampler(),
+            Ruler2Config(max_seq_length=131072, tokenizer_path="t"),
+            GenConfig(),
+        )
+
+
+def test_preflight_passes_with_headroom_in_the_window(monkeypatch, capsys):
+    from sgl_eval.evals._ruler2 import _preflight_context_length
+
+    _stub_model_info(monkeypatch, {"max_context_length": 262144})
+    _preflight_context_length(
+        _StubSampler(),
+        Ruler2Config(max_seq_length=131072, tokenizer_path="t"),
+        GenConfig(),
+    )
+    assert "Preflight" in capsys.readouterr().out
+
+
+def test_preflight_uses_explicit_max_tokens_as_the_budget(monkeypatch):
+    """With --max-tokens given, that is the room the window must have."""
+    from sgl_eval.evals._ruler2 import _preflight_context_length
+
+    _stub_model_info(monkeypatch, {"max_context_length": 5000})
+    cfg = Ruler2Config(max_seq_length=4096, tokenizer_path="t")
+    # 4096 + 512 default budget fits in 5000.
+    _preflight_context_length(_StubSampler(), cfg, GenConfig())
+    # 4096 + 2048 does not.
+    with pytest.raises(SystemExit):
+        _preflight_context_length(_StubSampler(), cfg, GenConfig(max_tokens=2048))
+
+
+def test_preflight_warns_when_limit_unreadable(monkeypatch, capsys):
+    """Refusing to run against an endpoint we cannot introspect would be worse
+    than warning."""
+    from sgl_eval.evals._ruler2 import _preflight_context_length
+
+    _stub_model_info(monkeypatch, {})
+    _preflight_context_length(
+        _StubSampler(), Ruler2Config(max_seq_length=4096, tokenizer_path="t"), GenConfig()
+    )
+    assert "WARNING" in capsys.readouterr().err
+
+
+# --- refresh --------------------------------------------------------------
+
+
+def _ruler2_row(task: str, index: int, score: float) -> dict:
+    return {
+        "generation": "g",
+        "id": f"{task}-{index}",
+        "expected_answer": ["a"],
+        "num_generated_tokens": 5,
+        "num_reasoning_tokens": 0,
+        "num_answer_tokens": 5,
+        "finish_reason": "stop",
+        "problem": "",
+        "predicted_answer": "g",
+        "is_correct": score,
+    }
+
+
+def test_refresh_rebuilds_the_group_headline(tmp_path):
+    """``sgl-eval refresh`` read a hardcoded ``symbolic_correct`` and had no
+    group branch, so a ruler2 run refreshed to 0.00% -- overwriting the real
+    metrics.json. Uneven subtask counts here separate the two failures: the
+    sample-level mean is 0.25, the mean-of-subtask-means is 0.50.
+    """
+    from types import SimpleNamespace
+
+    from sgl_eval.pipeline.refresh import cmd_refresh
+
+    run_dir = tmp_path / "sgl_eval_ruler2_20260731-120000"
+    run_dir.mkdir()
+    rows = [_ruler2_row("qa_basic", 0, 1.0)] + [_ruler2_row("qa_easy", i, 0.0) for i in range(3)]
+    with (run_dir / "output-rs0.jsonl").open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+    assert cmd_refresh(SimpleNamespace(run_dir=str(run_dir))) == 0
+
+    agg = json.loads((run_dir / "metrics.json").read_text())["aggregate"]
+    assert agg["score"] == pytest.approx(0.5)
+    assert agg["task.qa_basic"] == pytest.approx(1.0)
+    assert agg["task.qa_easy"] == pytest.approx(0.0)
+    assert agg["partial_group"] == 1.0
+
+
+def test_refresh_rejects_unattributable_ids(tmp_path):
+    """Ids that do not name a subtask cannot be grouped; guessing a headline
+    from them would report a plausible number for the wrong denominator."""
+    from types import SimpleNamespace
+
+    from sgl_eval.pipeline.refresh import cmd_refresh
+
+    run_dir = tmp_path / "sgl_eval_ruler2_20260731-120000"
+    run_dir.mkdir()
+    with (run_dir / "output-rs0.jsonl").open("w", encoding="utf-8") as f:
+        f.write(json.dumps(_ruler2_row("not_a_task", 0, 1.0)) + "\n")
+
+    with pytest.raises(SystemExit):
+        cmd_refresh(SimpleNamespace(run_dir=str(run_dir)))


### PR DESCRIPTION
## Summary
- Add `ruler2`: 12 synthetic long-context subtasks, scored separately and averaged by upstream's own `compute_score`
- Its dataset is generated per `(tokenizer, seq_len, dataset_size)` rather than downloaded, so it requires `--bench-arg seq_len=N` and caches under `~/.cache/sgl_eval/ruler2/<setup>/`

## Vendored
- `dataset/ruler2/`: `prepare.py`, the three generators, `tokenizer.py` (Gemini tokenizer dropped -- it needs an API key), `ruler2_score.py`
- `evaluator/ruler.py` (`eval_ruler2`), `metrics/ruler2_metrics.py`, `prompt/config/generic/default.yaml`
- One import rewrite for the dotted prefix `nemo_skills.dataset.ruler2.`: `prepare.py` spawns its siblings as `python -m` module paths, which the audit regex cannot see as imports
- Each subtask's grader is read back from vendored `prepare_task_for_ns` rather than mirrored here

## Plumbing
- `--bench-arg KEY=VALUE` (repeatable), recorded in `metrics.json` -- a generated dataset is identified by nothing else
- `EvalSpec.default_num_threads`, lowered to 4 for ruler2: the runner caps in-flight requests, not tokens, so 64 x 128k would be ~8M tokens in flight
- `EvalSpec.pred_schema` / `PredSchema`: keeps a list-valued answer unstringified, skips echoing the ~500KB prompt, writes the float `is_correct`
- Per-subtask rows in the summary, plus a `PARTIAL` marker when the group is incomplete

## Failure modes this closes
- Preflight refuses to start unless the endpoint's context length covers `seq_len` plus room to answer; both under-sized cases otherwise finish with all-zero metrics and exit code 0
- Stringifying the answer made `eval_ruler2` walk the repr character by character, scoring a wrong answer the same as a right one (`test_stringified_target_would_destroy_the_signal` pins the gap)
- Ctrl-C mid-run still dumps partial metrics: the group headline gates on the subtasks that completed, not the ones requested (vendored `compute_score` raises on a gap)
- `sgl-eval refresh` handles the group -- reads the score field from the spec's `PredSchema` and rebuilds per-subtask means, instead of scoring every row 0 and overwriting a correct `metrics.json`

## Deps
- `editdistance` into core: vendored `evaluator/ruler.py` imports it at module level
- New `longcontext` extra (`transformers`, `nltk`, `wonderwords`, `inflect`), needed only to generate a dataset -- scoring an existing one needs core alone

Stacks on #25.
