### PR TITLE
Sample `mmlu` with a seed instead of taking its first N rows

### DIFF
--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -14,16 +14,24 @@ Two patterns are needed across the current benchmark set:
 A multimodal **prepare** benchmark also writes a media sidecar dir beside its
 jsonl and references it by relative path (mmmu_pro_vision -> ``images/`` +
 ``image_path``); see ``load_via_prepare``.
+
+``--num-examples N`` keeps the first N rows, which is upstream's own behavior
+(``max_samples`` in its generation config, documented there as a debugging
+aid). That is wrong for a dataset stored grouped rather than shuffled -- mmlu
+comes out of the Hendrycks tar as one CSV per subject, so the first 60 rows are
+all one category. Such a benchmark declares ``sample_seed`` and gets a
+seeded sample of the whole split instead; see ``load_via_prepare``.
 """
 
 from __future__ import annotations
 
 import importlib
 import json
+import random
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from sgl_eval import VENDORED_NS_ROOT
 from sgl_eval.types import Example, MediaItem
@@ -69,22 +77,47 @@ def _row_media(row: dict, media_field: str, base_dir: Path) -> List[MediaItem]:
     return [MediaItem(kind="image", data=path.read_bytes(), mime=mime)]
 
 
+def _select_rows(
+    path: Path, num_examples: Optional[int], sample_seed: Optional[int]
+) -> List[Tuple[int, dict]]:
+    """Rows to score, each paired with its line number in the full split.
+
+    Without ``sample_seed`` this stops reading at ``num_examples`` -- a
+    long-context split (ruler2 rows are ~500KB) must not be pulled into memory
+    whole just to take the first few. Sampling needs the full row list, so it
+    is opt-in per benchmark.
+
+    The line number, not the position after sampling, is what ``_row_to_example``
+    turns into a fallback id, so a row keeps the same id at every
+    ``num_examples``.
+    """
+    rows: List[Tuple[int, dict]] = []
+    with path.open("rt", encoding="utf-8") as f:
+        for i, line in enumerate(f):
+            rows.append((i, json.loads(line)))
+            if sample_seed is None and num_examples and len(rows) >= num_examples:
+                break
+    if sample_seed is not None and num_examples and num_examples < len(rows):
+        rows = random.Random(sample_seed).sample(rows, num_examples)
+    return rows
+
+
 def _read_jsonl(
     path: Path,
     name: str,
     num_examples: Optional[int],
     media_field: Optional[str] = None,
     media_base: Optional[Path] = None,
+    sample_seed: Optional[int] = None,
 ) -> List[Example]:
-    examples: List[Example] = []
-    with path.open("rt", encoding="utf-8") as f:
-        for i, line in enumerate(f):
-            row = json.loads(line)
-            media = _row_media(row, media_field, media_base) if media_field else []
-            examples.append(_row_to_example(row, i, name, media))
-            if num_examples and len(examples) >= num_examples:
-                break
-    return examples
+    # Media is read after selection so a sampled run only loads the files it
+    # scores.
+    return [
+        _row_to_example(
+            row, i, name, _row_media(row, media_field, media_base) if media_field else []
+        )
+        for i, row in _select_rows(path, num_examples, sample_seed)
+    ]
 
 
 def load_bundled(name: str, filename: str = "test.txt") -> Callable[[Optional[int]], List[Example]]:
@@ -134,6 +167,7 @@ def load_via_prepare(
     save_kwargs: Optional[Dict[str, Any]] = None,
     media_dir: Optional[str] = None,
     media_field: Optional[str] = None,
+    sample_seed: Optional[int] = None,
 ) -> Callable[[Optional[int]], List[Example]]:
     """Loader that runs vendored ``<name>/prepare.py:save_data`` once and
     caches the resulting JSONL.
@@ -141,6 +175,11 @@ def load_via_prepare(
     ``media_dir`` is a sidecar dir ``save_data`` writes beside the jsonl;
     ``media_field`` is the jsonl column pointing into it. Both land in the cache
     dir together so the relative paths keep resolving.
+
+    ``sample_seed`` makes ``num_examples`` a seeded sample of the whole split
+    rather than its first N rows. Declare it when the prepared jsonl is grouped
+    (mmlu is one CSV per subject), or a small ``num_examples`` silently scores a
+    single category.
     """
     save_kwargs = save_kwargs or {}
     output_basename = f"{save_args[0]}.jsonl"
@@ -158,7 +197,9 @@ def load_via_prepare(
             # _vendored -- the sidecar has to come out with the jsonl.
             if media_dir:
                 _move_tree(vendored_dir / media_dir, cache_dir / media_dir)
-        return _read_jsonl(cache_path, name, num_examples, media_field, cache_dir)
+        return _read_jsonl(
+            cache_path, name, num_examples, media_field, cache_dir, sample_seed
+        )
 
     return loader
 

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -197,9 +197,7 @@ def load_via_prepare(
             # _vendored -- the sidecar has to come out with the jsonl.
             if media_dir:
                 _move_tree(vendored_dir / media_dir, cache_dir / media_dir)
-        return _read_jsonl(
-            cache_path, name, num_examples, media_field, cache_dir, sample_seed
-        )
+        return _read_jsonl(cache_path, name, num_examples, media_field, cache_dir, sample_seed)
 
     return loader
 

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -15,12 +15,9 @@ A multimodal **prepare** benchmark also writes a media sidecar dir beside its
 jsonl and references it by relative path (mmmu_pro_vision -> ``images/`` +
 ``image_path``); see ``load_via_prepare``.
 
-``--num-examples N`` keeps the first N rows, which is upstream's own behavior
-(``max_samples`` in its generation config, documented there as a debugging
-aid). That is wrong for a dataset stored grouped rather than shuffled -- mmlu
-comes out of the Hendrycks tar as one CSV per subject, so the first 60 rows are
-all one category. Such a benchmark declares ``sample_seed`` and gets a
-seeded sample of the whole split instead; see ``load_via_prepare``.
+``--num-examples N`` keeps the first N rows, matching upstream's ``max_samples``.
+A benchmark whose jsonl is grouped rather than shuffled declares ``sample_seed``
+instead, or a small N scores one group only.
 """
 
 from __future__ import annotations
@@ -80,17 +77,9 @@ def _row_media(row: dict, media_field: str, base_dir: Path) -> List[MediaItem]:
 def _select_rows(
     path: Path, num_examples: Optional[int], sample_seed: Optional[int]
 ) -> List[Tuple[int, dict]]:
-    """Rows to score, each paired with its line number in the full split.
-
-    Without ``sample_seed`` this stops reading at ``num_examples`` -- a
-    long-context split (ruler2 rows are ~500KB) must not be pulled into memory
-    whole just to take the first few. Sampling needs the full row list, so it
-    is opt-in per benchmark.
-
-    The line number, not the position after sampling, is what ``_row_to_example``
-    turns into a fallback id, so a row keeps the same id at every
-    ``num_examples``.
-    """
+    """Rows to score, paired with their line number so ids stay stable across
+    ``num_examples``. Without ``sample_seed`` reading stops early -- sampling
+    needs every row, which a ~500KB-per-row split cannot afford."""
     rows: List[Tuple[int, dict]] = []
     with path.open("rt", encoding="utf-8") as f:
         for i, line in enumerate(f):
@@ -110,8 +99,7 @@ def _read_jsonl(
     media_base: Optional[Path] = None,
     sample_seed: Optional[int] = None,
 ) -> List[Example]:
-    # Media is read after selection so a sampled run only loads the files it
-    # scores.
+    # Media loads after selection, so a sampled run only reads what it scores.
     return [
         _row_to_example(
             row, i, name, _row_media(row, media_field, media_base) if media_field else []
@@ -177,9 +165,7 @@ def load_via_prepare(
     dir together so the relative paths keep resolving.
 
     ``sample_seed`` makes ``num_examples`` a seeded sample of the whole split
-    rather than its first N rows. Declare it when the prepared jsonl is grouped
-    (mmlu is one CSV per subject), or a small ``num_examples`` silently scores a
-    single category.
+    rather than its first N rows.
     """
     save_kwargs = save_kwargs or {}
     output_basename = f"{save_args[0]}.jsonl"

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -10,6 +10,9 @@ no new module. Each entry encodes only the things that genuinely differ:
 - ``media_dir`` / ``media_field``: multimodal ``prepare`` benchmarks only --
   the sidecar directory ``save_data`` writes beside its jsonl, and the jsonl
   column holding each row's path into it.
+- ``sample_seed``: turns ``--num-examples N`` into a seeded sample of the whole
+  split. Needed when the prepared jsonl is grouped rather than shuffled, since
+  the default keeps the first N rows.
 - ``thinking``: whether to set ``chat_template_kwargs={"thinking": True}``
   by default. True for reasoning benchmarks (aime / gpqa); off otherwise.
 - ``default_n_repeats``: per-example repeat count (sgl-eval choice; NS
@@ -85,9 +88,14 @@ _TABLE = [
         "description": "AIME 2026 (30 problems, integer answers).",
     },
     {
+        # The Hendrycks tar is one CSV per subject, so the prepared jsonl is
+        # ordered by subject -- the first 60 of its 14042 rows are all one
+        # category. `sample_seed` makes `--num-examples N` a seeded sample of
+        # the whole split instead of its first N rows.
         "name": "mmlu",
         "loader": "prepare",
         "save_args": ("test",),
+        "sample_seed": 0,
         "thinking": False,
         "default_n_repeats": 1,
         "description": "MMLU all-subjects multichoice (mean accuracy).",
@@ -194,6 +202,7 @@ def _build_loader(entry: dict):
             entry.get("save_kwargs", {}),
             media_dir=entry.get("media_dir"),
             media_field=entry.get("media_field"),
+            sample_seed=entry.get("sample_seed"),
         )
     raise ValueError(f"unknown loader kind: {kind!r}")
 

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -11,8 +11,7 @@ no new module. Each entry encodes only the things that genuinely differ:
   the sidecar directory ``save_data`` writes beside its jsonl, and the jsonl
   column holding each row's path into it.
 - ``sample_seed``: turns ``--num-examples N`` into a seeded sample of the whole
-  split. Needed when the prepared jsonl is grouped rather than shuffled, since
-  the default keeps the first N rows.
+  split, for benchmarks whose jsonl is grouped rather than shuffled.
 - ``thinking``: whether to set ``chat_template_kwargs={"thinking": True}``
   by default. True for reasoning benchmarks (aime / gpqa); off otherwise.
 - ``default_n_repeats``: per-example repeat count (sgl-eval choice; NS
@@ -88,10 +87,8 @@ _TABLE = [
         "description": "AIME 2026 (30 problems, integer answers).",
     },
     {
-        # The Hendrycks tar is one CSV per subject, so the prepared jsonl is
-        # ordered by subject -- the first 60 of its 14042 rows are all one
-        # category. `sample_seed` makes `--num-examples N` a seeded sample of
-        # the whole split instead of its first N rows.
+        # One CSV per subject in the Hendrycks tar, so the first 60 of 14042
+        # rows are all one category -- `--num-examples` has to sample.
         "name": "mmlu",
         "loader": "prepare",
         "save_args": ("test",),

--- a/tests/test_sample_seed.py
+++ b/tests/test_sample_seed.py
@@ -103,9 +103,7 @@ def test_default_path_stops_reading_early(tmp_path, monkeypatch):
     _write_grouped(path)
     parsed = []
     real_loads = json.loads
-    monkeypatch.setattr(
-        json, "loads", lambda s, **kw: (parsed.append(1), real_loads(s, **kw))[1]
-    )
+    monkeypatch.setattr(json, "loads", lambda s, **kw: (parsed.append(1), real_loads(s, **kw))[1])
     _loader._read_jsonl(path, "b", 5)
     assert len(parsed) == 5
 

--- a/tests/test_sample_seed.py
+++ b/tests/test_sample_seed.py
@@ -1,0 +1,161 @@
+"""Tests for ``sample_seed`` -- seeded sampling instead of first-N truncation.
+
+The default (no ``sample_seed``) keeps first-N and stops reading there, which a
+long-context split depends on. mmlu opts in because its prepared jsonl is
+ordered by subject.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+
+import pytest
+
+from sgl_eval.evals import _loader
+
+
+def _write_grouped(path, n_per_group=30, groups=("politics", "math", "law")):
+    """A jsonl ordered by group, like the Hendrycks tar's per-subject CSVs."""
+    with path.open("w") as f:
+        for g in groups:
+            for i in range(n_per_group):
+                f.write(
+                    json.dumps(
+                        {
+                            "problem": f"{g}-q{i}",
+                            "expected_answer": "A",
+                            "subset_for_metrics": g,
+                        }
+                    )
+                    + "\n"
+                )
+    return len(groups) * n_per_group
+
+
+def _groups(examples):
+    return {e.meta["subset_for_metrics"] for e in examples}
+
+
+def test_default_keeps_first_n_and_stays_in_one_group(tmp_path):
+    """Documents the behavior sample_seed exists to fix."""
+    path = tmp_path / "test.jsonl"
+    _write_grouped(path)
+    examples = _loader._read_jsonl(path, "bench", 20)
+    assert len(examples) == 20
+    assert _groups(examples) == {"politics"}
+
+
+def test_sample_seed_spans_groups(tmp_path):
+    path = tmp_path / "test.jsonl"
+    _write_grouped(path)
+    examples = _loader._read_jsonl(path, "bench", 20, sample_seed=0)
+    assert len(examples) == 20
+    assert len(_groups(examples)) > 1
+
+
+def test_sample_seed_is_reproducible(tmp_path):
+    path = tmp_path / "test.jsonl"
+    _write_grouped(path)
+    a = _loader._read_jsonl(path, "bench", 15, sample_seed=0)
+    b = _loader._read_jsonl(path, "bench", 15, sample_seed=0)
+    assert [e.id for e in a] == [e.id for e in b]
+
+
+def test_different_seeds_differ(tmp_path):
+    path = tmp_path / "test.jsonl"
+    _write_grouped(path)
+    a = _loader._read_jsonl(path, "bench", 15, sample_seed=0)
+    b = _loader._read_jsonl(path, "bench", 15, sample_seed=1)
+    assert [e.id for e in a] != [e.id for e in b]
+
+
+def test_ids_track_line_number_not_sample_position(tmp_path):
+    """A row must keep one id across num_examples, so a prediction dump stays
+    comparable between a subsampled and a fuller run."""
+    path = tmp_path / "test.jsonl"
+    _write_grouped(path)
+    small = {e.id: e.inputs["problem"] for e in _loader._read_jsonl(path, "b", 10, sample_seed=0)}
+    big = {e.id: e.inputs["problem"] for e in _loader._read_jsonl(path, "b", 60, sample_seed=0)}
+    shared = set(small) & set(big)
+    assert shared, "seeded samples of different sizes should overlap"
+    for k in shared:
+        assert small[k] == big[k]
+
+
+def test_num_examples_none_reads_everything(tmp_path):
+    path = tmp_path / "test.jsonl"
+    total = _write_grouped(path)
+    assert len(_loader._read_jsonl(path, "b", None, sample_seed=0)) == total
+    assert len(_loader._read_jsonl(path, "b", None)) == total
+
+
+def test_num_examples_above_total_is_not_an_error(tmp_path):
+    path = tmp_path / "test.jsonl"
+    total = _write_grouped(path)
+    assert len(_loader._read_jsonl(path, "b", total * 2, sample_seed=0)) == total
+
+
+def test_default_path_stops_reading_early(tmp_path, monkeypatch):
+    """Without sample_seed the reader must not pull the whole split into memory
+    -- ruler2 rows are ~500KB each."""
+    path = tmp_path / "test.jsonl"
+    _write_grouped(path)
+    parsed = []
+    real_loads = json.loads
+    monkeypatch.setattr(
+        json, "loads", lambda s, **kw: (parsed.append(1), real_loads(s, **kw))[1]
+    )
+    _loader._read_jsonl(path, "b", 5)
+    assert len(parsed) == 5
+
+
+def test_mmlu_declares_sample_seed(tmp_path):
+    from sgl_eval.evals._registry import _TABLE
+
+    [entry] = [e for e in _TABLE if e["name"] == "mmlu"]
+    assert entry["sample_seed"] == 0
+
+
+def test_long_context_rows_are_not_sampled(tmp_path):
+    """ruler2 must keep the streaming first-N path; sampling it would load every
+    ~500KB row."""
+    from sgl_eval.evals._registry import _TABLE
+
+    [entry] = [e for e in _TABLE if e["name"] == "ruler2"]
+    assert "sample_seed" not in entry
+
+
+def test_sample_seed_reaches_the_loader(tmp_path, monkeypatch):
+    """load_via_prepare must forward sample_seed, not silently drop it."""
+    rows = [
+        {"problem": f"q{i}", "expected_answer": "A", "subset_for_metrics": "g" if i < 30 else "h"}
+        for i in range(60)
+    ]
+    vendored = tmp_path / "pkg"
+    vendored.mkdir()
+    mod = types.ModuleType("fake_prepare")
+    mod.__file__ = str(vendored / "prepare.py")
+
+    def save_data(split):
+        with (vendored / f"{split}.jsonl").open("w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+    mod.save_data = save_data
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _n: mod)
+
+    examples = _loader.load_via_prepare("bench", ["test"], sample_seed=0)(20)
+    assert len(examples) == 20
+    assert len({e.meta["subset_for_metrics"] for e in examples}) == 2
+
+
+@pytest.mark.parametrize("seed", [0, 7])
+def test_sample_is_a_subset_of_the_split(tmp_path, seed):
+    path = tmp_path / "test.jsonl"
+    _write_grouped(path)
+    everything = {e.inputs["problem"] for e in _loader._read_jsonl(path, "b", None)}
+    sampled = {e.inputs["problem"] for e in _loader._read_jsonl(path, "b", 20, sample_seed=seed)}
+    assert sampled <= everything
+    assert len(sampled) == 20

--- a/tests/test_sample_seed.py
+++ b/tests/test_sample_seed.py
@@ -1,159 +1,61 @@
-"""Tests for ``sample_seed`` -- seeded sampling instead of first-N truncation.
-
-The default (no ``sample_seed``) keeps first-N and stops reading there, which a
-long-context split depends on. mmlu opts in because its prepared jsonl is
-ordered by subject.
-"""
+"""Tests for ``sample_seed`` (seeded sampling instead of first-N truncation)."""
 
 from __future__ import annotations
 
 import json
-import types
-
-import pytest
 
 from sgl_eval.evals import _loader
 
 
-def _write_grouped(path, n_per_group=30, groups=("politics", "math", "law")):
-    """A jsonl ordered by group, like the Hendrycks tar's per-subject CSVs."""
+def _grouped_jsonl(path, n=30, groups=("politics", "math", "law")):
+    """Ordered by group, like the Hendrycks tar's per-subject CSVs."""
     with path.open("w") as f:
         for g in groups:
-            for i in range(n_per_group):
-                f.write(
-                    json.dumps(
-                        {
-                            "problem": f"{g}-q{i}",
-                            "expected_answer": "A",
-                            "subset_for_metrics": g,
-                        }
-                    )
-                    + "\n"
-                )
-    return len(groups) * n_per_group
+            for i in range(n):
+                f.write(json.dumps({"problem": f"{g}{i}", "expected_answer": "A", "g": g}) + "\n")
+    return len(groups) * n
 
 
-def _groups(examples):
-    return {e.meta["subset_for_metrics"] for e in examples}
+def test_first_n_stays_in_one_group_but_a_sample_spans_them(tmp_path):
+    path = tmp_path / "t.jsonl"
+    _grouped_jsonl(path)
+    first_n = _loader._read_jsonl(path, "b", 20)
+    sampled = _loader._read_jsonl(path, "b", 20, sample_seed=0)
+    assert {e.meta["g"] for e in first_n} == {"politics"}
+    assert len(sampled) == 20 and len({e.meta["g"] for e in sampled}) > 1
 
 
-def test_default_keeps_first_n_and_stays_in_one_group(tmp_path):
-    """Documents the behavior sample_seed exists to fix."""
-    path = tmp_path / "test.jsonl"
-    _write_grouped(path)
-    examples = _loader._read_jsonl(path, "bench", 20)
-    assert len(examples) == 20
-    assert _groups(examples) == {"politics"}
-
-
-def test_sample_seed_spans_groups(tmp_path):
-    path = tmp_path / "test.jsonl"
-    _write_grouped(path)
-    examples = _loader._read_jsonl(path, "bench", 20, sample_seed=0)
-    assert len(examples) == 20
-    assert len(_groups(examples)) > 1
-
-
-def test_sample_seed_is_reproducible(tmp_path):
-    path = tmp_path / "test.jsonl"
-    _write_grouped(path)
-    a = _loader._read_jsonl(path, "bench", 15, sample_seed=0)
-    b = _loader._read_jsonl(path, "bench", 15, sample_seed=0)
-    assert [e.id for e in a] == [e.id for e in b]
-
-
-def test_different_seeds_differ(tmp_path):
-    path = tmp_path / "test.jsonl"
-    _write_grouped(path)
-    a = _loader._read_jsonl(path, "bench", 15, sample_seed=0)
-    b = _loader._read_jsonl(path, "bench", 15, sample_seed=1)
-    assert [e.id for e in a] != [e.id for e in b]
+def test_sample_is_reproducible(tmp_path):
+    path = tmp_path / "t.jsonl"
+    _grouped_jsonl(path)
+    ids = [_loader._read_jsonl(path, "b", 15, sample_seed=0) for _ in range(2)]
+    assert [e.id for e in ids[0]] == [e.id for e in ids[1]]
 
 
 def test_ids_track_line_number_not_sample_position(tmp_path):
-    """A row must keep one id across num_examples, so a prediction dump stays
-    comparable between a subsampled and a fuller run."""
-    path = tmp_path / "test.jsonl"
-    _write_grouped(path)
+    """A row keeps one id across num_examples, so prediction dumps stay comparable."""
+    path = tmp_path / "t.jsonl"
+    _grouped_jsonl(path)
     small = {e.id: e.inputs["problem"] for e in _loader._read_jsonl(path, "b", 10, sample_seed=0)}
     big = {e.id: e.inputs["problem"] for e in _loader._read_jsonl(path, "b", 60, sample_seed=0)}
     shared = set(small) & set(big)
-    assert shared, "seeded samples of different sizes should overlap"
-    for k in shared:
-        assert small[k] == big[k]
+    assert shared and all(small[k] == big[k] for k in shared)
 
 
-def test_num_examples_none_reads_everything(tmp_path):
-    path = tmp_path / "test.jsonl"
-    total = _write_grouped(path)
-    assert len(_loader._read_jsonl(path, "b", None, sample_seed=0)) == total
-    assert len(_loader._read_jsonl(path, "b", None)) == total
-
-
-def test_num_examples_above_total_is_not_an_error(tmp_path):
-    path = tmp_path / "test.jsonl"
-    total = _write_grouped(path)
+def test_num_examples_above_total_does_not_raise(tmp_path):
+    """random.sample raises when k > len; the guard has to catch that."""
+    path = tmp_path / "t.jsonl"
+    total = _grouped_jsonl(path)
     assert len(_loader._read_jsonl(path, "b", total * 2, sample_seed=0)) == total
 
 
 def test_default_path_stops_reading_early(tmp_path, monkeypatch):
-    """Without sample_seed the reader must not pull the whole split into memory
-    -- ruler2 rows are ~500KB each."""
-    path = tmp_path / "test.jsonl"
-    _write_grouped(path)
-    parsed = []
-    real_loads = json.loads
-    monkeypatch.setattr(json, "loads", lambda s, **kw: (parsed.append(1), real_loads(s, **kw))[1])
+    """Without sample_seed the reader must not parse the whole split -- ruler2
+    rows are ~500KB each."""
+    path = tmp_path / "t.jsonl"
+    _grouped_jsonl(path)
+    calls = []
+    real = json.loads
+    monkeypatch.setattr(json, "loads", lambda s, **kw: (calls.append(1), real(s, **kw))[1])
     _loader._read_jsonl(path, "b", 5)
-    assert len(parsed) == 5
-
-
-def test_mmlu_declares_sample_seed(tmp_path):
-    from sgl_eval.evals._registry import _TABLE
-
-    [entry] = [e for e in _TABLE if e["name"] == "mmlu"]
-    assert entry["sample_seed"] == 0
-
-
-def test_long_context_rows_are_not_sampled(tmp_path):
-    """ruler2 must keep the streaming first-N path; sampling it would load every
-    ~500KB row."""
-    from sgl_eval.evals._registry import _TABLE
-
-    [entry] = [e for e in _TABLE if e["name"] == "ruler2"]
-    assert "sample_seed" not in entry
-
-
-def test_sample_seed_reaches_the_loader(tmp_path, monkeypatch):
-    """load_via_prepare must forward sample_seed, not silently drop it."""
-    rows = [
-        {"problem": f"q{i}", "expected_answer": "A", "subset_for_metrics": "g" if i < 30 else "h"}
-        for i in range(60)
-    ]
-    vendored = tmp_path / "pkg"
-    vendored.mkdir()
-    mod = types.ModuleType("fake_prepare")
-    mod.__file__ = str(vendored / "prepare.py")
-
-    def save_data(split):
-        with (vendored / f"{split}.jsonl").open("w") as f:
-            for r in rows:
-                f.write(json.dumps(r) + "\n")
-
-    mod.save_data = save_data
-    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
-    monkeypatch.setattr(_loader.importlib, "import_module", lambda _n: mod)
-
-    examples = _loader.load_via_prepare("bench", ["test"], sample_seed=0)(20)
-    assert len(examples) == 20
-    assert len({e.meta["subset_for_metrics"] for e in examples}) == 2
-
-
-@pytest.mark.parametrize("seed", [0, 7])
-def test_sample_is_a_subset_of_the_split(tmp_path, seed):
-    path = tmp_path / "test.jsonl"
-    _write_grouped(path)
-    everything = {e.inputs["problem"] for e in _loader._read_jsonl(path, "b", None)}
-    sampled = {e.inputs["problem"] for e in _loader._read_jsonl(path, "b", 20, sample_seed=seed)}
-    assert sampled <= everything
-    assert len(sampled) == 20
+    assert len(calls) == 5


### PR DESCRIPTION
The Hendrycks tar is one CSV per subject, so the prepared jsonl is ordered by subject and `--num-examples 64` scored 64 questions from a single category. Measured on one model: 92.5% on the first 64 rows (all `politics`) vs 67.5% on a seeded sample of the same size spanning 16 categories.

`sample_seed` is opt-in per benchmark so the default keeps the streaming first-N read, which long-context splits (ruler2 rows are ~500KB) depend on.