### PR TITLE
Fix chat-template preset precedence

### DIFF
--- a/sgl_eval/preset.py
+++ b/sgl_eval/preset.py
@@ -261,18 +261,15 @@ def apply_to_gen(
     p = preset.sampling if preset else None
     mp = model_preset.sampling if model_preset else None
     chat_template_kwargs = dict(default.chat_template_kwargs or {})
-    thinking = pick(
-        args.thinking,
-        p.thinking if p else None,
-        mp.thinking if mp else None,
-    )
-    if thinking is not None:
-        chat_template_kwargs["thinking"] = thinking
-    if mp and mp.chat_template_kwargs:
-        chat_template_kwargs.update(mp.chat_template_kwargs)
-    if p and p.chat_template_kwargs:
-        chat_template_kwargs.update(p.chat_template_kwargs)
-    chat_template_kwargs.update(parse_chat_template_kwargs(args))
+    for layer_thinking, layer_kwargs in (
+        (mp.thinking, mp.chat_template_kwargs) if mp else (None, None),
+        (p.thinking, p.chat_template_kwargs) if p else (None, None),
+        (args.thinking, parse_chat_template_kwargs(args)),
+    ):
+        if layer_thinking is not None:
+            chat_template_kwargs["thinking"] = layer_thinking
+        if layer_kwargs:
+            chat_template_kwargs.update(layer_kwargs)
     return GenConfig(
         temperature=pick(
             args.temperature,

--- a/sgl_eval/preset.py
+++ b/sgl_eval/preset.py
@@ -260,16 +260,16 @@ def apply_to_gen(
     """
     p = preset.sampling if preset else None
     mp = model_preset.sampling if model_preset else None
+    cli = Sampling(thinking=args.thinking, chat_template_kwargs=parse_chat_template_kwargs(args))
     chat_template_kwargs = dict(default.chat_template_kwargs or {})
-    for layer_thinking, layer_kwargs in (
-        (mp.thinking, mp.chat_template_kwargs) if mp else (None, None),
-        (p.thinking, p.chat_template_kwargs) if p else (None, None),
-        (args.thinking, parse_chat_template_kwargs(args)),
-    ):
-        if layer_thinking is not None:
-            chat_template_kwargs["thinking"] = layer_thinking
-        if layer_kwargs:
-            chat_template_kwargs.update(layer_kwargs)
+    # Lowest priority first; each later layer overwrites the previous one.
+    for layer in (mp, p, cli):
+        if layer is None:
+            continue
+        if layer.thinking is not None:
+            chat_template_kwargs["thinking"] = layer.thinking
+        # Within one source the nested key wins over the flat ``thinking`` alias.
+        chat_template_kwargs.update(layer.chat_template_kwargs or {})
     return GenConfig(
         temperature=pick(
             args.temperature,

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -176,6 +176,16 @@ def test_chat_template_kwarg_wins_over_thinking() -> None:
     gen = apply_to_gen(
         GenConfig(chat_template_kwargs={"thinking": True}),
         preset=None,
+        args=_args(chat_template_kwarg=["thinking=false"]),
+    )
+    assert gen.chat_template_kwargs == {"thinking": False}
+
+
+def test_same_layer_nested_thinking_beats_flat() -> None:
+    """Within one source the nested key wins over the flat ``thinking`` alias."""
+    gen = apply_to_gen(
+        GenConfig(),
+        preset=None,
         args=_args(thinking=True, chat_template_kwarg=["thinking=false"]),
     )
     assert gen.chat_template_kwargs == {"thinking": False}

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from sgl_eval.model_preset import ModelPreset
 from sgl_eval.preset import (
     Endpoint,
     Expected,
@@ -175,7 +176,7 @@ def test_chat_template_kwarg_wins_over_thinking() -> None:
     gen = apply_to_gen(
         GenConfig(chat_template_kwargs={"thinking": True}),
         preset=None,
-        args=_args(chat_template_kwarg=["thinking=false"]),
+        args=_args(thinking=True, chat_template_kwarg=["thinking=false"]),
     )
     assert gen.chat_template_kwargs == {"thinking": False}
 
@@ -213,6 +214,32 @@ def test_apply_to_gen_thinking_priority() -> None:
     # Preset beats default
     gen = apply_to_gen(default, _preset_with(thinking=True), _args())
     assert gen.chat_template_kwargs == {"thinking": True}
+
+
+def test_cli_thinking_beats_user_preset_kwargs() -> None:
+    """A nested preset value must not override an explicit CLI flag."""
+    gen = apply_to_gen(
+        GenConfig(),
+        _preset_with(chat_template_kwargs={"thinking": True}),
+        _args(thinking=False),
+    )
+    assert gen.chat_template_kwargs == {"thinking": False}
+
+
+def test_user_preset_thinking_beats_model_preset_kwargs() -> None:
+    """A nested model default must not override a saved user preset."""
+    model_preset = ModelPreset(
+        model_id="org/model",
+        model="org/model",
+        sampling=Sampling(chat_template_kwargs={"thinking": True}),
+    )
+    gen = apply_to_gen(
+        GenConfig(),
+        _preset_with(thinking=False),
+        _args(),
+        model_preset,
+    )
+    assert gen.chat_template_kwargs == {"thinking": False}
 
 
 def test_apply_to_gen_reasoning_effort_priority() -> None:


### PR DESCRIPTION
## Summary

`apply_to_gen` promises this configuration priority: CLI, saved user preset, built-in model preset, then benchmark default. The `thinking` option could bypass that order because its flat values were selected before nested `chat_template_kwargs` were merged.

For example, an explicit `--no-thinking` was overwritten when a saved preset contained `chat_template_kwargs: {thinking: true}`. The resulting evaluation used a different rendered prompt from the one selected on the command line. This failure still reproduces on current `main` at `db1547d`.

Resolve every configuration source as a complete layer, proceeding from the benchmark default through the model and user presets to the CLI. Generic chat-template values continue to take precedence over flat `thinking` when both come from the same source, preserving the existing `--chat-template-kwarg thinking=...` behavior.

Regression coverage verifies CLI precedence over a saved preset, saved-preset precedence over a built-in model preset, and same-CLI-layer nested-key precedence.

## Validation

Validated on exact head `9067b4348b80b0f4b4a569f5e2b927c96ac00cbc`, rebased onto current `main` at `db1547d6098c791ecb3576353f8a5e9d06344e7c`:

- Current-main control: reproduced `--no-thinking` being overwritten by the user preset's nested `thinking: true`
- `pytest -q tests/test_preset.py tests/test_cli_partial.py`: 31 passed
- `pytest -q`: 239 passed
- Exhaustive flat/nested `thinking` precedence matrix across benchmark, model, user, and CLI layers: 2,187 cases passed
- `pre-commit run --all-files`: passed
- `python scripts/audit_vendored.py`: passed
- `python -m compileall -q sgl_eval tests`: passed
- `python -m build`: sdist and wheel built successfully
- Detached clean-worktree verification confirmed only `sgl_eval/preset.py` and `tests/test_preset.py` changed, with a clean diff and exact Chuyue Wang authorship/sign-off
