### PR TITLE
Add presets for DeepSeek V4 Pro, Kimi K3, and GLM-5.2

### DIFF
--- a/sgl_eval/model_presets.yaml
+++ b/sgl_eval/model_presets.yaml
@@ -8,3 +8,26 @@ models:
       max_tokens: 200000
       thinking: true
       reasoning_effort: max
+  deepseek-ai/DeepSeek-V4-Pro-0813:
+    model: deepseek-ai/DeepSeek-V4-Pro-0813
+    sampling:
+      temperature: 1.0
+      top_p: 0.95
+      max_tokens: 400000
+      thinking: true
+      reasoning_effort: max
+  moonshotai/Kimi-K3:
+    model: moonshotai/Kimi-K3
+    sampling:
+      temperature: 1.0
+      top_p: 0.95
+      max_tokens: 300000
+      thinking: true
+      reasoning_effort: max
+  zai-org/GLM-5.2-FP8:
+    model: zai-org/GLM-5.2-FP8
+    sampling:
+      temperature: 1.0
+      top_p: 0.95
+      max_tokens: 200000
+      thinking: true


### PR DESCRIPTION
## Summary

Add repository-owned presets for three additional exact Hugging Face model IDs:

| Model ID | Temperature | Top-p | Max tokens | Thinking | Reasoning effort |
| --- | ---: | ---: | ---: | --- | --- |
| `deepseek-ai/DeepSeek-V4-Pro-0813` | 1.0 | 0.95 | 400,000 | enabled | `max` |
| `moonshotai/Kimi-K3` | 1.0 | 0.95 | 300,000 | enabled | `max` |
| `zai-org/GLM-5.2-FP8` | 1.0 | 0.95 | 200,000 | enabled | unset |

GLM-5.2-FP8 intentionally leaves `reasoning_effort` unset.

## Validation

- exercised the real packaged registry loader for all three IDs and verified every resolved model/sampling value
- verified the supported-ID list contains the existing V4 Flash preset plus all three new presets
- `.venv/bin/pytest -q`: **211 passed**
- `pre-commit run --all-files`: **all hooks passed**
