### PR TITLE
Add `--prompt` to override a benchmark's prompt yaml

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -30,10 +30,34 @@ Sampling lines up with NS's `InferenceConfig` field for field, including
 to the served model's `generation_config.json`, which would otherwise decide
 them.
 
-Two knobs differ.
+Three knobs differ.
 
 **`seed`**: NS sends `seed=0`, sgl-eval sends none unless asked. Add `--seed 0`
 to match. It has no effect at `temperature=0`.
+
+**`prompt_config`**: each benchmark uses upstream's default -- the one its
+vendored `dataset/<name>/__init__.py` names in `GENERATION_ARGS`. An NS run
+that passed `++prompt_config=<other>` asked a different question, so its score
+will not reproduce until you pass the same prompt. `--prompt <name-or-path>`
+does that: a bare name resolves against the vendored NS prompts and then
+sgl-eval's own `evals/prompts/`, and anything with a `/` or a `.yaml` suffix
+is read as a file, so a prompt this repo does not ship still works.
+
+The case that actually comes up is AIME. Published AIME numbers are frequently
+produced with `eval/matharena/aime`, which states that the answer is an integer
+between 0 and 999; `generic/math` -- the default -- does not. Vendored here as
+`matharena-aime`:
+
+```bash
+sgl-eval run aime25 --base-url http://localhost:30000/v1 \
+  --model <model> --n-repeats 32 --temperature 1.0 --top-p 0.95 \
+  --prompt matharena-aime
+```
+
+An overridden prompt is recorded under `prompt` in `metrics.json`; a score
+carrying that key is not comparable with one that does not. `ruler2` rejects
+the flag -- its prompt is a pure passthrough and the context is assembled by
+the prepare scripts.
 
 **`temperature`, if the NS run went through `ns eval`**: that pipeline does
 *not* use `InferenceConfig`'s `temperature=0.0`. The repeat suffix on

--- a/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
+++ b/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
@@ -156,6 +156,12 @@ files:
     dst: prompts/math.yaml
   - src: nemo_skills/prompt/config/eval/aai/mcq-4choices.yaml
     dst: prompts/mcq-4choices.yaml
+  # Not a default for any benchmark -- reachable only via `run --prompt
+  # matharena-aime`. Published AIME numbers are often produced with this
+  # phrasing (it states the 0-999 integer range, which `generic/math` does
+  # not), so a run reproducing one needs it available.
+  - src: nemo_skills/prompt/config/eval/matharena/aime.yaml
+    dst: prompts/matharena-aime.yaml
   - src: nemo_skills/prompt/config/eval/aai/mcq-4choices-boxed.yaml
     dst: prompts/mcq-4choices-boxed.yaml
   # RULER2's ++prompt_config. Pure passthrough (`user: "{question}"`) -- the

--- a/sgl_eval/_vendored/nemo_skills/prompts/matharena-aime.yaml
+++ b/sgl_eval/_vendored/nemo_skills/prompts/matharena-aime.yaml
@@ -1,0 +1,13 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/prompt/config/eval/matharena/aime.yaml
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# MathArena AIME prompt - matches https://github.com/MathArena
+# Used for reproducing MathArena benchmark results
+
+user: |-
+  Please reason step by step, and put your final answer within \boxed{{}}.
+  The answer is an integer between 0 and 999 inclusive.
+
+  {problem}

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -121,6 +121,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="path to NS-shape jsonl ({id?, problem, expected_answer}); "
         "replaces the vendored dataset for this run",
     )
+    p_run.add_argument(
+        "--prompt",
+        default=None,
+        metavar="NAME_OR_PATH",
+        help="prompt yaml to wrap each question in, overriding the benchmark's "
+        "own (e.g. matharena-aime for AIME's MathArena phrasing). A bare name "
+        "resolves against the vendored NeMo-Skills prompts then sgl-eval's own; "
+        "a path or *.yaml is read as a file. Changes what the model is asked, so "
+        "scores are not comparable across prompts -- the choice is recorded in "
+        "metrics.json.",
+    )
     p_run.set_defaults(func=cmd_run, dump_predictions=True)
 
     # Benchmarks contribute their own options, so argparse -- not a hand-rolled

--- a/sgl_eval/evals/_math.py
+++ b/sgl_eval/evals/_math.py
@@ -2,7 +2,7 @@
 evaluator.
 
 Mirrors NS pipeline stages:
-  - Stage 2a (prompt render): vendored ``prompts/math.yaml`` + ``str.format``.
+  - Stage 2a (prompt render): the benchmark's prompt yaml + ``str.format``.
   - Stage 2c (extract + score): vendored ``MathEvaluator.eval_single``.
   - Stage 4 (aggregate): vendored ``MathMetrics.update`` + ``get_metrics``.
 """
@@ -10,21 +10,22 @@ Mirrors NS pipeline stages:
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from sgl_eval._vendored.nemo_skills.evaluator.math import MathEvaluator
 from sgl_eval._vendored.nemo_skills.math_metrics import MathMetrics
-from sgl_eval.evals._prompts import render_prompt, vendored_prompt
+from sgl_eval.evals._prompts import render_prompt
 from sgl_eval.predictions import PredictionsWriter, sample_to_pred
 from sgl_eval.runner import SampleFn, ScoreOneFn, run_examples
 from sgl_eval.sampler import ChatCompletionSampler
 from sgl_eval.types import Example, ExampleResult, GenConfig, RunResult, Sample
 
-_MATH_PROMPT_YAML = vendored_prompt("math")
 
-
-def render_math_prompt(problem: str, few_shot_examples: Optional[list] = None) -> str:
-    return render_prompt(_MATH_PROMPT_YAML, problem=problem, few_shot_examples=few_shot_examples)
+def render_math_prompt(
+    prompt_yaml: Path, problem: str, few_shot_examples: Optional[list] = None
+) -> str:
+    return render_prompt(prompt_yaml, problem=problem, few_shot_examples=few_shot_examples)
 
 
 def _eval_single_sync(evaluator: MathEvaluator, data_point: Dict[str, Any]) -> Dict[str, Any]:
@@ -33,9 +34,9 @@ def _eval_single_sync(evaluator: MathEvaluator, data_point: Dict[str, Any]) -> D
     return asyncio.run(evaluator.eval_single(data_point))
 
 
-def make_sample_fn(sampler: ChatCompletionSampler, gen: GenConfig) -> SampleFn:
+def make_sample_fn(sampler: ChatCompletionSampler, gen: GenConfig, prompt_yaml: Path) -> SampleFn:
     def sample_fn(ex: Example, _rep_idx: int) -> Sample:
-        prompt = render_math_prompt(ex.inputs["problem"])
+        prompt = render_math_prompt(prompt_yaml, ex.inputs["problem"])
         return sampler([{"role": "user", "content": prompt}], gen)
 
     return sample_fn
@@ -101,12 +102,13 @@ def run_math_benchmark(
     num_examples: Optional[int],
     num_threads: int,
     load_examples: Callable[[Optional[int]], List[Example]],
+    prompt_yaml: Path,
     evaluator_config: Optional[Dict[str, Any]] = None,
     predictions_writer: Optional[PredictionsWriter] = None,
 ) -> RunResult:
     examples = load_examples(num_examples)
     evaluator = MathEvaluator(config=evaluator_config or {})
-    sample_fn = make_sample_fn(sampler, gen)
+    sample_fn = make_sample_fn(sampler, gen, prompt_yaml)
     score_one_fn = make_score_one_fn(evaluator)
     aggregator = (
         (lambda results: aggregate_with_math_metrics(results, n_repeats)) if n_repeats > 1 else None

--- a/sgl_eval/evals/_prompts.py
+++ b/sgl_eval/evals/_prompts.py
@@ -27,12 +27,9 @@ def vendored_prompt(name: str) -> Path:
 def resolve_prompt(spec: str) -> Path:
     """Resolve a prompt spec to a yaml path.
 
-    A bare basename resolves against the vendored NeMo-Skills prompts first,
-    then sgl-eval's own ``prompts/``. Anything carrying a path separator or a
-    ``.yaml`` suffix is taken as a filesystem path instead, so a caller can
-    point at a prompt this repo does not ship. Existence is not checked here:
-    registration resolves every benchmark's default at import time, and a
-    missing file should surface where it is read, not where it is named.
+    The path branch exists so a caller can point at a prompt this repo does not
+    ship. Existence is deliberately not checked: registration resolves every
+    benchmark's default at import time, so a raise here would fail at import.
     """
     if "/" in spec or spec.endswith(".yaml"):
         return Path(spec).expanduser()

--- a/sgl_eval/evals/_prompts.py
+++ b/sgl_eval/evals/_prompts.py
@@ -16,11 +16,30 @@ import yaml
 _VENDORED_PROMPT_DIR = (
     Path(__file__).resolve().parent.parent / "_vendored" / "nemo_skills" / "prompts"
 )
+_SE_PROMPT_DIR = Path(__file__).resolve().parent / "prompts"
 
 
 def vendored_prompt(name: str) -> Path:
     """Return the path to a vendored prompt yaml by basename (no extension)."""
     return _VENDORED_PROMPT_DIR / f"{name}.yaml"
+
+
+def resolve_prompt(spec: str) -> Path:
+    """Resolve a prompt spec to a yaml path.
+
+    A bare basename resolves against the vendored NeMo-Skills prompts first,
+    then sgl-eval's own ``prompts/``. Anything carrying a path separator or a
+    ``.yaml`` suffix is taken as a filesystem path instead, so a caller can
+    point at a prompt this repo does not ship. Existence is not checked here:
+    registration resolves every benchmark's default at import time, and a
+    missing file should surface where it is read, not where it is named.
+    """
+    if "/" in spec or spec.endswith(".yaml"):
+        return Path(spec).expanduser()
+    vendored = vendored_prompt(spec)
+    if vendored.exists():
+        return vendored
+    return _SE_PROMPT_DIR / f"{spec}.yaml"
 
 
 def prompt_media_config(yaml_path: Path) -> dict:

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -39,22 +39,19 @@ ships no dataset metadata -- its subtasks only exist once generated).
 from __future__ import annotations
 
 import importlib
-from pathlib import Path
 from typing import Any, Callable, Dict, Tuple
 
 from sgl_eval.evals._loader import load_bundled, load_via_prepare
 from sgl_eval.evals._math import run_math_benchmark
 from sgl_eval.evals._mmmu_pro import load_mmmu_pro
 from sgl_eval.evals._multichoice import run_multichoice_benchmark
-from sgl_eval.evals._prompts import vendored_prompt
+from sgl_eval.evals._prompts import resolve_prompt
 from sgl_eval.evals._ruler2 import PRED_SCHEMA as _RULER2_PRED_SCHEMA
 from sgl_eval.evals._ruler2 import add_arguments as _add_ruler2_arguments
 from sgl_eval.evals._ruler2 import run_ruler2_benchmark
 from sgl_eval.predictions import PredSchema
 from sgl_eval.registry import EvalSpec, register
 from sgl_eval.types import GenConfig
-
-_SE_PROMPT_DIR = Path(__file__).resolve().parent / "prompts"
 
 _TABLE = [
     {
@@ -170,14 +167,6 @@ def _resolve_upstream_metadata(name: str) -> Tuple[str, str]:
     return metrics_type, prompt_config.split("/")[-1]
 
 
-def _resolve_prompt(basename: str) -> Path:
-    """Vendored prompt if it exists, else sgl-eval's own prompts/ dir."""
-    vendored = vendored_prompt(basename)
-    if vendored.exists():
-        return vendored
-    return _SE_PROMPT_DIR / f"{basename}.yaml"
-
-
 def _build_default_gen(thinking: bool) -> GenConfig:
     """All NS-aligned defaults (``temperature=0.0``, ``top_p=0.95``,
     ``max_tokens=None``); only ``chat_template_kwargs.thinking`` varies."""
@@ -207,7 +196,9 @@ def _build_loader(entry: dict):
 # Per-category behavior, in one place. Every factory takes the same arguments so
 # the registration loop below stays free of benchmark names; a new category is a
 # new row here plus its runner module.
-def _math_run(name: str, _prompt_basename: str, loader: Callable):
+def _math_run(name: str, prompt_basename: str, loader: Callable):
+    default_prompt_yaml = resolve_prompt(prompt_basename)
+
     def run(
         *,
         sampler,
@@ -218,6 +209,7 @@ def _math_run(name: str, _prompt_basename: str, loader: Callable):
         predictions_writer=None,
         load_examples=None,
         bench_args=None,
+        prompt_yaml=None,
     ):
         return run_math_benchmark(
             name=name,
@@ -227,6 +219,7 @@ def _math_run(name: str, _prompt_basename: str, loader: Callable):
             num_examples=num_examples,
             num_threads=num_threads,
             load_examples=load_examples or loader,
+            prompt_yaml=prompt_yaml or default_prompt_yaml,
             predictions_writer=predictions_writer,
         )
 
@@ -234,7 +227,7 @@ def _math_run(name: str, _prompt_basename: str, loader: Callable):
 
 
 def _mcq_run(name: str, prompt_basename: str, loader: Callable):
-    prompt_yaml = _resolve_prompt(prompt_basename)
+    default_prompt_yaml = resolve_prompt(prompt_basename)
 
     def run(
         *,
@@ -246,6 +239,7 @@ def _mcq_run(name: str, prompt_basename: str, loader: Callable):
         predictions_writer=None,
         load_examples=None,
         bench_args=None,
+        prompt_yaml=None,
     ):
         return run_multichoice_benchmark(
             name=name,
@@ -255,7 +249,7 @@ def _mcq_run(name: str, prompt_basename: str, loader: Callable):
             num_examples=num_examples,
             num_threads=num_threads,
             load_examples=load_examples or loader,
-            prompt_yaml=prompt_yaml,
+            prompt_yaml=prompt_yaml or default_prompt_yaml,
             predictions_writer=predictions_writer,
         )
 
@@ -273,7 +267,14 @@ def _ruler2_run(name: str, _prompt_basename: str, _loader: Callable):
         predictions_writer=None,
         load_examples=None,
         bench_args=None,
+        prompt_yaml=None,
     ):
+        if prompt_yaml is not None:
+            raise ValueError(
+                f"{name} does not take a prompt override: its prompt is a pure "
+                'passthrough (`user: "{question}"`) and the whole context is '
+                "assembled by the prepare scripts."
+            )
         return run_ruler2_benchmark(
             name=name,
             sampler=sampler,

--- a/sgl_eval/pipeline/report.py
+++ b/sgl_eval/pipeline/report.py
@@ -68,6 +68,10 @@ def _build_run_meta(ctx: RunContext) -> Dict[str, Any]:
     # these -- without them a metrics.json cannot say which setup it scored.
     if ctx.bench_args:
         meta["bench_args"] = dict(ctx.bench_args)
+    # Only on override: a different prompt is a different question, so a score
+    # carrying this key is not comparable with one that doesn't.
+    if ctx.prompt_yaml is not None:
+        meta["prompt"] = {"spec": ctx.args.prompt, "path": str(ctx.prompt_yaml)}
     model_preset_block = make_model_preset_meta_block(ctx.inputs.model_preset)
     if model_preset_block:
         meta["model_preset"] = model_preset_block

--- a/sgl_eval/pipeline/report.py
+++ b/sgl_eval/pipeline/report.py
@@ -68,8 +68,8 @@ def _build_run_meta(ctx: RunContext) -> Dict[str, Any]:
     # these -- without them a metrics.json cannot say which setup it scored.
     if ctx.bench_args:
         meta["bench_args"] = dict(ctx.bench_args)
-    # Only on override: a different prompt is a different question, so a score
-    # carrying this key is not comparable with one that doesn't.
+    # A different prompt is a different question: a score carrying this key is
+    # not comparable with one that does not.
     if ctx.prompt_yaml is not None:
         meta["prompt"] = {"spec": ctx.args.prompt, "path": str(ctx.prompt_yaml)}
     model_preset_block = make_model_preset_meta_block(ctx.inputs.model_preset)

--- a/sgl_eval/pipeline/run.py
+++ b/sgl_eval/pipeline/run.py
@@ -19,6 +19,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             predictions_writer=ctx.writer,
             load_examples=ctx.load_examples,
             bench_args=ctx.bench_args,
+            prompt_yaml=ctx.prompt_yaml,
         )
     finally:
         setup.teardown(ctx)

--- a/sgl_eval/pipeline/setup.py
+++ b/sgl_eval/pipeline/setup.py
@@ -82,8 +82,7 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
 
 
 def _resolve_prompt_override(spec: Optional[str]) -> Optional[Path]:
-    """Resolve ``--prompt`` up front so a typo fails before the first request
-    rather than on the first render, after the server is already loaded."""
+    """Resolve up front so a typo fails before the server is loaded, not at first render."""
     if spec is None:
         return None
     path = resolve_prompt(spec)

--- a/sgl_eval/pipeline/setup.py
+++ b/sgl_eval/pipeline/setup.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from sgl_eval.evals._loader import load_from_path
+from sgl_eval.evals._prompts import resolve_prompt
 from sgl_eval.predictions import PredictionsWriter
 from sgl_eval.preset import ResolvedRunInputs, resolve_run_inputs
 from sgl_eval.registry import EvalSpec, get
@@ -34,6 +35,8 @@ class RunContext:
     args: argparse.Namespace
     load_examples: Optional[Callable[[Optional[int]], List[Example]]]
     bench_args: Dict[str, Any]
+    # None means "the benchmark's registered prompt"; set only by --prompt.
+    prompt_yaml: Optional[Path]
     _prev_sigint_handler: Any
 
 
@@ -60,6 +63,7 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
     load_examples = load_from_path(args.from_dataset) if args.from_dataset else None
 
     num_threads = args.num_threads if args.num_threads is not None else spec.default_num_threads
+    prompt_yaml = _resolve_prompt_override(getattr(args, "prompt", None))
 
     return RunContext(
         inputs=inputs,
@@ -72,8 +76,20 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
         args=args,
         load_examples=load_examples,
         bench_args=_collect_bench_args(args, spec.name),
+        prompt_yaml=prompt_yaml,
         _prev_sigint_handler=prev_sigint,
     )
+
+
+def _resolve_prompt_override(spec: Optional[str]) -> Optional[Path]:
+    """Resolve ``--prompt`` up front so a typo fails before the first request
+    rather than on the first render, after the server is already loaded."""
+    if spec is None:
+        return None
+    path = resolve_prompt(spec)
+    if not path.exists():
+        raise FileNotFoundError(f"--prompt {spec!r}: no prompt yaml at {path}")
+    return path
 
 
 def _collect_bench_args(args: argparse.Namespace, name: str) -> Dict[str, Any]:

--- a/tests/test_mmmu_pro.py
+++ b/tests/test_mmmu_pro.py
@@ -218,11 +218,11 @@ def test_mmmu_pro_registered():
 def test_mmmu_pro_prompt_packaged():
     """The SE-own 10-choice prompt must ship in the installed package -- the
     vendored prompts are declared in pyproject package-data, but this one is
-    not, and ``_resolve_prompt`` returns a path ``render_prompt`` reads at
+    not, and ``resolve_prompt`` returns a path ``render_prompt`` reads at
     run time. A missing file crashes the first MMMU-Pro run, not import."""
-    from sgl_eval.evals._registry import _resolve_prompt
+    from sgl_eval.evals._prompts import resolve_prompt
 
-    assert _resolve_prompt("mcq-10choices").exists()
+    assert resolve_prompt("mcq-10choices").exists()
 
 
 def test_max_tokens_not_pinned_for_any_benchmark():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -38,6 +38,7 @@ def test_math_pipeline_end_to_end():
     def loader(num_examples):
         return examples[:num_examples] if num_examples else examples
 
+    from sgl_eval.evals._prompts import vendored_prompt
     from sgl_eval.types import GenConfig
 
     result = run_math_benchmark(
@@ -48,6 +49,7 @@ def test_math_pipeline_end_to_end():
         num_examples=None,
         num_threads=2,
         load_examples=loader,
+        prompt_yaml=vendored_prompt("math"),
     )
     assert result.num_examples == 3
     assert result.aggregate["score"] == 1.0

--- a/tests/test_prompt_override.py
+++ b/tests/test_prompt_override.py
@@ -2,9 +2,7 @@
 
 A benchmark's prompt is part of what it measures -- ``generic/math`` and
 ``eval/matharena/aime`` ask an AIME question differently, so their scores are
-not comparable. These tests pin that the override reaches the sampler, that a
-bad spec fails before any request goes out, and that the choice lands in
-``metrics.json``.
+not comparable.
 """
 
 from __future__ import annotations

--- a/tests/test_prompt_override.py
+++ b/tests/test_prompt_override.py
@@ -1,0 +1,173 @@
+"""``run --prompt``: swapping the prompt yaml a benchmark wraps questions in.
+
+A benchmark's prompt is part of what it measures -- ``generic/math`` and
+``eval/matharena/aime`` ask an AIME question differently, so their scores are
+not comparable. These tests pin that the override reaches the sampler, that a
+bad spec fails before any request goes out, and that the choice lands in
+``metrics.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from sgl_eval.evals._prompts import _SE_PROMPT_DIR, render_prompt, resolve_prompt, vendored_prompt
+from sgl_eval.registry import get
+from sgl_eval.types import Example, GenConfig, Sample
+
+
+def test_resolve_prompt_prefers_vendored_then_se_own():
+    assert resolve_prompt("math") == vendored_prompt("math")
+    # mcq-10choices is sgl-eval's own; upstream ships no such config.
+    assert not vendored_prompt("mcq-10choices").exists()
+    assert resolve_prompt("mcq-10choices") == _SE_PROMPT_DIR / "mcq-10choices.yaml"
+
+
+def test_resolve_prompt_takes_a_path_verbatim(tmp_path):
+    """A user reproducing someone else's numbers may hold a prompt this repo
+    does not ship; a path (or a .yaml basename) bypasses the two search dirs."""
+    own = tmp_path / "custom.yaml"
+    own.write_text("user: |-\n  {problem}\n")
+    assert resolve_prompt(str(own)) == own
+
+
+def test_matharena_prompt_is_vendored_and_differs_from_generic_math():
+    matharena = resolve_prompt("matharena-aime")
+    assert matharena.exists()
+    rendered = render_prompt(matharena, problem="Find n.")
+    assert "integer between 0 and 999" in rendered
+    assert "Find n." in rendered
+    # The distinguishing claim: generic/math never states the answer range.
+    assert "integer between 0 and 999" not in render_prompt(
+        vendored_prompt("math"), problem="Find n."
+    )
+
+
+class _PromptCapturingSampler:
+    """Records the user message each request was built from."""
+
+    def __init__(self):
+        self.prompts = []
+
+    def __call__(self, messages, gen):
+        self.prompts.append(messages[0]["content"])
+        return Sample(text="\\boxed{42}", completion_tokens=3, finish_reason="stop")
+
+
+def _one_example_loader(_num_examples):
+    return [Example(id="p1", inputs={"problem": "Find n."}, target="42")]
+
+
+@pytest.mark.parametrize("benchmark", ["aime25", "gsm8k"])
+def test_prompt_override_reaches_the_math_sampler(benchmark):
+    sampler = _PromptCapturingSampler()
+    get(benchmark).run(
+        sampler=sampler,
+        gen=GenConfig(),
+        n_repeats=1,
+        num_examples=1,
+        num_threads=1,
+        load_examples=_one_example_loader,
+        prompt_yaml=resolve_prompt("matharena-aime"),
+    )
+    assert sampler.prompts and "integer between 0 and 999" in sampler.prompts[0]
+
+
+def test_math_default_prompt_still_applies_without_override():
+    """The registered basename -- not a module-level constant -- is what a
+    math benchmark falls back to, so the two cannot drift apart."""
+    sampler = _PromptCapturingSampler()
+    get("aime25").run(
+        sampler=sampler,
+        gen=GenConfig(),
+        n_repeats=1,
+        num_examples=1,
+        num_threads=1,
+        load_examples=_one_example_loader,
+        prompt_yaml=None,
+    )
+    assert "Solve the following math problem" in sampler.prompts[0]
+    assert "integer between 0 and 999" not in sampler.prompts[0]
+
+
+def _run_gpqa_capturing(prompt_yaml):
+    sampler = _PromptCapturingSampler()
+
+    def loader(_num_examples):
+        return [Example(id="q1", inputs={"problem": "Q?\n\nA) x\nB) y"}, target="A")]
+
+    get("gpqa").run(
+        sampler=sampler,
+        gen=GenConfig(),
+        n_repeats=1,
+        num_examples=1,
+        num_threads=1,
+        load_examples=loader,
+        prompt_yaml=prompt_yaml,
+    )
+    assert sampler.prompts
+    return sampler.prompts[0]
+
+
+def test_prompt_override_reaches_the_multichoice_sampler():
+    """gpqa's registered prompt is the plain `Answer: A/B/C/D` variant; the
+    override swaps in the boxed one, which is the only difference between them."""
+    overridden = _run_gpqa_capturing(vendored_prompt("mcq-4choices-boxed"))
+    assert "Answer: \\boxed{A/B/C/D}" in overridden
+    assert "Answer: \\boxed{A/B/C/D}" not in _run_gpqa_capturing(None)
+
+
+def test_ruler2_refuses_a_prompt_override():
+    """RULER2's prompt is `user: "{question}"` -- the context is assembled by
+    the prepare scripts, so an override would silently do nothing."""
+    with pytest.raises(ValueError, match="does not take a prompt override"):
+        get("ruler2").run(
+            sampler=_PromptCapturingSampler(),
+            gen=GenConfig(),
+            n_repeats=1,
+            num_examples=1,
+            num_threads=1,
+            prompt_yaml=vendored_prompt("math"),
+        )
+
+
+def test_unknown_prompt_fails_before_the_first_request():
+    """Resolution happens in setup, not at first render -- otherwise a typo
+    only surfaces after the server is up and the dataset is loaded."""
+    from sgl_eval.pipeline.setup import _resolve_prompt_override
+
+    assert _resolve_prompt_override(None) is None
+    with pytest.raises(FileNotFoundError, match="no-such-prompt"):
+        _resolve_prompt_override("no-such-prompt")
+
+
+def test_run_meta_records_the_override_only_when_set():
+    from sgl_eval.pipeline.report import _build_run_meta
+
+    def _ctx(prompt_yaml, spec):
+        return SimpleNamespace(
+            stamp="20260828-000000",
+            sampler=SimpleNamespace(model="m"),
+            inputs=SimpleNamespace(base_url="http://x/v1", gen=GenConfig(), model_preset=None),
+            num_threads=1,
+            bench_args={},
+            prompt_yaml=prompt_yaml,
+            args=argparse.Namespace(prompt=spec),
+        )
+
+    assert "prompt" not in _build_run_meta(_ctx(None, None))
+    meta = _build_run_meta(_ctx(resolve_prompt("matharena-aime"), "matharena-aime"))
+    assert meta["prompt"]["spec"] == "matharena-aime"
+    assert meta["prompt"]["path"].endswith("matharena-aime.yaml")
+
+
+def test_run_subcommand_exposes_prompt():
+    from sgl_eval.cli import build_parser
+
+    args = build_parser().parse_args(
+        ["run", "aime25", "--base-url", "http://x/v1", "--prompt", "matharena-aime"]
+    )
+    assert args.prompt == "matharena-aime"

--- a/tests/test_vendored_evaluator.py
+++ b/tests/test_vendored_evaluator.py
@@ -44,8 +44,9 @@ def test_aime_bundled_data_loads(name):
 
 def test_prompt_render_no_few_shot():
     from sgl_eval.evals._math import render_math_prompt
+    from sgl_eval.evals._prompts import vendored_prompt
 
-    rendered = render_math_prompt("What is 2+2?")
+    rendered = render_math_prompt(vendored_prompt("math"), "What is 2+2?")
     assert "Solve the following math problem" in rendered
     assert "\\boxed{}" in rendered
     assert "What is 2+2?" in rendered
@@ -54,8 +55,10 @@ def test_prompt_render_no_few_shot():
 
 def test_prompt_render_with_few_shot():
     from sgl_eval.evals._math import render_math_prompt
+    from sgl_eval.evals._prompts import vendored_prompt
 
     rendered = render_math_prompt(
+        vendored_prompt("math"),
         "Find x.",
         few_shot_examples=[{"problem": "1+1=?", "solution": "\\boxed{2}"}],
     )


### PR DESCRIPTION
Lets a run swap the prompt each question is wrapped in, so a published number produced with a different `++prompt_config` can be reproduced. Vendors `eval/matharena/aime` as `matharena-aime` for the AIME case.