### PR TITLE
Split per-benchmark docs into `benchmarks.md` and slim the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,18 @@ sgl-eval ping --base-url http://localhost:30000/v1
 sgl-eval run gsm8k --base-url http://localhost:30000/v1 --num-examples 50
 ```
 
+Four subcommands: `run`, `list`, `ping`, `preset`. `sgl-eval run --help` is
+the full flag reference -- endpoint, sampling overrides (`--temperature`,
+`--seed`, `--thinking`, ...), and any flags the benchmark itself adds.
+
 ---
 
-## Usage
+## Reading a run
 
-Three subcommands: `list`, `ping`, `run <name>`. See `sgl-eval --help` for
-flags.
-
-Each run prints a summary with the headline metric on top -- single-shot
-accuracy, averaged across the `k` repeats when `k > 1` -- and writes the
-full payload as JSON under `--out-dir`. For example:
+Each run prints the headline metric first -- single-shot accuracy, averaged
+across the `k` repeats when `k > 1` -- and writes the same payload plus
+provenance (model, endpoint, sampling config, vendored NS commit) as
+`metrics.json` under `--out-dir`.
 
 ```
 == aime25 ==
@@ -41,63 +43,39 @@ full payload as JSON under `--out-dir`. For example:
   no_answer          =  20.00%  [warn: consider --max-tokens]
 ```
 
----
-
-## Partial runs & subsetting
-
-A run doesn't have to cover the full dataset, finish to completion, or even
-use the vendored questions. Three mechanisms:
-
-### Subsetting -- `--num-examples N`
-
-Run only the first `N` examples (smoke tests, quick sanity checks). Omit it
-(or set `num_examples: null` in a preset) to run the full set.
-
-```bash
-sgl-eval run aime25 --base-url http://localhost:30000/v1 --num-examples 5
-```
-
-### Early stop -- `Ctrl-C`
-
-A run can be stopped early without losing scored work:
-
-- **First `Ctrl-C`** -- kills in-flight requests, dumps everything scored
-  so far, writes `metrics.json` flagged `partial: true`, and exits `130`.
-- **Second `Ctrl-C`** -- hard-exit (escape hatch if cleanup hangs).
-
-Either way the per-sample record survives: every run streams predictions to
-`<out-dir>/sgl_eval_<name>_<stamp>/output-rs*.jsonl` as they are scored
-(disable with `--no-dump-predictions`).
-
-The score printed for a partial run is whatever the completed samples say --
-read it as a sanity signal, not a result. `metrics.json` records `partial:
-true` plus how much ran, so a half-run can't later be mistaken for a full one.
-The preset `expected_vs_actual` comparison is skipped (a half-run isn't
-comparable to a baseline).
-
-```
-[partial] 240 / 480 samples completed (of 30 examples x 16)
-[partial] expected_vs_actual skipped (partial runs aren't comparable to baselines).
-```
-
-The progress bar carries a live accuracy while the run is going, which is
-usually the point: watch it, decide, stop.
+While the run is going, the progress bar carries a live accuracy. For a
+sanity check that is usually the whole point: watch it, decide, stop.
 
 ```
 gsm8k:  34%|###4      | 452/1319 [02:11<04:12, 3.4it/s, acc=81.42%]
 ```
 
-### Custom dataset -- `--from-dataset <path>`
-
-Replace the vendored dataset for one run with your own NS-shape JSONL
-(`{id?, problem, expected_answer}`, one object per line). Only the
-questions change -- scoring still goes through the vendored grader.
-
-```bash
-sgl-eval run aime25 --base-url http://localhost:30000/v1 --from-dataset ./my_problems.jsonl
-```
+Every scored sample is streamed to
+`<out-dir>/sgl_eval_<name>_<stamp>/output-rs*.jsonl` as it lands (disable
+with `--no-dump-predictions`), so the per-sample record survives however the
+run ends.
 
 ---
+
+## Running less than the whole thing
+
+- **`--num-examples N`** -- only the first `N` examples.
+- **`Ctrl-C`** -- kills in-flight requests, keeps everything already scored,
+  and writes `metrics.json` flagged `partial: true` with how much ran, so a
+  half-run can't later be mistaken for a full one. Exits `130`; a second
+  `Ctrl-C` hard-exits if cleanup hangs. The preset `expected_vs_actual`
+  comparison is skipped -- a half-run isn't comparable to a baseline.
+- **`--from-dataset <path>`** -- swap in your own NS-shape JSONL
+  (`{id?, problem, expected_answer}`) for one run. Only the questions
+  change; scoring still goes through the vendored grader.
+
+---
+
+## Benchmarks
+
+`sgl-eval list` for the registered set, `sgl-eval list -v` for each one's
+defaults. See [`benchmarks.md`](benchmarks.md) for the ones that need more
+than an endpoint (today: `ruler2`), and for how to match a NeMo-Skills run.
 
 ## Presets
 
@@ -105,94 +83,6 @@ Save a `(benchmark, endpoint, sampling, n_repeats, expected)` bundle to
 `~/.sgl_eval/presets/<name>.yaml` and replay with `sgl-eval run --preset
 <name>`. See [`preset.md`](preset.md) for schema, example, usage, and
 override priority.
-
----
-
-## Supported benchmarks
-
-`sgl-eval list` for the registered set; `sgl-eval list -v` for per-benchmark
-defaults (`n_repeats`, `thinking`, sampling params). All scoring behavior
-(prompt, answer extraction, grading, pass@k / majority@k aggregation) comes
-from the vendored NeMo-Skills slice.
-
-### RULER2 -- long context
-
-`ruler2` is a **group** of 12 synthetic subtasks (`mk_niah_*`, `mv_niah_*`,
-`qa_*`), averaged into one headline by upstream's own
-`ruler2_score.compute_score`. It differs from every other benchmark in three
-ways worth knowing before the first run:
-
-```bash
-pip install 'sgl-eval[longcontext]'      # transformers, nltk, wonderwords, inflect
-
-sgl-eval run ruler2 --base-url http://localhost:30000/v1 \
-  --ruler2-seq-len 131072
-```
-
-**1. The dataset is generated, not downloaded.** It is bound to a tokenizer and
-a target length, so the cache key is `(tokenizer, seq_len, dataset_size)` under
-`~/.cache/sgl_eval/ruler2/<setup>/`. First build of a 128k setup takes tens of
-minutes and lands ~600 MB; later runs reuse it.
-
-| flag | default | meaning |
-|---|---|---|
-| `--ruler2-seq-len` | **required** | target context length; no default because the data is per-length |
-| `--ruler2-tokenizer` | the served model id | HF repo id or local path used to size samples |
-| `--ruler2-tokenizer-type` | `hf` | `hf` or `openai` (tiktoken) |
-| `--ruler2-dataset-size` | `100` | samples per subtask |
-| `--ruler2-tasks` | all 12 | space-separated subset; headline is flagged `task_subset` |
-
-`sgl-eval run --help` lists them under `ruler2 options`. They go straight to the
-vendored generator, whose own `random_seed` is fixed at 42 -- so a given config
-reproduces NeMo-Skills' dataset byte for byte. There is deliberately **no knob
-that shrinks `seq_len`**: it defines the dataset and therefore the score, which
-puts it under the vendoring rule. The chosen values are recorded in
-`metrics.json` so a result always names its setup.
-
-**2. The window must hold prompt *plus* answer.** Prompts are sized with the
-raw tokenizer, but requests go through `/v1/chat/completions`, where the server
-prepends a chat template. And with `max_tokens` unset, a window exactly equal to
-`seq_len` leaves zero room to generate. Both failures are silent -- the sampler
-turns them into empty samples scoring 0, so the run finishes with all-zero
-metrics and a successful exit code. sgl-eval therefore queries the endpoint's
-context length up front and **refuses to start** unless it is at least
-`seq_len + max_tokens` (or `seq_len + 512` when `max_tokens` is unset). RULER2 is
-meant to be swept over lengths *below* the window, so pick `seq_len` accordingly
-rather than matching it to the window.
-
-**3. Concurrency defaults to 4, not 64.** The runner limits in-flight
-*requests*, not tokens; 64 concurrent 128k prompts would put ~8M tokens in
-flight. Override with `--num-threads` if the server can take it. Note that batch
-composition affects generation numerics, so `num_threads` is part of what a
-result is bound to -- it is recorded in `metrics.json`.
-
-### Matching a NeMo-Skills run
-
-Same vendored generator, prompt (`generic/default` is a bare `{question}`
-passthrough), endpoint type (`chat`), grader, and aggregator. Sampling lines up
-field for field with NS's `InferenceConfig` -- including `min_p=0.0` and
-`repetition_penalty=1.0`, which are sent explicitly rather than left to the
-served model's `generation_config.json`. One knob differs: NS sends `seed=0`,
-sgl-eval sends none unless asked, so add `--seed 0` for an exact match. It has
-no effect at `temperature=0`.
-
-Three values are yours to align, because they define the dataset rather than
-the request: pass the same `--ruler2-tokenizer` NS was given (sgl-eval
-otherwise defaults to the served model id), the same `seq_len` (the official
-RULER2 sweep picks it explicitly, e.g. `1048576 - 768` to reserve room to
-answer), and the same `dataset_size`. `--num-examples` is *not* a substitute for
-`dataset_size`: it slices the generated file (NS's `++max_samples`), it does not
-change what gets generated.
-
-Output shows the headline plus a per-subtask breakdown, which is what tells you
-*which* capability degraded:
-
-```
-* score        =  62.41%
-    mk_niah_basic  =  91.00%
-    qa_hard        =  28.50%
-    ...
-```
 
 ---
 
@@ -224,43 +114,21 @@ pytest                             # upstream's own tests run against the
                                    # new slice -- catches behavior drift
 ```
 
----
-
-## Roadmap
-
-- **Replace the accuracy-eval surface in `sgl-project/sglang`.** Today
-  `sglang.test.run_eval` + assorted per-test ad-hoc harnesses do this
-  job. sgl-eval aims to be the single client SGLang's CI calls.
-- **More benchmarks within `math` and `multichoice`** (MATH-500, AIME26,
-  MMLU-Pro, GPQA-extended, ...). Each is one row in `_registry.py:_TABLE`.
-- **New metrics types** (require a new runner per category, but graders
-  are usually already in NeMo-Skills):
-  - `long_context`: LongBench V2, MRCR (RULER2 is in -- see below)
-  - `code`: HumanEval, MBPP, LiveCodeBench (with execution sandbox)
-  - `instruction_following`: IFEval, IFBench
-  - `multimodal` (VLM): MMMU, MathVista (needs an image-aware sampler)
-  - `agentic` / tool use: BFCL, Tau-Bench
-- **More vendor sources** beyond NeMo-Skills, when their slice is the
-  best canonical implementation: `lm-evaluation-harness`, `lmms-eval`,
-  `openai/simple-evals`. Same `_vendored/<source>/` + `SOURCES.yaml`
-  pattern.
-- **LLM-as-judge benchmarks** (Arena-Hard, MTBench). Needs a second
-  judge endpoint and prompt-pair handling -- a real architectural
-  addition, not just a benchmark row.
-- **Regression CI infra**: publish per-run metrics to a `sgl-eval-data`
-  repo, compare against rolling baselines, fail PRs on regression.
+Adding a benchmark inside an existing category (`math`, `multichoice`) is one
+row in `_registry.py:_TABLE`. A new category needs a runner alongside it --
+graders are usually already in NeMo-Skills.
 
 ---
 
-## Out of scope
+## Scope
 
-- **Performance benchmarking.** Latency, throughput, scheduling. Lives
-  in SGLang's `bench_serving.py`. sgl-eval records `latency` /
-  `output_throughput` only as side metrics, never as the headline.
-- **Model training or fine-tuning.**
-- **Multi-server orchestration.** Each invocation targets one
-  OpenAI-compatible endpoint.
-- **Browser / OS-level agent loops** (full BrowseComp-style sandboxing).
+The goal is to be the single accuracy-eval client SGLang's CI calls, in place
+of `sglang.test.run_eval` and the assorted per-test harnesses.
+
+Not in scope: performance benchmarking (latency / throughput / scheduling --
+that is SGLang's `bench_serving.py`; sgl-eval records them only as side
+metrics, never as the headline), training or fine-tuning, multi-server
+orchestration (one endpoint per invocation), and OS-level agent loops.
 
 ---
 

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -1,0 +1,99 @@
+# Benchmarks
+
+`sgl-eval list` prints the registered set; `sgl-eval list -v` prints each
+one's defaults (`n_repeats`, `thinking`, sampling params). Those are the
+source of truth -- this file does not repeat them.
+
+What follows is only what a benchmark needs **beyond** pointing sgl-eval at
+an endpoint. Most need nothing.
+
+| benchmark | category | notes |
+|---|---|---|
+| `gsm8k` | math | -- |
+| `aime24/25/26` | math | one per contest year, same shape |
+| `mmlu` | multichoice | -- |
+| `gpqa` | multichoice | Diamond split |
+| `mmmu_pro` | multichoice | vision-dependent; the endpoint must serve a VLM |
+| `ruler2` | ruler2 | extra install, a required flag, generated data -- [see below](#ruler2) |
+
+All scoring behavior (prompt, answer extraction, grading, pass@k /
+majority@k aggregation) comes from the vendored NeMo-Skills slice, whatever
+the benchmark.
+
+---
+
+## Matching a NeMo-Skills run
+
+Sampling lines up with NS's `InferenceConfig` field for field, including
+`min_p=0.0` and `repetition_penalty=1.0` -- sent explicitly rather than left
+to the served model's `generation_config.json`, which would otherwise decide
+them.
+
+One knob differs: NS sends `seed=0`, sgl-eval sends none unless asked. Add
+`--seed 0` to match. It has no effect at `temperature=0`.
+
+---
+
+## ruler2
+
+A **group** of 12 synthetic long-context subtasks (`mk_niah_*`, `mv_niah_*`,
+`qa_*`), averaged into one headline by upstream's own
+`ruler2_score.compute_score`.
+
+```bash
+pip install 'sgl-eval[longcontext]'      # transformers, nltk, wonderwords, inflect
+
+sgl-eval run ruler2 --base-url http://localhost:30000/v1 \
+  --ruler2-seq-len 131072
+```
+
+Output is the headline plus a per-subtask breakdown, which is what tells you
+*which* capability degraded:
+
+```
+* score        =  62.41%
+    mk_niah_basic  =  91.00%
+    qa_hard        =  28.50%
+    ...
+```
+
+`sgl-eval run --help` lists the `--ruler2-*` flags under `ruler2 options`.
+Three things about them are not obvious from the help text:
+
+**The dataset is generated, not downloaded.** It is bound to a tokenizer and
+a target length, so the cache key is `(tokenizer, seq_len, dataset_size)`
+under `~/.cache/sgl_eval/ruler2/<setup>/`. First build of a 128k setup takes
+tens of minutes and lands ~600 MB; later runs reuse it. Generation runs the
+vendored scripts with upstream's fixed `random_seed=42`, so a given config
+reproduces NeMo-Skills' dataset byte for byte. There is deliberately **no
+knob that shrinks `seq_len`**: it defines the dataset and therefore the
+score, which puts it under the vendoring rule.
+
+**The window must hold prompt *plus* answer.** Prompts are sized with the raw
+tokenizer, but requests go through `/v1/chat/completions`, where the server
+prepends a chat template; and with `max_tokens` unset, a window exactly equal
+to `seq_len` leaves zero room to generate. Both failures are silent -- empty
+samples score 0, so the run would finish with all-zero metrics and a
+successful exit code. sgl-eval therefore reads the endpoint's context length
+up front and **refuses to start** below `seq_len + max_tokens` (or
+`seq_len + 512` when `max_tokens` is unset). RULER2 is meant to be swept over
+lengths *below* the window, so pick `seq_len` accordingly rather than
+matching it to the window.
+
+**Concurrency defaults to 4, not 64.** The runner limits in-flight
+*requests*, not tokens; 64 concurrent 128k prompts would put ~8M tokens in
+flight. Raise it with `--num-threads` if the server can take it -- batch
+composition affects generation numerics, so the value is recorded in
+`metrics.json` as part of what the result is bound to.
+
+### Matching an NS ruler2 run specifically
+
+Three values define the dataset rather than the request, so they are yours to
+align: the same `--ruler2-tokenizer` (sgl-eval otherwise defaults to the
+served model id), the same `--ruler2-seq-len` (the official sweep picks it
+explicitly, e.g. `1048576 - 768` to reserve room to answer), and the same
+`--ruler2-dataset-size`.
+
+`--num-examples` is *not* a substitute for `--ruler2-dataset-size`: it slices
+the generated file (NS's `++max_samples`), it does not change what gets
+generated.


### PR DESCRIPTION
The README had grown to 270 lines, 85 of which documented one benchmark out of eight. Now 138, with per-benchmark material in `benchmarks.md` (same pattern as `preset.md`).

- Move the RULER2 section and the NeMo-Skills alignment notes into `benchmarks.md`, which opens with a table of all eight. Seven of them need nothing beyond an endpoint, so only `ruler2` gets a section -- one file rather than eight stubs.
- Drop the `--ruler2-*` flag table: it duplicated `sgl-eval run --help` verbatim since those options moved into argparse. What is left is what the help text cannot say -- why the dataset is generated per `(tokenizer, seq_len, dataset_size)`, why the preflight refuses to start, why concurrency defaults to 4.
- Fold the three "less than a whole run" mechanisms (`--num-examples`, `Ctrl-C`, `--from-dataset`) into one section; the Ctrl-C part was still written for the score-bounds reporting removed in #27.
- Replace Roadmap + Out of scope with a shorter `Scope`. Both listed `aime26` and RULER2 as upcoming, though both have shipped.
- Neither file restates `n_repeats` / `thinking` / sampling defaults -- `sgl-eval list -v` prints them, and a second copy would drift.
