### PR TITLE
Use the pinned, verified MMLU archive directly

### DIFF
--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -169,7 +169,7 @@ def load_via_prepare(
     media_field: Optional[str] = None,
     sample_seed: Optional[int] = None,
     argparse_main: bool = False,
-    archive_urls: Optional[Sequence[str]] = None,
+    archive_url: Optional[str] = None,
     archive_sha256: Optional[str] = None,
 ) -> Callable[[Optional[int]], List[Example]]:
     """Loader that runs vendored ``<name>/prepare.py`` once and caches the
@@ -182,16 +182,14 @@ def load_via_prepare(
     ``sample_seed`` makes ``num_examples`` a seeded sample of the whole split
     rather than its first N rows.
 
-    ``archive_urls`` provides ordered mirrors for a prepare module whose
-    ``save_data`` downloads one archive through its module-level ``URL``.
-    sgl-eval downloads and verifies the archive first, then lets the vendored
-    transformation consume the local copy unchanged.
+    ``archive_url`` replaces the source a prepare module downloads through its
+    module-level ``URL``. sgl-eval fetches and verifies the archive first, then
+    lets the vendored transformation consume the local copy unchanged.
     """
     save_kwargs = save_kwargs or {}
-    archive_urls = tuple(archive_urls or ())
-    if bool(archive_urls) != bool(archive_sha256):
-        raise ValueError("archive_urls and archive_sha256 must be configured together")
-    if archive_urls and argparse_main:
+    if bool(archive_url) != bool(archive_sha256):
+        raise ValueError("archive_url and archive_sha256 must be configured together")
+    if archive_url and argparse_main:
         raise ValueError("archive fallback and argparse_main are mutually exclusive")
     if archive_sha256 is not None:
         archive_sha256 = archive_sha256.lower()
@@ -205,12 +203,12 @@ def load_via_prepare(
         if not cache_path.exists():
             mod = importlib.import_module(f"sgl_eval._vendored.nemo_skills.dataset.{name}.prepare")
             vendored_dir = Path(mod.__file__).resolve().parent
-            if archive_urls:
+            if archive_url:
                 _save_data_from_verified_archive(
                     mod,
                     save_args,
                     save_kwargs,
-                    archive_urls,
+                    archive_url,
                     archive_sha256,
                     cache_dir,
                 )
@@ -233,7 +231,7 @@ def _save_data_from_verified_archive(
     mod: Any,
     save_args: Sequence[Any],
     save_kwargs: Dict[str, Any],
-    archive_urls: Sequence[str],
+    archive_url: str,
     archive_sha256: str,
     cache_dir: Path,
 ) -> None:
@@ -242,7 +240,7 @@ def _save_data_from_verified_archive(
         raise RuntimeError("archive fallback requires the prepare module to define URL")
     original_url = mod.URL
     archive_path = _download_verified_archive(
-        archive_urls,
+        archive_url,
         expected_sha256=archive_sha256,
         directory=cache_dir,
     )
@@ -257,54 +255,46 @@ def _save_data_from_verified_archive(
 
 
 def _download_verified_archive(
-    urls: Sequence[str],
+    url: str,
     expected_sha256: str,
     directory: Path,
 ) -> Path:
-    """Download the first reachable archive whose SHA-256 matches."""
+    """Download the archive and return it only if its SHA-256 matches."""
     directory.mkdir(parents=True, exist_ok=True)
-    failures: list[str] = []
+    fd, temp_name = tempfile.mkstemp(
+        prefix=".sgl-eval-archive-",
+        suffix=".tmp",
+        dir=directory,
+    )
+    os.close(fd)
+    temp_path = Path(temp_name)
+    digest = hashlib.sha256()
+    verified = False
+    try:
+        with (
+            temp_path.open("wb") as temp_file,
+            httpx.stream(
+                "GET",
+                url,
+                follow_redirects=True,
+                timeout=_DOWNLOAD_TIMEOUT,
+            ) as response,
+        ):
+            response.raise_for_status()
+            for chunk in response.iter_bytes(_DOWNLOAD_CHUNK_BYTES):
+                temp_file.write(chunk)
+                digest.update(chunk)
 
-    for url in urls:
-        fd, temp_name = tempfile.mkstemp(
-            prefix=".sgl-eval-archive-",
-            suffix=".tmp",
-            dir=directory,
-        )
-        os.close(fd)
-        temp_path = Path(temp_name)
-        digest = hashlib.sha256()
-        verified = False
-        try:
-            with (
-                temp_path.open("wb") as temp_file,
-                httpx.stream(
-                    "GET",
-                    url,
-                    follow_redirects=True,
-                    timeout=_DOWNLOAD_TIMEOUT,
-                ) as response,
-            ):
-                response.raise_for_status()
-                for chunk in response.iter_bytes(_DOWNLOAD_CHUNK_BYTES):
-                    temp_file.write(chunk)
-                    digest.update(chunk)
-
-            actual_sha256 = digest.hexdigest()
-            if actual_sha256 != expected_sha256:
-                raise ValueError(
-                    f"SHA-256 mismatch (expected {expected_sha256}, got {actual_sha256})"
-                )
-            verified = True
-            return temp_path
-        except (OSError, httpx.HTTPError, ValueError) as exc:
-            failures.append(f"{url}: {type(exc).__name__}: {exc}")
-        finally:
-            if not verified:
-                temp_path.unlink(missing_ok=True)
-
-    details = "\n".join(f"- {failure}" for failure in failures)
-    raise RuntimeError(f"Unable to download a verified dataset archive:\n{details}")
+        actual_sha256 = digest.hexdigest()
+        if actual_sha256 != expected_sha256:
+            raise ValueError(
+                f"SHA-256 mismatch for {url} (expected {expected_sha256}, got {actual_sha256})"
+            )
+        verified = True
+        return temp_path
+    finally:
+        if not verified:
+            temp_path.unlink(missing_ok=True)
 
 
 def _move_tree(src: Path, dst: Path) -> None:

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -45,6 +45,8 @@ from sgl_eval.types import Example, MediaItem
 
 _CACHE_ROOT = Path.home() / ".cache" / "sgl_eval"
 _VENDORED_DATASET_ROOT = VENDORED_NS_ROOT / "dataset"
+# Per socket operation, not per download; a 166 MB archive reads in many chunks,
+# so this does not cap a slow but working transfer. Values are arbitrary.
 _DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=10.0)
 _DOWNLOAD_CHUNK_BYTES = 1024 * 1024
 
@@ -182,9 +184,8 @@ def load_via_prepare(
     ``sample_seed`` makes ``num_examples`` a seeded sample of the whole split
     rather than its first N rows.
 
-    ``archive_url`` replaces the source a prepare module downloads through its
-    module-level ``URL``. sgl-eval fetches and verifies the archive first, then
-    lets the vendored transformation consume the local copy unchanged.
+    ``archive_url`` is fetched and digest-checked here, then handed to the
+    vendored script by pointing its module-level ``URL`` at the local copy.
     """
     save_kwargs = save_kwargs or {}
     if bool(archive_url) != bool(archive_sha256):

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -189,8 +189,6 @@ def load_via_prepare(
     save_kwargs = save_kwargs or {}
     if bool(archive_url) != bool(archive_sha256):
         raise ValueError("archive_url and archive_sha256 must be configured together")
-    if archive_url and argparse_main:
-        raise ValueError("archive prefetch and argparse_main are mutually exclusive")
     if archive_sha256 is not None:
         archive_sha256 = archive_sha256.lower()
         if len(archive_sha256) != 64 or any(c not in "0123456789abcdef" for c in archive_sha256):

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -26,19 +26,27 @@ instead, or a small N scores one group only.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib
 import json
+import os
 import random
 import shutil
 import sys
+import tempfile
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import httpx
 
 from sgl_eval import VENDORED_NS_ROOT
 from sgl_eval.types import Example, MediaItem
 
 _CACHE_ROOT = Path.home() / ".cache" / "sgl_eval"
 _VENDORED_DATASET_ROOT = VENDORED_NS_ROOT / "dataset"
+_DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=10.0)
+_DOWNLOAD_CHUNK_BYTES = 1024 * 1024
 
 _MIME_BY_SUFFIX = {
     ".png": "image/png",
@@ -155,12 +163,14 @@ def load_from_path(path: str) -> Callable[[Optional[int]], List[Example]]:
 
 def load_via_prepare(
     name: str,
-    save_args: List[Any],
+    save_args: Sequence[Any],
     save_kwargs: Optional[Dict[str, Any]] = None,
     media_dir: Optional[str] = None,
     media_field: Optional[str] = None,
     sample_seed: Optional[int] = None,
     argparse_main: bool = False,
+    archive_urls: Optional[Sequence[str]] = None,
+    archive_sha256: Optional[str] = None,
 ) -> Callable[[Optional[int]], List[Example]]:
     """Loader that runs vendored ``<name>/prepare.py`` once and caches the
     resulting JSONL.
@@ -171,8 +181,22 @@ def load_via_prepare(
 
     ``sample_seed`` makes ``num_examples`` a seeded sample of the whole split
     rather than its first N rows.
+
+    ``archive_urls`` provides ordered mirrors for a prepare module whose
+    ``save_data`` downloads one archive through its module-level ``URL``.
+    sgl-eval downloads and verifies the archive first, then lets the vendored
+    transformation consume the local copy unchanged.
     """
     save_kwargs = save_kwargs or {}
+    archive_urls = tuple(archive_urls or ())
+    if bool(archive_urls) != bool(archive_sha256):
+        raise ValueError("archive_urls and archive_sha256 must be configured together")
+    if archive_urls and argparse_main:
+        raise ValueError("archive fallback and argparse_main are mutually exclusive")
+    if archive_sha256 is not None:
+        archive_sha256 = archive_sha256.lower()
+        if len(archive_sha256) != 64 or any(c not in "0123456789abcdef" for c in archive_sha256):
+            raise ValueError("archive_sha256 must be a 64-character hexadecimal digest")
     output_basename = f"{save_args[0]}.jsonl"
 
     def loader(num_examples: Optional[int]) -> List[Example]:
@@ -181,7 +205,16 @@ def load_via_prepare(
         if not cache_path.exists():
             mod = importlib.import_module(f"sgl_eval._vendored.nemo_skills.dataset.{name}.prepare")
             vendored_dir = Path(mod.__file__).resolve().parent
-            if argparse_main:
+            if archive_urls:
+                _save_data_from_verified_archive(
+                    mod,
+                    save_args,
+                    save_kwargs,
+                    archive_urls,
+                    archive_sha256,
+                    cache_dir,
+                )
+            elif argparse_main:
                 mod.main(argparse.Namespace(split=save_args[0], **save_kwargs))
             else:
                 mod.save_data(*save_args, **save_kwargs)
@@ -194,6 +227,84 @@ def load_via_prepare(
         return _read_jsonl(cache_path, name, num_examples, media_field, cache_dir, sample_seed)
 
     return loader
+
+
+def _save_data_from_verified_archive(
+    mod: Any,
+    save_args: Sequence[Any],
+    save_kwargs: Dict[str, Any],
+    archive_urls: Sequence[str],
+    archive_sha256: str,
+    cache_dir: Path,
+) -> None:
+    """Run a vendored prepare transform against a verified local archive."""
+    if not hasattr(mod, "URL"):
+        raise RuntimeError("archive fallback requires the prepare module to define URL")
+    original_url = mod.URL
+    archive_path = _download_verified_archive(
+        archive_urls,
+        expected_sha256=archive_sha256,
+        directory=cache_dir,
+    )
+    try:
+        try:
+            mod.URL = archive_path.as_uri()
+            mod.save_data(*save_args, **save_kwargs)
+        finally:
+            mod.URL = original_url
+    finally:
+        archive_path.unlink(missing_ok=True)
+
+
+def _download_verified_archive(
+    urls: Sequence[str],
+    expected_sha256: str,
+    directory: Path,
+) -> Path:
+    """Download the first reachable archive whose SHA-256 matches."""
+    directory.mkdir(parents=True, exist_ok=True)
+    failures: list[str] = []
+
+    for url in urls:
+        fd, temp_name = tempfile.mkstemp(
+            prefix=".sgl-eval-archive-",
+            suffix=".tmp",
+            dir=directory,
+        )
+        os.close(fd)
+        temp_path = Path(temp_name)
+        digest = hashlib.sha256()
+        verified = False
+        try:
+            with (
+                temp_path.open("wb") as temp_file,
+                httpx.stream(
+                    "GET",
+                    url,
+                    follow_redirects=True,
+                    timeout=_DOWNLOAD_TIMEOUT,
+                ) as response,
+            ):
+                response.raise_for_status()
+                for chunk in response.iter_bytes(_DOWNLOAD_CHUNK_BYTES):
+                    temp_file.write(chunk)
+                    digest.update(chunk)
+
+            actual_sha256 = digest.hexdigest()
+            if actual_sha256 != expected_sha256:
+                raise ValueError(
+                    f"SHA-256 mismatch (expected {expected_sha256}, got {actual_sha256})"
+                )
+            verified = True
+            return temp_path
+        except (OSError, httpx.HTTPError, ValueError) as exc:
+            failures.append(f"{url}: {type(exc).__name__}: {exc}")
+        finally:
+            if not verified:
+                temp_path.unlink(missing_ok=True)
+
+    details = "\n".join(f"- {failure}" for failure in failures)
+    raise RuntimeError(f"Unable to download a verified dataset archive:\n{details}")
 
 
 def _move_tree(src: Path, dst: Path) -> None:

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -7,8 +7,8 @@ Two patterns are needed across the current benchmark set:
     read directly.
 
   - **prepare**: data is downloaded by upstream's ``prepare.py`` (gsm8k from
-    openai/grade-school-math, mmlu from Berkeley tar, gpqa and mmlu_pro from
-    HuggingFace). We invoke it once, move its output to
+    openai/grade-school-math, mmlu from a pinned CAIS archive, and gpqa and
+    mmlu_pro from HuggingFace). We invoke it once, move its output to
     ``~/.cache/sgl_eval/<name>/``, and serve from cache on subsequent runs.
     Upstream's entry point is not uniform -- most expose ``save_data(split,
     ...)``, mmlu-pro only an argparse ``main(args)`` -- so ``argparse_main``
@@ -190,7 +190,7 @@ def load_via_prepare(
     if bool(archive_url) != bool(archive_sha256):
         raise ValueError("archive_url and archive_sha256 must be configured together")
     if archive_url and argparse_main:
-        raise ValueError("archive fallback and argparse_main are mutually exclusive")
+        raise ValueError("archive prefetch and argparse_main are mutually exclusive")
     if archive_sha256 is not None:
         archive_sha256 = archive_sha256.lower()
         if len(archive_sha256) != 64 or any(c not in "0123456789abcdef" for c in archive_sha256):
@@ -237,7 +237,7 @@ def _save_data_from_verified_archive(
 ) -> None:
     """Run a vendored prepare transform against a verified local archive."""
     if not hasattr(mod, "URL"):
-        raise RuntimeError("archive fallback requires the prepare module to define URL")
+        raise RuntimeError("archive prefetch requires the prepare module to define URL")
     original_url = mod.URL
     archive_path = _download_verified_archive(
         archive_url,

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -9,6 +9,8 @@ no new module. Each entry encodes only the things that genuinely differ:
   ``loader == "prepare"``.
 - ``argparse_main``: upstream's prepare.py exposes an argparse ``main(args)``
   rather than ``save_data``; ``save_args[0]`` becomes ``args.split``.
+- ``archive_urls`` / ``archive_sha256``: ordered mirrors and the required
+  digest when sgl-eval must prefetch a prepare module's source archive.
 - ``media_dir`` / ``media_field``: multimodal ``prepare`` benchmarks only --
   the sidecar directory ``save_data`` writes beside its jsonl, and the jsonl
   column holding each row's path into it.
@@ -55,6 +57,10 @@ from sgl_eval.predictions import PredSchema
 from sgl_eval.registry import EvalSpec, register
 from sgl_eval.types import GenConfig
 
+_MMLU_ARCHIVE_REVISION = "c30699e8356da336a370243923dbaf21066bb9fe"
+# Git LFS object digest for data.tar at the pinned Hugging Face revision.
+_MMLU_ARCHIVE_SHA256 = "bec563ba4bac1d6aaf04141cd7d1605d7a5ca833e38f994051e818489592989b"
+
 _TABLE = [
     {
         "name": "gsm8k",
@@ -92,6 +98,11 @@ _TABLE = [
         "loader": "prepare",
         "save_args": ("test",),
         "sample_seed": 0,
+        "archive_urls": (
+            "https://people.eecs.berkeley.edu/~hendrycks/data.tar",
+            f"https://huggingface.co/datasets/cais/mmlu/resolve/{_MMLU_ARCHIVE_REVISION}/data.tar",
+        ),
+        "archive_sha256": _MMLU_ARCHIVE_SHA256,
         "thinking": False,
         "default_n_repeats": 1,
         "description": "MMLU all-subjects multichoice (mean accuracy).",
@@ -206,6 +217,8 @@ def _build_loader(entry: dict):
             media_field=entry.get("media_field"),
             sample_seed=entry.get("sample_seed"),
             argparse_main=entry.get("argparse_main", False),
+            archive_urls=entry.get("archive_urls"),
+            archive_sha256=entry.get("archive_sha256"),
         )
     raise ValueError(f"unknown loader kind: {kind!r}")
 

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -9,9 +9,8 @@ no new module. Each entry encodes only the things that genuinely differ:
   ``loader == "prepare"``.
 - ``argparse_main``: upstream's prepare.py exposes an argparse ``main(args)``
   rather than ``save_data``; ``save_args[0]`` becomes ``args.split``.
-- ``archive_url`` / ``archive_sha256``: the source and required digest when
-  sgl-eval must prefetch a prepare module's archive instead of letting the
-  vendored script fetch it.
+- ``archive_url`` / ``archive_sha256``: prefetch and digest-check the prepare
+  module's archive here instead of letting the vendored script fetch it.
 - ``media_dir`` / ``media_field``: multimodal ``prepare`` benchmarks only --
   the sidecar directory ``save_data`` writes beside its jsonl, and the jsonl
   column holding each row's path into it.
@@ -99,10 +98,8 @@ _TABLE = [
         "loader": "prepare",
         "save_args": ("test",),
         "sample_seed": 0,
-        # Upstream points at a personal faculty web space that has had repeated
-        # outages; `cais` is the Center for AI Safety, the authors' own org, so
-        # this is the same archive from a second first-party location rather
-        # than a third-party mirror. Pinned by revision, checked by digest.
+        # `cais` is the Center for AI Safety, the MMLU authors' own org -- this
+        # is the same archive served first-party, not a third-party mirror of it.
         "archive_url": (
             f"https://huggingface.co/datasets/cais/mmlu/resolve/{_MMLU_ARCHIVE_REVISION}/data.tar"
         ),

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -9,8 +9,9 @@ no new module. Each entry encodes only the things that genuinely differ:
   ``loader == "prepare"``.
 - ``argparse_main``: upstream's prepare.py exposes an argparse ``main(args)``
   rather than ``save_data``; ``save_args[0]`` becomes ``args.split``.
-- ``archive_urls`` / ``archive_sha256``: ordered mirrors and the required
-  digest when sgl-eval must prefetch a prepare module's source archive.
+- ``archive_url`` / ``archive_sha256``: the source and required digest when
+  sgl-eval must prefetch a prepare module's archive instead of letting the
+  vendored script fetch it.
 - ``media_dir`` / ``media_field``: multimodal ``prepare`` benchmarks only --
   the sidecar directory ``save_data`` writes beside its jsonl, and the jsonl
   column holding each row's path into it.
@@ -98,9 +99,12 @@ _TABLE = [
         "loader": "prepare",
         "save_args": ("test",),
         "sample_seed": 0,
-        "archive_urls": (
-            "https://people.eecs.berkeley.edu/~hendrycks/data.tar",
-            f"https://huggingface.co/datasets/cais/mmlu/resolve/{_MMLU_ARCHIVE_REVISION}/data.tar",
+        # Upstream points at a personal faculty web space that has had repeated
+        # outages; `cais` is the Center for AI Safety, the authors' own org, so
+        # this is the same archive from a second first-party location rather
+        # than a third-party mirror. Pinned by revision, checked by digest.
+        "archive_url": (
+            f"https://huggingface.co/datasets/cais/mmlu/resolve/{_MMLU_ARCHIVE_REVISION}/data.tar"
         ),
         "archive_sha256": _MMLU_ARCHIVE_SHA256,
         "thinking": False,
@@ -217,7 +221,7 @@ def _build_loader(entry: dict):
             media_field=entry.get("media_field"),
             sample_seed=entry.get("sample_seed"),
             argparse_main=entry.get("argparse_main", False),
-            archive_urls=entry.get("archive_urls"),
+            archive_url=entry.get("archive_url"),
             archive_sha256=entry.get("archive_sha256"),
         )
     raise ValueError(f"unknown loader kind: {kind!r}")

--- a/tests/test_mmlu_download.py
+++ b/tests/test_mmlu_download.py
@@ -177,9 +177,8 @@ def test_missing_prepare_url_fails_before_download(tmp_path, monkeypatch):
 
 @pytest.mark.parametrize(
     ("url", "digest"),
-    # (url, None) is left out: an unpaired url fails at the digest comparison
-    # with a readable message anyway. These two do not -- a digest without a url
-    # is silently never checked, and a malformed one wastes the whole download.
+    # (url, None) is left out -- it fails at the digest comparison anyway. These
+    # two do not: an unpaired digest is never checked, a bad one wastes 166 MB.
     [(None, "0" * 64), (_SOURCE, "not-a-digest")],
 )
 def test_archive_configuration_is_complete_and_valid(url, digest):
@@ -204,10 +203,9 @@ def test_registry_pins_the_archive_revision_and_digest():
 
 
 def test_vendored_prepare_still_exposes_the_url_it_is_redirected_through():
-    """The prefetch works by pointing the vendored module's `URL` at a local
-    file, so that variable is a contract with upstream rather than an internal
-    detail. A sync that renames it puts MMLU back on the original download with
-    nothing else failing -- every other test here drives a fake module."""
+    """A sync that renames the vendored module-level `URL` silently puts MMLU
+    back on the upstream download: the prefetch redirects that name, and every
+    other test here drives a fake module."""
     from sgl_eval._vendored.nemo_skills.dataset.mmlu import prepare
 
     assert isinstance(prepare.URL, str)

--- a/tests/test_mmlu_download.py
+++ b/tests/test_mmlu_download.py
@@ -94,7 +94,6 @@ def test_checksum_failure_cleans_the_temporary_file(tmp_path, monkeypatch):
     monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
     monkeypatch.setattr(_loader.httpx, "stream", fake_stream)
 
-    # A single source means the digest error surfaces directly.
     with pytest.raises(ValueError, match="SHA-256 mismatch"):
         _loader_for(archive)(None)
 
@@ -178,7 +177,10 @@ def test_missing_prepare_url_fails_before_download(tmp_path, monkeypatch):
 
 @pytest.mark.parametrize(
     ("url", "digest"),
-    [(_SOURCE, None), (None, "0" * 64), (_SOURCE, "not-a-digest")],
+    # (url, None) is left out: an unpaired url fails at the digest comparison
+    # with a readable message anyway. These two do not -- a digest without a url
+    # is silently never checked, and a malformed one wastes the whole download.
+    [(None, "0" * 64), (_SOURCE, "not-a-digest")],
 )
 def test_archive_configuration_is_complete_and_valid(url, digest):
     with pytest.raises(ValueError, match="archive_"):
@@ -187,17 +189,6 @@ def test_archive_configuration_is_complete_and_valid(url, digest):
             ["test"],
             archive_url=url,
             archive_sha256=digest,
-        )
-
-
-def test_archive_prefetch_cannot_replace_argparse_entry_point():
-    with pytest.raises(ValueError, match="mutually exclusive"):
-        _loader.load_via_prepare(
-            "invalid",
-            ["test"],
-            argparse_main=True,
-            archive_url=_SOURCE,
-            archive_sha256="0" * 64,
         )
 
 
@@ -210,3 +201,14 @@ def test_registry_pins_the_archive_revision_and_digest():
     assert mmlu["archive_sha256"] == (
         "bec563ba4bac1d6aaf04141cd7d1605d7a5ca833e38f994051e818489592989b"
     )
+
+
+def test_vendored_prepare_still_exposes_the_url_it_is_redirected_through():
+    """The prefetch works by pointing the vendored module's `URL` at a local
+    file, so that variable is a contract with upstream rather than an internal
+    detail. A sync that renames it puts MMLU back on the original download with
+    nothing else failing -- every other test here drives a fake module."""
+    from sgl_eval._vendored.nemo_skills.dataset.mmlu import prepare
+
+    assert isinstance(prepare.URL, str)
+    assert prepare.URL.endswith(".tar")

--- a/tests/test_mmlu_download.py
+++ b/tests/test_mmlu_download.py
@@ -1,0 +1,214 @@
+"""MMLU archive fallback tests (no network)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import types
+import urllib.parse
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+
+import httpx
+import pytest
+
+from sgl_eval.evals import _loader
+
+_PRIMARY = "https://primary.invalid/data.tar"
+_MIRROR = "https://mirror.invalid/data.tar"
+
+
+def _fake_prepare_module(tmp_path: Path, expected_archive: bytes):
+    vendored_dir = tmp_path / "vendored_pkg"
+    vendored_dir.mkdir()
+    mod = types.ModuleType("fake_mmlu_prepare")
+    mod.__file__ = str(vendored_dir / "prepare.py")
+    mod.URL = "https://upstream.invalid/data.tar"
+    consumed_urls = []
+
+    def save_data(split: str) -> None:
+        consumed_urls.append(mod.URL)
+        parsed = urllib.parse.urlparse(mod.URL)
+        assert parsed.scheme == "file"
+        archive_path = Path(urllib.request.url2pathname(parsed.path))
+        assert archive_path.read_bytes() == expected_archive
+        row = {"id": "m1", "problem": "Question", "expected_answer": "A"}
+        (vendored_dir / f"{split}.jsonl").write_text(json.dumps(row) + "\n")
+
+    mod.save_data = save_data
+    return mod, consumed_urls
+
+
+def _loader_for(archive: bytes):
+    return _loader.load_via_prepare(
+        "mmlu",
+        ["test"],
+        archive_urls=(_PRIMARY, _MIRROR),
+        archive_sha256=hashlib.sha256(archive).hexdigest(),
+    )
+
+
+def test_primary_failure_uses_verified_mirror_and_then_cache(tmp_path, monkeypatch):
+    archive = b"pinned MMLU archive"
+    mod, consumed_urls = _fake_prepare_module(tmp_path, archive)
+    seen = []
+
+    @contextmanager
+    def fake_stream(method, url, **kwargs):
+        seen.append((method, url, kwargs))
+        if url == _PRIMARY:
+            request = httpx.Request(method, url)
+            raise httpx.ConnectError("primary unavailable", request=request)
+        yield httpx.Response(200, content=archive, request=httpx.Request(method, url))
+
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
+    monkeypatch.setattr(_loader.httpx, "stream", fake_stream)
+
+    loader = _loader_for(archive)
+    [example] = loader(None)
+    [cached_example] = loader(None)
+
+    assert example.id == cached_example.id == "m1"
+    assert [url for _method, url, _kwargs in seen] == [_PRIMARY, _MIRROR]
+    assert all(kwargs["follow_redirects"] for _method, _url, kwargs in seen)
+    assert all(kwargs["timeout"] is _loader._DOWNLOAD_TIMEOUT for _method, _url, kwargs in seen)
+    assert len(consumed_urls) == 1
+    assert consumed_urls[0].startswith("file:")
+    assert mod.URL == "https://upstream.invalid/data.tar"
+    assert not list((tmp_path / "cache" / "mmlu").glob(".sgl-eval-archive-*"))
+
+
+def test_checksum_failure_tries_all_sources_and_cleans_temporary_files(tmp_path, monkeypatch):
+    archive = b"expected archive"
+    mod, consumed_urls = _fake_prepare_module(tmp_path, archive)
+    seen = []
+
+    @contextmanager
+    def fake_stream(method, url, **kwargs):
+        seen.append(url)
+        yield httpx.Response(
+            200,
+            content=b"unexpected archive",
+            request=httpx.Request(method, url),
+        )
+
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
+    monkeypatch.setattr(_loader.httpx, "stream", fake_stream)
+
+    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+        _loader_for(archive)(None)
+
+    assert seen == [_PRIMARY, _MIRROR]
+    assert consumed_urls == []
+    assert mod.URL == "https://upstream.invalid/data.tar"
+    assert not list((tmp_path / "cache" / "mmlu").glob(".sgl-eval-archive-*"))
+
+
+def test_unexpected_stream_failure_cleans_temporary_file(tmp_path, monkeypatch):
+    archive = b"expected archive"
+    mod, consumed_urls = _fake_prepare_module(tmp_path, archive)
+
+    class FailingStream:
+        def __enter__(self):
+            raise RuntimeError("unexpected transport failure")
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
+    monkeypatch.setattr(_loader.httpx, "stream", lambda *_args, **_kwargs: FailingStream())
+
+    with pytest.raises(RuntimeError, match="unexpected transport failure"):
+        _loader_for(archive)(None)
+
+    assert consumed_urls == []
+    assert not list((tmp_path / "cache" / "mmlu").glob(".sgl-eval-archive-*"))
+
+
+def test_prepare_failure_restores_url_and_removes_verified_archive(tmp_path, monkeypatch):
+    archive = b"pinned MMLU archive"
+    mod, _consumed_urls = _fake_prepare_module(tmp_path, archive)
+    original_url = mod.URL
+    local_urls = []
+
+    def failing_save_data(_split):
+        local_urls.append(mod.URL)
+        raise RuntimeError("prepare failed")
+
+    @contextmanager
+    def fake_stream(method, url, **kwargs):
+        yield httpx.Response(200, content=archive, request=httpx.Request(method, url))
+
+    mod.save_data = failing_save_data
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
+    monkeypatch.setattr(_loader.httpx, "stream", fake_stream)
+
+    with pytest.raises(RuntimeError, match="prepare failed"):
+        _loader.load_via_prepare(
+            "mmlu",
+            ["test"],
+            archive_urls=(_PRIMARY,),
+            archive_sha256=hashlib.sha256(archive).hexdigest(),
+        )(None)
+
+    assert len(local_urls) == 1 and local_urls[0].startswith("file:")
+    assert mod.URL == original_url
+    assert not list((tmp_path / "cache" / "mmlu").glob(".sgl-eval-archive-*"))
+
+
+def test_missing_prepare_url_fails_before_download(tmp_path, monkeypatch):
+    archive = b"pinned MMLU archive"
+    mod, _consumed_urls = _fake_prepare_module(tmp_path, archive)
+    del mod.URL
+
+    def unexpected_stream(*_args, **_kwargs):
+        raise AssertionError("download should not start")
+
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
+    monkeypatch.setattr(_loader.httpx, "stream", unexpected_stream)
+
+    with pytest.raises(RuntimeError, match="prepare module to define URL"):
+        _loader_for(archive)(None)
+
+    assert not (tmp_path / "cache" / "mmlu").exists()
+
+
+@pytest.mark.parametrize(
+    ("urls", "digest"),
+    [((_PRIMARY,), None), (None, "0" * 64), ((_PRIMARY,), "not-a-digest")],
+)
+def test_archive_configuration_is_complete_and_valid(urls, digest):
+    with pytest.raises(ValueError, match="archive_"):
+        _loader.load_via_prepare(
+            "mmlu",
+            ["test"],
+            archive_urls=urls,
+            archive_sha256=digest,
+        )
+
+
+def test_archive_fallback_cannot_replace_argparse_entry_point():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _loader.load_via_prepare(
+            "invalid",
+            ["test"],
+            argparse_main=True,
+            archive_urls=(_PRIMARY,),
+            archive_sha256="0" * 64,
+        )
+
+
+def test_registry_pins_the_mirror_revision_and_archive_digest():
+    from sgl_eval.evals._registry import _TABLE
+
+    [mmlu] = [entry for entry in _TABLE if entry["name"] == "mmlu"]
+    assert "c30699e8356da336a370243923dbaf21066bb9fe" in mmlu["archive_urls"][1]
+    assert mmlu["archive_sha256"] == (
+        "bec563ba4bac1d6aaf04141cd7d1605d7a5ca833e38f994051e818489592989b"
+    )

--- a/tests/test_mmlu_download.py
+++ b/tests/test_mmlu_download.py
@@ -1,4 +1,4 @@
-"""MMLU archive fallback tests (no network)."""
+"""MMLU verified-archive prefetch tests (no network)."""
 
 from __future__ import annotations
 
@@ -94,8 +94,7 @@ def test_checksum_failure_cleans_the_temporary_file(tmp_path, monkeypatch):
     monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
     monkeypatch.setattr(_loader.httpx, "stream", fake_stream)
 
-    # A single source means the digest error surfaces as itself, rather than
-    # wrapped in the "every source failed" report a fallback chain produced.
+    # A single source means the digest error surfaces directly.
     with pytest.raises(ValueError, match="SHA-256 mismatch"):
         _loader_for(archive)(None)
 
@@ -191,7 +190,7 @@ def test_archive_configuration_is_complete_and_valid(url, digest):
         )
 
 
-def test_archive_fallback_cannot_replace_argparse_entry_point():
+def test_archive_prefetch_cannot_replace_argparse_entry_point():
     with pytest.raises(ValueError, match="mutually exclusive"):
         _loader.load_via_prepare(
             "invalid",
@@ -202,7 +201,7 @@ def test_archive_fallback_cannot_replace_argparse_entry_point():
         )
 
 
-def test_registry_pins_the_mirror_revision_and_archive_digest():
+def test_registry_pins_the_archive_revision_and_digest():
     from sgl_eval.evals._registry import _TABLE
 
     [mmlu] = [entry for entry in _TABLE if entry["name"] == "mmlu"]

--- a/tests/test_mmlu_download.py
+++ b/tests/test_mmlu_download.py
@@ -15,8 +15,7 @@ import pytest
 
 from sgl_eval.evals import _loader
 
-_PRIMARY = "https://primary.invalid/data.tar"
-_MIRROR = "https://mirror.invalid/data.tar"
+_SOURCE = "https://pinned.invalid/data.tar"
 
 
 def _fake_prepare_module(tmp_path: Path, expected_archive: bytes):
@@ -44,12 +43,12 @@ def _loader_for(archive: bytes):
     return _loader.load_via_prepare(
         "mmlu",
         ["test"],
-        archive_urls=(_PRIMARY, _MIRROR),
+        archive_url=_SOURCE,
         archive_sha256=hashlib.sha256(archive).hexdigest(),
     )
 
 
-def test_primary_failure_uses_verified_mirror_and_then_cache(tmp_path, monkeypatch):
+def test_archive_is_fetched_once_and_then_served_from_cache(tmp_path, monkeypatch):
     archive = b"pinned MMLU archive"
     mod, consumed_urls = _fake_prepare_module(tmp_path, archive)
     seen = []
@@ -57,9 +56,6 @@ def test_primary_failure_uses_verified_mirror_and_then_cache(tmp_path, monkeypat
     @contextmanager
     def fake_stream(method, url, **kwargs):
         seen.append((method, url, kwargs))
-        if url == _PRIMARY:
-            request = httpx.Request(method, url)
-            raise httpx.ConnectError("primary unavailable", request=request)
         yield httpx.Response(200, content=archive, request=httpx.Request(method, url))
 
     monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
@@ -71,7 +67,7 @@ def test_primary_failure_uses_verified_mirror_and_then_cache(tmp_path, monkeypat
     [cached_example] = loader(None)
 
     assert example.id == cached_example.id == "m1"
-    assert [url for _method, url, _kwargs in seen] == [_PRIMARY, _MIRROR]
+    assert [url for _method, url, _kwargs in seen] == [_SOURCE]
     assert all(kwargs["follow_redirects"] for _method, _url, kwargs in seen)
     assert all(kwargs["timeout"] is _loader._DOWNLOAD_TIMEOUT for _method, _url, kwargs in seen)
     assert len(consumed_urls) == 1
@@ -80,7 +76,7 @@ def test_primary_failure_uses_verified_mirror_and_then_cache(tmp_path, monkeypat
     assert not list((tmp_path / "cache" / "mmlu").glob(".sgl-eval-archive-*"))
 
 
-def test_checksum_failure_tries_all_sources_and_cleans_temporary_files(tmp_path, monkeypatch):
+def test_checksum_failure_cleans_the_temporary_file(tmp_path, monkeypatch):
     archive = b"expected archive"
     mod, consumed_urls = _fake_prepare_module(tmp_path, archive)
     seen = []
@@ -98,10 +94,12 @@ def test_checksum_failure_tries_all_sources_and_cleans_temporary_files(tmp_path,
     monkeypatch.setattr(_loader.importlib, "import_module", lambda _name: mod)
     monkeypatch.setattr(_loader.httpx, "stream", fake_stream)
 
-    with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
+    # A single source means the digest error surfaces as itself, rather than
+    # wrapped in the "every source failed" report a fallback chain produced.
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
         _loader_for(archive)(None)
 
-    assert seen == [_PRIMARY, _MIRROR]
+    assert seen == [_SOURCE]
     assert consumed_urls == []
     assert mod.URL == "https://upstream.invalid/data.tar"
     assert not list((tmp_path / "cache" / "mmlu").glob(".sgl-eval-archive-*"))
@@ -152,7 +150,7 @@ def test_prepare_failure_restores_url_and_removes_verified_archive(tmp_path, mon
         _loader.load_via_prepare(
             "mmlu",
             ["test"],
-            archive_urls=(_PRIMARY,),
+            archive_url=_SOURCE,
             archive_sha256=hashlib.sha256(archive).hexdigest(),
         )(None)
 
@@ -180,15 +178,15 @@ def test_missing_prepare_url_fails_before_download(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("urls", "digest"),
-    [((_PRIMARY,), None), (None, "0" * 64), ((_PRIMARY,), "not-a-digest")],
+    ("url", "digest"),
+    [(_SOURCE, None), (None, "0" * 64), (_SOURCE, "not-a-digest")],
 )
-def test_archive_configuration_is_complete_and_valid(urls, digest):
+def test_archive_configuration_is_complete_and_valid(url, digest):
     with pytest.raises(ValueError, match="archive_"):
         _loader.load_via_prepare(
             "mmlu",
             ["test"],
-            archive_urls=urls,
+            archive_url=url,
             archive_sha256=digest,
         )
 
@@ -199,7 +197,7 @@ def test_archive_fallback_cannot_replace_argparse_entry_point():
             "invalid",
             ["test"],
             argparse_main=True,
-            archive_urls=(_PRIMARY,),
+            archive_url=_SOURCE,
             archive_sha256="0" * 64,
         )
 
@@ -208,7 +206,8 @@ def test_registry_pins_the_mirror_revision_and_archive_digest():
     from sgl_eval.evals._registry import _TABLE
 
     [mmlu] = [entry for entry in _TABLE if entry["name"] == "mmlu"]
-    assert "c30699e8356da336a370243923dbaf21066bb9fe" in mmlu["archive_urls"][1]
+    assert "c30699e8356da336a370243923dbaf21066bb9fe" in mmlu["archive_url"]
+    assert "huggingface.co/datasets/cais/mmlu" in mmlu["archive_url"]
     assert mmlu["archive_sha256"] == (
         "bec563ba4bac1d6aaf04141cd7d1605d7a5ca833e38f994051e818489592989b"
     )


### PR DESCRIPTION
## Motivation

A cold-cache MMLU run delegates archive retrieval to the vendored NeMo-Skills script, whose Berkeley endpoint is timing out. The same archive is available from the MMLU authors' `cais` Hugging Face organization at an immutable revision. Using that pinned first-party source directly removes the known-failing request while keeping the evaluation input and transformation reproducible.

Fixes #33.

## Changes

- Configure MMLU to fetch `data.tar` from `cais/mmlu` at revision `c30699e8356da336a370243923dbaf21066bb9fe`.
- Stream the archive with bounded per-operation connect/read/write/pool timeouts and redirect handling, then require SHA-256 `bec563ba4bac1d6aaf04141cd7d1605d7a5ca833e38f994051e818489592989b` before preparation.
- Give the verified local archive to the unchanged vendored `save_data` transformation through its existing module-level `URL`, restore that state afterward, and remove the temporary archive on success and every tested failure path.
- Preserve the existing cache path and every other prepare benchmark's behavior. Validate complete source/digest configuration and the digest format before downloading.
- Guard the vendored module-level `URL` contract and align loader documentation, runtime errors, and regression-test names with the direct-source design.

## Validation

Validated on exact head `e0e025e19a4417f3823214412970516fb028f263`:

- `pytest -q tests/test_mmlu_download.py tests/test_mmlu_pro.py`: 14 passed
- `pytest -q`: 237 passed
- `pre-commit run --all-files`: passed
- `python scripts/audit_vendored.py`: passed
- `python -m compileall -q sgl_eval tests`: passed
- Registry invariant probe confirmed every configured archive has a paired digest and no archive-prefetch entry uses the argparse-only prepare path
- Independent HTTP-status and mid-stream transport failure checks: exceptions propagated and partial archives were removed
- The pinned source returns HTTP 200 with `X-Repo-Commit: c30699e8356da336a370243923dbaf21066bb9fe`, a 166,184,960-byte object, and `X-Linked-ETag: bec563ba4bac1d6aaf04141cd7d1605d7a5ca833e38f994051e818489592989b`
- Real cold-cache preparation from the pinned source produced 14,042 examples across 57 subjects and left no archive temporary files
- Clean-worktree verification confirmed the three intended changed files, a clean diff, and exact Chuyue Wang authorship/sign-off on contributor commits

The regression suite covers direct fetch and cache reuse, checksum rejection, transport cleanup, prepare-failure cleanup, module-state restoration, missing vendored URL handling, invalid source/digest configuration, the real vendored `URL` contract, and pinned-source provenance.
