### PR TITLE
Add `mmmu_pro_vision` (upstream MMMU-Pro `vision` config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ sgl_eval/_vendored/nemo_skills/dataset/gsm8k/original_*.jsonl
 sgl_eval/_vendored/nemo_skills/dataset/mmlu/test.jsonl
 sgl_eval/_vendored/nemo_skills/dataset/mmlu/data.tar
 sgl_eval/_vendored/nemo_skills/dataset/gpqa/*.jsonl
+sgl_eval/_vendored/nemo_skills/dataset/mmmu_pro_vision/*.jsonl
+sgl_eval/_vendored/nemo_skills/dataset/mmmu_pro_vision/images/
 
 /preset_config/

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -83,13 +83,12 @@ Verified equivalent to `ns eval --benchmarks=mmmu-pro`: same prepared
 concurrency pinned to 1 on both sides, byte-identical generations and the same
 score question by question.
 
-> Concurrency is not score-neutral in practice even though it should be. Two
-> back-to-back greedy runs of this benchmark at `--num-threads 64` differed on
-> ~half the raw generations and landed 7 points apart on 100 questions --
-> batch composition shifts kernel selection, which flips argmax on questions
-> the model is unsure about. That run-to-run spread dwarfs any harness
-> difference, so treat a single concurrent run as a noisy estimate and pin
-> concurrency to 1 when a run has to be reproducible.
+> Concurrency should be score-neutral but is not: two back-to-back greedy runs
+> at `--num-threads 64` differed on ~half the raw generations and landed 7
+> points apart on 100 questions, because batch composition shifts kernel
+> selection and flips argmax wherever the model is unsure. That spread dwarfs
+> any harness difference -- treat a single concurrent run as a noisy estimate,
+> and pin concurrency to 1 when a number has to be reproducible.
 
 One difference has no sgl-eval equivalent: NS can mark an answer incorrect
 when its token count exceeds a `max_seq_len` threshold. Nothing sets it in

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -13,7 +13,8 @@ an endpoint. Most need nothing.
 | `aime24/25/26` | math | one per contest year, same shape |
 | `mmlu` | multichoice | -- |
 | `gpqa` | multichoice | Diamond split |
-| `mmmu_pro` | multichoice | vision-dependent; the endpoint must serve a VLM |
+| `mmmu_pro` | multichoice | VLM endpoint; MMMU-Pro `standard (10 options)` -- [see below](#mmmu-pro-variants) |
+| `mmmu_pro_vision` | multichoice | VLM endpoint; MMMU-Pro `vision` -- [see below](#mmmu-pro-variants) |
 | `ruler2` | ruler2 | extra install, a required flag, generated data -- [see below](#ruler2) |
 
 All scoring behavior (prompt, answer extraction, grading, pass@k /
@@ -29,8 +30,70 @@ Sampling lines up with NS's `InferenceConfig` field for field, including
 to the served model's `generation_config.json`, which would otherwise decide
 them.
 
-One knob differs: NS sends `seed=0`, sgl-eval sends none unless asked. Add
-`--seed 0` to match. It has no effect at `temperature=0`.
+Two knobs differ.
+
+**`seed`**: NS sends `seed=0`, sgl-eval sends none unless asked. Add `--seed 0`
+to match. It has no effect at `temperature=0`.
+
+**`temperature`, if the NS run went through `ns eval`**: that pipeline does
+*not* use `InferenceConfig`'s `temperature=0.0`. The repeat suffix on
+`--benchmarks` decides it -- `<bench>` and `<bench>:0` mean greedy, but
+`<bench>:1` and above default to **`temperature=0.7`**. So a harness building
+its spec as `f"{bench}:{repeats}"` gets 0.7 even when it means "run once",
+and sgl-eval's greedy default will not reproduce it. Pass
+`--temperature 0.7 --seed 0` to match such a run, or re-baseline against
+greedy.
+
+---
+
+## MMMU-Pro variants
+
+MMMU-Pro ships several HuggingFace configs. Two are registered, and they are
+**different tasks -- their scores are not comparable**:
+
+| | `mmmu_pro` | `mmmu_pro_vision` |
+|---|---|---|
+| HF config | `standard (10 options)` | `vision` |
+| question text | in the prompt | rendered into the screenshot |
+| options | up to 10, as text | in the screenshot (and echoed as text) |
+| images per question | `<image 1..7>`, placed inline | one screenshot, placed first |
+| prompt | sgl-eval's `mcq-10choices`, asks for CoT | vendored `vlm/mmmu-pro`, no CoT |
+
+`mmmu_pro_vision` is the one upstream NeMo-Skills ships, so it is the row to
+use when reproducing an NS number or an `ns eval --benchmarks=mmmu-pro` run.
+Upstream has no `standard (10 options)` module, which is why `mmmu_pro` keeps
+an sgl-eval-own loader and prompt.
+
+Picking the row is not sufficient on its own -- sgl-eval's defaults are
+greedy and let the endpoint pick `max_tokens`, so both have to be passed
+explicitly to match an `ns eval` run (see the `temperature` note
+[above](#matching-a-nemo-skills-run) for why 0.7 rather than 0.0):
+
+```bash
+sgl-eval run mmmu_pro_vision --base-url ... \
+    --max-tokens 32768 --temperature 0.7 --seed 0 --num-threads 512
+```
+
+`--num-threads` only affects wall-clock, not the expected score -- the
+registered default is 64, NS's own runs use 512. Add `--num-examples N` if the
+run being matched capped its sample count.
+
+Verified equivalent to `ns eval --benchmarks=mmmu-pro`: same prepared
+`test.jsonl` (identical md5), byte-identical rendered messages, and with
+concurrency pinned to 1 on both sides, byte-identical generations and the same
+score question by question.
+
+> Concurrency is not score-neutral in practice even though it should be. Two
+> back-to-back greedy runs of this benchmark at `--num-threads 64` differed on
+> ~half the raw generations and landed 7 points apart on 100 questions --
+> batch composition shifts kernel selection, which flips argmax on questions
+> the model is unsure about. That run-to-run spread dwarfs any harness
+> difference, so treat a single concurrent run as a noisy estimate and pin
+> concurrency to 1 when a run has to be reproducible.
+
+One difference has no sgl-eval equivalent: NS can mark an answer incorrect
+when its token count exceeds a `max_seq_len` threshold. Nothing sets it in
+the sglang harness, so it does not affect a comparison today.
 
 ---
 

--- a/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
+++ b/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
@@ -114,6 +114,18 @@ files:
     dst: dataset/gpqa/__init__.py
   - src: nemo_skills/dataset/gpqa/prepare.py
     dst: dataset/gpqa/prepare.py
+  # MMMU-Pro `vision` config: the whole question, options included, is
+  # rendered into one screenshot, so `prepare.py` builds `problem` from the
+  # options alone and writes a sidecar `images/` dir referenced by
+  # `image_path`. Upstream's dir is `mmmu-pro`; `dst` uses underscores
+  # because `_resolve_upstream_metadata` imports it as a Python module and a
+  # hyphen is not a legal module name. The name also has to say `vision` --
+  # sgl-eval's own `mmmu_pro` benchmark evaluates the `standard (10 options)`
+  # config, which upstream does not ship.
+  - src: nemo_skills/dataset/mmmu-pro/__init__.py
+    dst: dataset/mmmu_pro_vision/__init__.py
+  - src: nemo_skills/dataset/mmmu-pro/prepare.py
+    dst: dataset/mmmu_pro_vision/prepare.py
 
   # --- RULER2 (synthetic long-context; generated per tokenizer + seq length) ---
   # Upstream ships no test split for this one: `__init__.py` is just
@@ -153,6 +165,12 @@ files:
   # long context is already assembled by the prepare scripts.
   - src: nemo_skills/prompt/config/generic/default.yaml
     dst: prompts/default.yaml
+  # mmmu_pro_vision's ++prompt_config (`vlm/mmmu-pro`). The `dst` basename
+  # must stay hyphenated: `_resolve_upstream_metadata` derives it from
+  # GENERATION_ARGS via `prompt_config.split("/")[-1]`. Carries
+  # `image_position: before`, which `_prompts.prompt_media_config` reads.
+  - src: nemo_skills/prompt/config/vlm/mmmu-pro.yaml
+    dst: prompts/mmmu-pro.yaml
 
   # --- upstream's own behavior tests ---
   # Run as part of `pytest`. These are NS's canonical regression cases,

--- a/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
+++ b/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
@@ -23,6 +23,7 @@ pinned_deps:
   numpy: ""                     # upstream pin: unversioned
   tqdm: ""                      # upstream pin: unversioned (used by evaluator/base.py)
   editdistance: ""              # upstream pin: unversioned (evaluator/ruler.py WER)
+  datasets: ""                  # upstream pin: unversioned (every dataset/*/prepare.py)
   # RULER2 dataset generation only. Kept out of the core install because
   # nothing else needs them and `transformers` is heavy -- they live in the
   # `longcontext` extra. All four are imported by dataset/ruler2/prepare_*.py;
@@ -114,14 +115,10 @@ files:
     dst: dataset/gpqa/__init__.py
   - src: nemo_skills/dataset/gpqa/prepare.py
     dst: dataset/gpqa/prepare.py
-  # MMMU-Pro `vision` config: the whole question, options included, is
-  # rendered into one screenshot, so `prepare.py` builds `problem` from the
-  # options alone and writes a sidecar `images/` dir referenced by
-  # `image_path`. Upstream's dir is `mmmu-pro`; `dst` uses underscores
-  # because `_resolve_upstream_metadata` imports it as a Python module and a
-  # hyphen is not a legal module name. The name also has to say `vision` --
-  # sgl-eval's own `mmmu_pro` benchmark evaluates the `standard (10 options)`
-  # config, which upstream does not ship.
+  # MMMU-Pro `vision` config (see `_registry.py` for what it evaluates).
+  # `dst` de-hyphenates because `_resolve_upstream_metadata` imports this dir
+  # as a Python module; it says `vision` to stay distinct from the `mmmu_pro`
+  # row, which evaluates a config upstream does not ship.
   - src: nemo_skills/dataset/mmmu-pro/__init__.py
     dst: dataset/mmmu_pro_vision/__init__.py
   - src: nemo_skills/dataset/mmmu-pro/prepare.py

--- a/sgl_eval/_vendored/nemo_skills/dataset/mmmu_pro_vision/__init__.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/mmmu_pro_vision/__init__.py
@@ -1,0 +1,25 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/mmmu-pro/__init__.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+REQUIRES_DATA_DIR = True
+METRICS_TYPE = "multichoice"
+EVAL_SPLIT = "test"
+GENERATION_ARGS = "++prompt_config=vlm/mmmu-pro ++eval_type=multichoice"

--- a/sgl_eval/_vendored/nemo_skills/dataset/mmmu_pro_vision/prepare.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/mmmu_pro_vision/prepare.py
@@ -1,0 +1,87 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/mmmu-pro/prepare.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import ast
+import json
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from sgl_eval._vendored.nemo_skills.dataset._utils import get_mcq_fields
+
+
+def format_entry(entry, images_dir: Path) -> dict | None:
+    """Format a MMMU-Pro entry for NeMo-Skills VLM evaluation."""
+    if entry["image"] is None:
+        return None
+
+    image_filename = f"{entry['id']}.png"
+    image_path = images_dir / image_filename
+    entry["image"].save(image_path)
+
+    options = ast.literal_eval(entry["options"])
+    mcq_fields = get_mcq_fields("", options)
+    subject = entry["subject"].replace(" ", "_")
+
+    return {
+        "problem": mcq_fields["problem"],
+        "image_path": f"images/{image_filename}",
+        "expected_answer": entry["answer"],
+        "subset_for_metrics": subject,
+        "id": entry["id"],
+    }
+
+
+def save_data(split: str):
+    """Download and prepare MMMU-Pro data."""
+    data_dir = Path(__file__).absolute().parent
+    images_dir = data_dir / "images"
+    images_dir.mkdir(exist_ok=True)
+
+    output_file = data_dir / f"{split}.jsonl"
+
+    print(f"Loading MMMU-Pro vision {split} split...")
+    dataset = load_dataset("MMMU/MMMU_Pro", "vision", split=split)
+
+    print(f"Processing {len(dataset)} entries...")
+    count = 0
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(dataset, desc=f"Preparing {split}"):
+            formatted = format_entry(entry, images_dir)
+            if formatted is None:
+                continue
+            fout.write(json.dumps(formatted) + "\n")
+            count += 1
+
+    print(f"✓ Saved {count} entries to {output_file}")
+    print(f"✓ Images saved to {images_dir}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Prepare MMMU-Pro dataset")
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=("test",),
+        help="Dataset split to prepare (default: test)",
+    )
+    args = parser.parse_args()
+    save_data(args.split)

--- a/sgl_eval/_vendored/nemo_skills/prompts/mmmu-pro.yaml
+++ b/sgl_eval/_vendored/nemo_skills/prompts/mmmu-pro.yaml
@@ -1,0 +1,16 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/prompt/config/vlm/mmmu-pro.yaml
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Prompt config for MMMU-Pro VLM benchmark with 10 answer choices.
+# Based on AAI methodology: https://artificialanalysis.ai/methodology/intelligence-benchmarking
+# Image is shown before the question text.
+
+image_field: image_path
+image_position: before
+
+user: |-
+  Answer the following multiple choice question. The last line of your response should be in the following format: 'Answer: A/B/C/D/E/F/G/H/I/J' (e.g. 'Answer: A').
+
+  {problem}

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -11,11 +11,9 @@ Two patterns are needed across the current benchmark set:
     HuggingFace). We invoke the vendored function once, move its output to
     ``~/.cache/sgl_eval/<name>/``, and serve from cache on subsequent runs.
 
-Multimodal ``prepare`` benchmarks additionally write a media sidecar
-directory beside the jsonl and reference it by relative path (mmmu_pro_vision
--> ``images/`` + ``image_path``). ``media_dir`` / ``media_field`` move that
-directory into the same cache dir and resolve each row's file into
-``Example.media``.
+A multimodal **prepare** benchmark also writes a media sidecar dir beside its
+jsonl and references it by relative path (mmmu_pro_vision -> ``images/`` +
+``image_path``); see ``load_via_prepare``.
 """
 
 from __future__ import annotations
@@ -55,12 +53,9 @@ def _row_to_example(
 
 
 def _row_media(row: dict, media_field: str, base_dir: Path) -> List[MediaItem]:
-    """Resolve a row's media path into an in-memory ``MediaItem``.
-
-    A row whose media file is missing is a corrupt cache, not a data variation
-    -- fail loudly rather than silently evaluating a screenshot benchmark as
-    text (the failure mode behind MMMU-Pro's original 9% baseline).
-    """
+    """A missing media file is a corrupt cache, not a data variation -- fail
+    loudly rather than silently evaluating a screenshot benchmark as text (the
+    failure mode behind MMMU-Pro's original 9% baseline)."""
     rel = row.get(media_field)
     if not rel:
         return []
@@ -143,10 +138,9 @@ def load_via_prepare(
     """Loader that runs vendored ``<name>/prepare.py:save_data`` once and
     caches the resulting JSONL.
 
-    ``media_dir`` is a sidecar directory ``save_data`` writes beside the jsonl
-    (relative to the vendored package dir); ``media_field`` is the jsonl column
-    holding each row's path into it. Both move to the cache dir together so the
-    relative paths keep resolving.
+    ``media_dir`` is a sidecar dir ``save_data`` writes beside the jsonl;
+    ``media_field`` is the jsonl column pointing into it. Both land in the cache
+    dir together so the relative paths keep resolving.
     """
     save_kwargs = save_kwargs or {}
     output_basename = f"{save_args[0]}.jsonl"
@@ -160,10 +154,8 @@ def load_via_prepare(
             mod.save_data(*save_args, **save_kwargs)
             cache_dir.mkdir(parents=True, exist_ok=True)
             shutil.move(str(vendored_dir / output_basename), str(cache_path))
-            # save_data writes the sidecar into _vendored (its data_dir is
-            # `Path(__file__).parent`), so it has to move out alongside the
-            # jsonl -- otherwise the cached relative paths dangle and
-            # _vendored accumulates generated data.
+            # save_data's data_dir is `Path(__file__).parent`, i.e. inside
+            # _vendored -- the sidecar has to come out with the jsonl.
             if media_dir:
                 _move_tree(vendored_dir / media_dir, cache_dir / media_dir)
         return _read_jsonl(cache_path, name, num_examples, media_field, cache_dir)

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -10,6 +10,12 @@ Two patterns are needed across the current benchmark set:
     (gsm8k from openai/grade-school-math, mmlu from Berkeley tar, gpqa from
     HuggingFace). We invoke the vendored function once, move its output to
     ``~/.cache/sgl_eval/<name>/``, and serve from cache on subsequent runs.
+
+Multimodal ``prepare`` benchmarks additionally write a media sidecar
+directory beside the jsonl and reference it by relative path (mmmu_pro_vision
+-> ``images/`` + ``image_path``). ``media_dir`` / ``media_field`` move that
+directory into the same cache dir and resolve each row's file into
+``Example.media``.
 """
 
 from __future__ import annotations
@@ -22,26 +28,65 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from sgl_eval import VENDORED_NS_ROOT
-from sgl_eval.types import Example
+from sgl_eval.types import Example, MediaItem
 
 _CACHE_ROOT = Path.home() / ".cache" / "sgl_eval"
 _VENDORED_DATASET_ROOT = VENDORED_NS_ROOT / "dataset"
 
+_MIME_BY_SUFFIX = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
 
-def _row_to_example(row: dict, idx: int, name: str) -> Example:
+
+def _row_to_example(
+    row: dict, idx: int, name: str, media: Optional[List[MediaItem]] = None
+) -> Example:
     return Example(
         id=row.get("id") or f"{name}-{idx}",
         inputs={"problem": row["problem"]},
         target=row["expected_answer"],
         meta={k: v for k, v in row.items() if k not in ("problem", "expected_answer", "id")},
+        media=media or [],
     )
 
 
-def _read_jsonl(path: Path, name: str, num_examples: Optional[int]) -> List[Example]:
+def _row_media(row: dict, media_field: str, base_dir: Path) -> List[MediaItem]:
+    """Resolve a row's media path into an in-memory ``MediaItem``.
+
+    A row whose media file is missing is a corrupt cache, not a data variation
+    -- fail loudly rather than silently evaluating a screenshot benchmark as
+    text (the failure mode behind MMMU-Pro's original 9% baseline).
+    """
+    rel = row.get(media_field)
+    if not rel:
+        return []
+    path = base_dir / rel
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"{media_field}={rel!r} missing under {base_dir}; "
+            f"delete the cache dir to force a re-prepare"
+        )
+    mime = _MIME_BY_SUFFIX.get(path.suffix.lower(), "application/octet-stream")
+    return [MediaItem(kind="image", data=path.read_bytes(), mime=mime)]
+
+
+def _read_jsonl(
+    path: Path,
+    name: str,
+    num_examples: Optional[int],
+    media_field: Optional[str] = None,
+    media_base: Optional[Path] = None,
+) -> List[Example]:
     examples: List[Example] = []
     with path.open("rt", encoding="utf-8") as f:
         for i, line in enumerate(f):
-            examples.append(_row_to_example(json.loads(line), i, name))
+            row = json.loads(line)
+            media = _row_media(row, media_field, media_base) if media_field else []
+            examples.append(_row_to_example(row, i, name, media))
             if num_examples and len(examples) >= num_examples:
                 break
     return examples
@@ -92,9 +137,17 @@ def load_via_prepare(
     name: str,
     save_args: List[Any],
     save_kwargs: Optional[Dict[str, Any]] = None,
+    media_dir: Optional[str] = None,
+    media_field: Optional[str] = None,
 ) -> Callable[[Optional[int]], List[Example]]:
     """Loader that runs vendored ``<name>/prepare.py:save_data`` once and
-    caches the resulting JSONL."""
+    caches the resulting JSONL.
+
+    ``media_dir`` is a sidecar directory ``save_data`` writes beside the jsonl
+    (relative to the vendored package dir); ``media_field`` is the jsonl column
+    holding each row's path into it. Both move to the cache dir together so the
+    relative paths keep resolving.
+    """
     save_kwargs = save_kwargs or {}
     output_basename = f"{save_args[0]}.jsonl"
 
@@ -107,6 +160,20 @@ def load_via_prepare(
             mod.save_data(*save_args, **save_kwargs)
             cache_dir.mkdir(parents=True, exist_ok=True)
             shutil.move(str(vendored_dir / output_basename), str(cache_path))
-        return _read_jsonl(cache_path, name, num_examples)
+            # save_data writes the sidecar into _vendored (its data_dir is
+            # `Path(__file__).parent`), so it has to move out alongside the
+            # jsonl -- otherwise the cached relative paths dangle and
+            # _vendored accumulates generated data.
+            if media_dir:
+                _move_tree(vendored_dir / media_dir, cache_dir / media_dir)
+        return _read_jsonl(cache_path, name, num_examples, media_field, cache_dir)
 
     return loader
+
+
+def _move_tree(src: Path, dst: Path) -> None:
+    if not src.is_dir():
+        raise FileNotFoundError(f"prepare.py produced no media dir at {src}")
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.move(str(src), str(dst))

--- a/sgl_eval/evals/_multichoice.py
+++ b/sgl_eval/evals/_multichoice.py
@@ -24,7 +24,7 @@ _mcq_mod.tqdm = lambda iterable, **_kwargs: iterable
 
 from sgl_eval._vendored.nemo_skills.evaluator.mcq import eval_mcq  # noqa: E402
 from sgl_eval._vendored.nemo_skills.math_metrics import MathMetrics  # noqa: E402
-from sgl_eval.evals._prompts import render_prompt  # noqa: E402
+from sgl_eval.evals._prompts import prompt_media_config, render_prompt  # noqa: E402
 from sgl_eval.evals._vision import build_user_content  # noqa: E402
 from sgl_eval.predictions import PredictionsWriter, sample_to_pred  # noqa: E402
 from sgl_eval.runner import SampleFn, ScoreOneFn, run_examples  # noqa: E402
@@ -49,9 +49,13 @@ def _score_via_eval_mcq(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 
 def make_sample_fn(sampler: ChatCompletionSampler, gen: GenConfig, prompt_yaml: Path) -> SampleFn:
+    # Read once: the yaml is fixed for the run, and parsing it per sample would
+    # put a file read on every request.
+    image_position = prompt_media_config(prompt_yaml)["image_position"]
+
     def sample_fn(ex: Example, _rep_idx: int) -> Sample:
         prompt_text = render_prompt(prompt_yaml, problem=ex.inputs["problem"])
-        content = build_user_content(prompt_text, ex.media)
+        content = build_user_content(prompt_text, ex.media, image_position=image_position)
         return sampler([{"role": "user", "content": content}], gen)
 
     return sample_fn

--- a/sgl_eval/evals/_prompts.py
+++ b/sgl_eval/evals/_prompts.py
@@ -26,11 +26,9 @@ def vendored_prompt(name: str) -> Path:
 def prompt_media_config(yaml_path: Path) -> dict:
     """Media placement keys from a VLM prompt yaml (``image_position``).
 
-    Upstream's VLM configs carry these alongside ``user``; ``render_prompt``
-    only consumes the template, so a caller that builds multimodal content
-    reads placement from here. ``image_field`` is upstream's jsonl column
-    name, which the loader has already resolved into ``Example.media``, so
-    it is deliberately not surfaced.
+    ``render_prompt`` consumes only the ``user`` template, so multimodal callers
+    read placement here. Upstream's sibling ``image_field`` stays unexposed --
+    the loader has already resolved it into ``Example.media``.
     """
     cfg = yaml.safe_load(yaml_path.read_text())
     return {"image_position": cfg.get("image_position", "after")}

--- a/sgl_eval/evals/_prompts.py
+++ b/sgl_eval/evals/_prompts.py
@@ -23,6 +23,19 @@ def vendored_prompt(name: str) -> Path:
     return _VENDORED_PROMPT_DIR / f"{name}.yaml"
 
 
+def prompt_media_config(yaml_path: Path) -> dict:
+    """Media placement keys from a VLM prompt yaml (``image_position``).
+
+    Upstream's VLM configs carry these alongside ``user``; ``render_prompt``
+    only consumes the template, so a caller that builds multimodal content
+    reads placement from here. ``image_field`` is upstream's jsonl column
+    name, which the loader has already resolved into ``Example.media``, so
+    it is deliberately not surfaced.
+    """
+    cfg = yaml.safe_load(yaml_path.read_text())
+    return {"image_position": cfg.get("image_position", "after")}
+
+
 def render_prompt(
     yaml_path: Path,
     problem: str,

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -7,6 +7,9 @@ no new module. Each entry encodes only the things that genuinely differ:
   (run vendored ``prepare.py:save_data``).
 - ``save_args`` / ``save_kwargs``: signature for ``save_data`` when
   ``loader == "prepare"``.
+- ``media_dir`` / ``media_field``: multimodal ``prepare`` benchmarks only --
+  the sidecar directory ``save_data`` writes beside its jsonl, and the jsonl
+  column holding each row's path into it.
 - ``thinking``: whether to set ``chat_template_kwargs={"thinking": True}``
   by default. True for reasoning benchmarks (aime / gpqa); off otherwise.
 - ``default_n_repeats``: per-example repeat count (sgl-eval choice; NS
@@ -25,9 +28,10 @@ single value here would encode a model-specific assumption.
 ``metrics_type`` and the prompt yaml basename are derived at registration
 time from the vendored ``dataset/<name>/__init__.py`` (``METRICS_TYPE`` +
 ``GENERATION_ARGS``), so we never hand-mirror upstream's per-benchmark
-choices. Two rows opt out by declaring both explicitly: ``mmmu_pro`` (no
-upstream module) and ``ruler2`` (upstream ships no dataset metadata -- its
-subtasks only exist once generated).
+choices. Two rows opt out by declaring both explicitly: ``mmmu_pro``
+(upstream ships MMMU-Pro's ``vision`` config only, not the
+``standard (10 options)`` one this row evaluates) and ``ruler2`` (upstream
+ships no dataset metadata -- its subtasks only exist once generated).
 """
 
 from __future__ import annotations
@@ -98,8 +102,10 @@ _TABLE = [
         "description": "GPQA Diamond (graduate-level QA, pass@k + majority@k).",
     },
     {
-        # SE-own benchmark (NS upstream has no MMMU-Pro). metrics_type + prompt
-        # + loader_fn bypass the vendored dataset/__init__.py + prepare path.
+        # SE-own: upstream ships MMMU-Pro's `vision` config only (registered
+        # below as `mmmu_pro_vision`), not `standard (10 options)`. So
+        # metrics_type + prompt + loader_fn bypass the vendored
+        # dataset/__init__.py + prepare path.
         "name": "mmmu_pro",
         "metrics_type": "multichoice",
         "prompt": "mcq-10choices",
@@ -107,6 +113,22 @@ _TABLE = [
         "thinking": False,
         "default_n_repeats": 1,
         "description": "MMMU-Pro (multimodal, 10-choice, vision-dependent).",
+    },
+    {
+        # MMMU-Pro `vision`: the question and its options are rendered into a
+        # single screenshot, so `problem` carries only the option list and the
+        # prompt is just an answer-format instruction placed after the image
+        # (`image_position: before` in the vendored yaml). A different task
+        # from `mmmu_pro` above, not a different prompt for the same one --
+        # scores are not comparable between the two rows.
+        "name": "mmmu_pro_vision",
+        "loader": "prepare",
+        "save_args": ("test",),
+        "media_dir": "images",
+        "media_field": "image_path",
+        "thinking": False,
+        "default_n_repeats": 1,
+        "description": "MMMU-Pro vision config (whole question rendered as one screenshot).",
     },
     {
         # Group benchmark: 12 subtasks scored separately, then averaged by
@@ -172,6 +194,8 @@ def _build_loader(entry: dict):
             entry["name"],
             list(entry["save_args"]),
             entry.get("save_kwargs", {}),
+            media_dir=entry.get("media_dir"),
+            media_field=entry.get("media_field"),
         )
     raise ValueError(f"unknown loader kind: {kind!r}")
 

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -115,12 +115,10 @@ _TABLE = [
         "description": "MMMU-Pro (multimodal, 10-choice, vision-dependent).",
     },
     {
-        # MMMU-Pro `vision`: the question and its options are rendered into a
-        # single screenshot, so `problem` carries only the option list and the
-        # prompt is just an answer-format instruction placed after the image
-        # (`image_position: before` in the vendored yaml). A different task
-        # from `mmmu_pro` above, not a different prompt for the same one --
-        # scores are not comparable between the two rows.
+        # MMMU-Pro `vision`: question and options are rendered into one
+        # screenshot, so `problem` carries just the option list. A different
+        # task from `mmmu_pro` above, not a different prompt for the same one
+        # -- scores are not comparable between the two rows.
         "name": "mmmu_pro_vision",
         "loader": "prepare",
         "save_args": ("test",),

--- a/sgl_eval/evals/_vision.py
+++ b/sgl_eval/evals/_vision.py
@@ -7,8 +7,8 @@ video_url blocks otherwise. The sampler passes it through unchanged.
 
 Image placement: if the prompt contains ``[image]`` placeholders (left by
 the MMMU-Pro loader after stripping ``<image n>``), images are inserted at
-those positions to preserve in-question order; otherwise they are appended
-after the text.
+those positions to preserve in-question order; otherwise ``image_position``
+decides, defaulting to appending after the text.
 """
 
 from __future__ import annotations
@@ -23,11 +23,19 @@ ContentType = Union[str, list]
 _IMAGE_PLACEHOLDER = "[image]"
 
 
-def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
+def build_user_content(
+    prompt: str, media: List[MediaItem], image_position: str = "after"
+) -> ContentType:
     """Render a user message ``content`` for the given prompt + media.
 
     No media -> plain string (text-benchmark path, unchanged). Images inline
     as ``data:`` base64; video uses a ``video_url`` block (too large to inline).
+
+    ``image_position`` (from the prompt yaml, see
+    ``_prompts.prompt_media_config``) applies only when the prompt carries no
+    ``[image]`` placeholder: ``"before"`` puts every image ahead of the text,
+    which is what screenshot-style benchmarks need since the text is just an
+    answer-format instruction. Explicit placeholders always win over it.
     """
     if not media:
         return prompt
@@ -36,7 +44,7 @@ def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
     image_idx = 0
 
     # Insert images at [image] placeholders to preserve in-question order
-    # (e.g. MMMU-Pro's <image n> position); fall back to appending after text.
+    # (e.g. MMMU-Pro's <image n> position); fall back to image_position.
     if image_media and _IMAGE_PLACEHOLDER in prompt:
         parts = prompt.split(_IMAGE_PLACEHOLDER)
         for idx, part in enumerate(parts):
@@ -49,6 +57,11 @@ def build_user_content(prompt: str, media: List[MediaItem]) -> ContentType:
                 else:
                     # placeholder with no matching image: visible, not silently dropped
                     content.append({"type": "text", "text": "[image missing]"})
+    elif image_media and image_position == "before":
+        for m in image_media:
+            content.append(_image_block(m))
+        image_idx = len(image_media)
+        content.append({"type": "text", "text": prompt})
     else:
         content.append({"type": "text", "text": prompt})
 

--- a/sgl_eval/evals/_vision.py
+++ b/sgl_eval/evals/_vision.py
@@ -32,10 +32,10 @@ def build_user_content(
     as ``data:`` base64; video uses a ``video_url`` block (too large to inline).
 
     ``image_position`` (from the prompt yaml, see
-    ``_prompts.prompt_media_config``) applies only when the prompt carries no
-    ``[image]`` placeholder: ``"before"`` puts every image ahead of the text,
-    which is what screenshot-style benchmarks need since the text is just an
-    answer-format instruction. Explicit placeholders always win over it.
+    ``_prompts.prompt_media_config``) applies only when the prompt has no
+    ``[image]`` placeholder -- an explicit position always wins. ``"before"``
+    suits screenshot benchmarks, whose text is only an answer-format
+    instruction.
     """
     if not media:
         return prompt

--- a/tests/test_mmmu_pro_vision.py
+++ b/tests/test_mmmu_pro_vision.py
@@ -1,0 +1,172 @@
+"""Tests for ``mmmu_pro_vision`` -- the strictly-vendored MMMU-Pro row.
+
+Covers the three things that make it different from every other ``prepare``
+benchmark: metadata is derived from upstream rather than declared, the media
+sidecar has to leave ``_vendored``, and the prompt places its image first.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+
+import pytest
+
+from sgl_eval.evals import _loader
+from sgl_eval.registry import get
+
+
+def test_registered_as_multichoice():
+    spec = get("mmmu_pro_vision")
+    assert spec.category == "multichoice"
+    assert spec.default_n_repeats == 1
+    assert spec.default_gen.max_tokens is None
+
+
+def test_metadata_is_derived_not_declared():
+    """The row must NOT hand-mirror upstream's choices: ``metrics_type`` and the
+    prompt basename come from the vendored ``__init__.py``. Declaring either in
+    ``_TABLE`` would silently decouple us from upstream."""
+    from sgl_eval.evals._registry import _TABLE, _resolve_upstream_metadata
+
+    [entry] = [e for e in _TABLE if e["name"] == "mmmu_pro_vision"]
+    assert "metrics_type" not in entry
+    assert "prompt" not in entry
+
+    metrics_type, prompt_basename = _resolve_upstream_metadata("mmmu_pro_vision")
+    assert metrics_type == "multichoice"
+    # Upstream's ++prompt_config=vlm/mmmu-pro -- hyphenated, hence the
+    # hyphenated vendored yaml basename.
+    assert prompt_basename == "mmmu-pro"
+
+
+def test_vendored_prompt_places_image_first():
+    """The vision config renders the question into the image, so the text (an
+    answer-format instruction) must follow it."""
+    from sgl_eval.evals._prompts import prompt_media_config, vendored_prompt
+
+    path = vendored_prompt("mmmu-pro")
+    assert path.exists()
+    assert prompt_media_config(path)["image_position"] == "before"
+
+
+def test_vendored_dataset_module_is_upstream_verbatim():
+    """The dst dir is renamed (hyphen -> underscore) but the file must still be
+    upstream's, banner included."""
+    from sgl_eval import VENDORED_NS_ROOT
+
+    text = (VENDORED_NS_ROOT / "dataset" / "mmmu_pro_vision" / "__init__.py").read_text()
+    assert "Source: nemo_skills/dataset/mmmu-pro/__init__.py" in text
+    assert 'METRICS_TYPE = "multichoice"' in text
+    assert "++prompt_config=vlm/mmmu-pro" in text
+
+
+def _fake_prepare_module(tmp_path, rows, image_names):
+    """A stand-in for the vendored ``prepare`` module: ``save_data`` writes a
+    jsonl plus an ``images/`` sidecar next to ``__file__``, exactly as
+    upstream's does."""
+    vendored_dir = tmp_path / "vendored_pkg"
+    vendored_dir.mkdir()
+    mod = types.ModuleType("fake_prepare")
+    mod.__file__ = str(vendored_dir / "prepare.py")
+
+    def save_data(split):
+        images_dir = vendored_dir / "images"
+        images_dir.mkdir(exist_ok=True)
+        for name in image_names:
+            (images_dir / name).write_bytes(b"\x89PNG" + name.encode())
+        with (vendored_dir / f"{split}.jsonl").open("w") as f:
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
+
+    mod.save_data = save_data
+    return mod, vendored_dir
+
+
+@pytest.fixture
+def prepared(tmp_path, monkeypatch):
+    rows = [
+        {"id": "v1", "problem": "A) x\nB) y", "expected_answer": "A", "image_path": "images/a.png"},
+        {"id": "v2", "problem": "A) p\nB) q", "expected_answer": "B", "image_path": "images/b.png"},
+    ]
+    mod, vendored_dir = _fake_prepare_module(tmp_path, rows, ["a.png", "b.png"])
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
+    return tmp_path, vendored_dir
+
+
+def test_media_sidecar_moves_out_of_vendored(prepared):
+    tmp_path, vendored_dir = prepared
+    loader = _loader.load_via_prepare(
+        "mmmu_pro_vision", ["test"], media_dir="images", media_field="image_path"
+    )
+    examples = loader(None)
+
+    cache_dir = tmp_path / "cache" / "mmmu_pro_vision"
+    assert (cache_dir / "test.jsonl").is_file()
+    assert (cache_dir / "images" / "a.png").is_file()
+    # _vendored must not retain generated data.
+    assert not (vendored_dir / "images").exists()
+
+    assert len(examples) == 2
+    assert [m.mime for ex in examples for m in ex.media] == ["image/png", "image/png"]
+    assert examples[0].media[0].data == b"\x89PNGa.png"
+    assert examples[0].target == "A"
+
+
+def test_media_path_kept_in_meta(prepared):
+    loader = _loader.load_via_prepare(
+        "mmmu_pro_vision", ["test"], media_dir="images", media_field="image_path"
+    )
+    [ex, _] = loader(None)
+    assert ex.meta["image_path"] == "images/a.png"
+
+
+def test_num_examples_truncates_before_reading_media(prepared):
+    loader = _loader.load_via_prepare(
+        "mmmu_pro_vision", ["test"], media_dir="images", media_field="image_path"
+    )
+    examples = loader(1)
+    assert len(examples) == 1
+    assert examples[0].id == "v1"
+
+
+def test_second_load_serves_from_cache(prepared):
+    """A cached run must not re-invoke save_data (whose sidecar is already
+    gone from _vendored)."""
+    tmp_path, vendored_dir = prepared
+    loader = _loader.load_via_prepare(
+        "mmmu_pro_vision", ["test"], media_dir="images", media_field="image_path"
+    )
+    loader(None)
+    again = loader(None)
+    assert len(again) == 2
+    assert again[0].media[0].data == b"\x89PNGa.png"
+
+
+def test_missing_media_file_raises(tmp_path, monkeypatch):
+    """A row pointing at a nonexistent image is a corrupt cache -- it must fail
+    loudly, never degrade to a text-only sample."""
+    rows = [
+        {"id": "v1", "problem": "A) x", "expected_answer": "A", "image_path": "images/gone.png"}
+    ]
+    mod, _ = _fake_prepare_module(tmp_path, rows, ["a.png"])
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
+
+    loader = _loader.load_via_prepare(
+        "mmmu_pro_vision", ["test"], media_dir="images", media_field="image_path"
+    )
+    with pytest.raises(FileNotFoundError, match="gone.png"):
+        loader(None)
+
+
+def test_text_benchmarks_keep_empty_media(tmp_path, monkeypatch):
+    """No media_field -> Example.media stays empty (gsm8k / mmlu / gpqa path)."""
+    rows = [{"id": "t1", "problem": "2+2?", "expected_answer": "4"}]
+    mod, _ = _fake_prepare_module(tmp_path, rows, [])
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
+
+    [ex] = _loader.load_via_prepare("gsm8k", ["test"])(None)
+    assert ex.media == []

--- a/tests/test_vision_message.py
+++ b/tests/test_vision_message.py
@@ -96,6 +96,46 @@ def test_two_placeholders_two_images_in_order():
     assert [b["type"] for b in content] == ["text", "image_url", "text", "image_url", "text"]
 
 
+def test_image_position_before_puts_image_ahead_of_text():
+    """Screenshot-style benchmarks (mmmu_pro_vision) carry the question inside
+    the image; the text is only an answer-format instruction."""
+    media = [MediaItem(kind="image", data=b"i", mime="image/png")]
+    content = build_user_content("answer format...", media, image_position="before")
+    assert [b["type"] for b in content] == ["image_url", "text"]
+    assert content[1]["text"] == "answer format..."
+
+
+def test_image_position_before_with_multiple_images():
+    media = [
+        MediaItem(kind="image", data=b"a", mime="image/png"),
+        MediaItem(kind="image", data=b"b", mime="image/png"),
+    ]
+    content = build_user_content("q", media, image_position="before")
+    assert [b["type"] for b in content] == ["image_url", "image_url", "text"]
+
+
+def test_placeholder_wins_over_image_position_before():
+    """An explicit ``[image]`` marker is a per-question position and must not be
+    overridden by the yaml-level default."""
+    media = [MediaItem(kind="image", data=b"i", mime="image/png")]
+    content = build_user_content("x [image] y", media, image_position="before")
+    assert [b["type"] for b in content] == ["text", "image_url", "text"]
+
+
+def test_image_position_before_still_appends_video():
+    media = [
+        MediaItem(kind="image", data=b"i", mime="image/png"),
+        MediaItem(kind="video", url="https://x/v.mp4"),
+    ]
+    content = build_user_content("q", media, image_position="before")
+    assert [b["type"] for b in content] == ["image_url", "text", "video_url"]
+
+
+def test_image_position_defaults_to_after():
+    media = [MediaItem(kind="image", data=b"i", mime="image/png")]
+    assert [b["type"] for b in build_user_content("q", media)] == ["text", "image_url"]
+
+
 def test_more_placeholders_than_images_inserts_missing_marker():
     """A ``[image]`` placeholder with no matching image becomes a visible
     ``[image missing]`` text block, not a silent drop."""


### PR DESCRIPTION
Registers NeMo-Skills' MMMU-Pro `vision` config (question rendered as one screenshot) as a benchmark distinct from the existing `mmmu_pro`, which evaluates `standard (10 options)`.