### PR TITLE
Add `mmlu_pro` (text 10-choice MMLU-Pro)

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -12,6 +12,7 @@ an endpoint. Most need nothing.
 | `gsm8k` | math | -- |
 | `aime24/25/26` | math | one per contest year, same shape |
 | `mmlu` | multichoice | -- |
+| `mmlu_pro` | multichoice | text 10-choice; **not** `mmmu_pro` -- [see below](#mmlu-pro-vs-mmmu-pro) |
 | `gpqa` | multichoice | Diamond split |
 | `mmmu_pro` | multichoice | VLM endpoint; MMMU-Pro `standard (10 options)` -- [see below](#mmmu-pro-variants) |
 | `mmmu_pro_vision` | multichoice | VLM endpoint; MMMU-Pro `vision` -- [see below](#mmmu-pro-variants) |
@@ -70,6 +71,26 @@ greedy.
 
 ---
 
+## MMLU-Pro vs MMMU-Pro
+
+Two unrelated benchmarks one letter apart, adjacent in `sgl-eval list`.
+
+| | `mmlu_pro` | `mmmu_pro` |
+|---|---|---|
+| dataset | TIGER-Lab/MMLU-Pro, 12032 text questions | MMMU-Pro, multimodal |
+| options | exactly 10, A-J | 4-10, varies per question |
+| endpoint | any chat endpoint | needs a VLM |
+| prompt | vendored `mcq-10choices`, enumerates A-J | sgl-eval's `mmmu-pro-cot`, `$LETTER` + CoT |
+
+The prompts are deliberately not shared: `resolve_prompt` prefers the vendored
+copy, so giving them one basename would silently hand MMMU-Pro a prompt that
+enumerates ten letters for a question that may have four.
+
+`mmlu_pro`'s split is ordered by subject, so it carries `sample_seed` -- a small
+`--num-examples` samples across subjects instead of scoring one of them.
+
+---
+
 ## MMMU-Pro variants
 
 MMMU-Pro ships several HuggingFace configs. Two are registered, and they are
@@ -81,7 +102,7 @@ MMMU-Pro ships several HuggingFace configs. Two are registered, and they are
 | question text | in the prompt | rendered into the screenshot |
 | options | up to 10, as text | in the screenshot (and echoed as text) |
 | images per question | `<image 1..7>`, placed inline | one screenshot, placed first |
-| prompt | sgl-eval's `mcq-10choices`, asks for CoT | vendored `vlm/mmmu-pro`, no CoT |
+| prompt | sgl-eval's `mmmu-pro-cot`, asks for CoT | vendored `vlm/mmmu-pro`, no CoT |
 
 `mmmu_pro_vision` is the one upstream NeMo-Skills ships, so it is the row to
 use when reproducing an NS number or an `ns eval --benchmarks=mmmu-pro` run.

--- a/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
+++ b/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
@@ -115,6 +115,15 @@ files:
     dst: dataset/gpqa/__init__.py
   - src: nemo_skills/dataset/gpqa/prepare.py
     dst: dataset/gpqa/prepare.py
+  # `dst` de-hyphenates because `_resolve_upstream_metadata` imports this dir
+  # as a Python module. Unlike gpqa/mmlu, this prepare.py exposes only an
+  # argparse `main(args)`, which the registry row flags with `argparse_main`.
+  # `subsets/` is deliberately absent: it backs upstream's `10pct_opt_v1`
+  # split, and sgl-eval evaluates `test`.
+  - src: nemo_skills/dataset/mmlu-pro/__init__.py
+    dst: dataset/mmlu_pro/__init__.py
+  - src: nemo_skills/dataset/mmlu-pro/prepare.py
+    dst: dataset/mmlu_pro/prepare.py
   # MMMU-Pro `vision` config (see `_registry.py` for what it evaluates).
   # `dst` de-hyphenates because `_resolve_upstream_metadata` imports this dir
   # as a Python module; it says `vision` to stay distinct from the `mmmu_pro`
@@ -164,6 +173,10 @@ files:
     dst: prompts/matharena-aime.yaml
   - src: nemo_skills/prompt/config/eval/aai/mcq-4choices-boxed.yaml
     dst: prompts/mcq-4choices-boxed.yaml
+  # MMLU-Pro's default. Hardcodes A-J, so it is not interchangeable with
+  # sgl-eval's own `mmmu-pro-cot` -- see the note there.
+  - src: nemo_skills/prompt/config/eval/aai/mcq-10choices.yaml
+    dst: prompts/mcq-10choices.yaml
   # RULER2's ++prompt_config. Pure passthrough (`user: "{question}"`) -- the
   # long context is already assembled by the prepare scripts.
   - src: nemo_skills/prompt/config/generic/default.yaml

--- a/sgl_eval/_vendored/nemo_skills/dataset/mmlu_pro/__init__.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/mmlu_pro/__init__.py
@@ -1,0 +1,22 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/mmlu-pro/__init__.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# settings that define how evaluation should be done by default (all can be changed from cmdline)
+
+METRICS_TYPE = "multichoice"
+GENERATION_ARGS = "++prompt_config=eval/aai/mcq-10choices ++eval_type=multichoice"

--- a/sgl_eval/_vendored/nemo_skills/dataset/mmlu_pro/prepare.py
+++ b/sgl_eval/_vendored/nemo_skills/dataset/mmlu_pro/prepare.py
@@ -1,0 +1,75 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/dataset/mmlu-pro/prepare.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from pathlib import Path
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from sgl_eval._vendored.nemo_skills.dataset._utils import filter_by_subset, get_mcq_fields, load_subset_ids
+
+SUBSETS_DIR = Path(__file__).absolute().parent / "subsets"
+
+
+def format_entry(entry):
+    category = entry["category"].replace(" ", "_")  # Fix computer science category
+
+    return {
+        "expected_answer": entry["answer"],
+        "examples_type": f"mmlu_pro_few_shot_{category}",
+        "subset_for_metrics": category,
+        **get_mcq_fields(entry["question"], entry["options"]),
+    }
+
+
+def write_data_to_file(output_file, data):
+    with open(output_file, "wt", encoding="utf-8") as fout:
+        for entry in tqdm(data, desc=f"Writing {output_file.name}"):
+            json.dump(format_entry(entry), fout)
+            fout.write("\n")
+
+
+def main(args):
+    if args.split in ("validation", "test"):
+        dataset = load_dataset("TIGER-Lab/MMLU-Pro")[args.split]
+    else:
+        subset_file = SUBSETS_DIR / f"{args.split}.txt"
+        if not subset_file.exists():
+            raise ValueError(
+                f"Unknown split '{args.split}'. Expected 'validation', 'test', or a subset file at subsets/{args.split}.txt"
+            )
+        dataset = load_dataset("TIGER-Lab/MMLU-Pro")["test"]
+        subset_ids = load_subset_ids(subset_file)
+        dataset = filter_by_subset(dataset, subset_ids, question_key="question", options_key="options")
+
+    data_dir = Path(__file__).absolute().parent
+    data_dir.mkdir(exist_ok=True)
+    output_file = data_dir / f"{args.split}.jsonl"
+    write_data_to_file(output_file, dataset)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--split", default="test", choices=("validation", "test", "10pct_opt_v1"), help="Dataset split to process."
+    )
+    args = parser.parse_args()
+    main(args)

--- a/sgl_eval/_vendored/nemo_skills/prompts/mcq-10choices.yaml
+++ b/sgl_eval/_vendored/nemo_skills/prompts/mcq-10choices.yaml
@@ -1,0 +1,12 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/prompt/config/eval/aai/mcq-10choices.yaml
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Default prompt for multuple choice benchmarks with ten answer choices (e.g. MMLU-Pro). It's intended for instruction-following models.
+# Based on https://artificialanalysis.ai/methodology/intelligence-benchmarking#intelligence-index-evaluation-suite-overview
+
+user: |-
+  Answer the following multiple choice question. The last line of your response should be in the following format: 'Answer: A/B/C/D/E/F/G/H/I/J' (e.g. 'Answer: A').
+
+  {problem}

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -6,10 +6,13 @@ Two patterns are needed across the current benchmark set:
     ``test.txt`` jsonl beside ``prepare.py``). The vendored ``test.txt`` is
     read directly.
 
-  - **prepare**: data is downloaded by upstream's ``prepare.py:save_data``
-    (gsm8k from openai/grade-school-math, mmlu from Berkeley tar, gpqa from
-    HuggingFace). We invoke the vendored function once, move its output to
+  - **prepare**: data is downloaded by upstream's ``prepare.py`` (gsm8k from
+    openai/grade-school-math, mmlu from Berkeley tar, gpqa and mmlu_pro from
+    HuggingFace). We invoke it once, move its output to
     ``~/.cache/sgl_eval/<name>/``, and serve from cache on subsequent runs.
+    Upstream's entry point is not uniform -- most expose ``save_data(split,
+    ...)``, mmlu-pro only an argparse ``main(args)`` -- so ``argparse_main``
+    selects the call shape.
 
 A multimodal **prepare** benchmark also writes a media sidecar dir beside its
 jsonl and references it by relative path (mmmu_pro_vision -> ``images/`` +
@@ -22,6 +25,7 @@ instead, or a small N scores one group only.
 
 from __future__ import annotations
 
+import argparse
 import importlib
 import json
 import random
@@ -156,9 +160,10 @@ def load_via_prepare(
     media_dir: Optional[str] = None,
     media_field: Optional[str] = None,
     sample_seed: Optional[int] = None,
+    argparse_main: bool = False,
 ) -> Callable[[Optional[int]], List[Example]]:
-    """Loader that runs vendored ``<name>/prepare.py:save_data`` once and
-    caches the resulting JSONL.
+    """Loader that runs vendored ``<name>/prepare.py`` once and caches the
+    resulting JSONL.
 
     ``media_dir`` is a sidecar dir ``save_data`` writes beside the jsonl;
     ``media_field`` is the jsonl column pointing into it. Both land in the cache
@@ -176,7 +181,10 @@ def load_via_prepare(
         if not cache_path.exists():
             mod = importlib.import_module(f"sgl_eval._vendored.nemo_skills.dataset.{name}.prepare")
             vendored_dir = Path(mod.__file__).resolve().parent
-            mod.save_data(*save_args, **save_kwargs)
+            if argparse_main:
+                mod.main(argparse.Namespace(split=save_args[0], **save_kwargs))
+            else:
+                mod.save_data(*save_args, **save_kwargs)
             cache_dir.mkdir(parents=True, exist_ok=True)
             shutil.move(str(vendored_dir / output_basename), str(cache_path))
             # save_data's data_dir is `Path(__file__).parent`, i.e. inside

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -107,9 +107,7 @@ _TABLE = [
     },
     {
         # MMLU-Pro, not to be confused with `mmmu_pro` below -- one letter
-        # apart and adjacent in `sgl-eval list`, but a text 10-choice exam
-        # vs a multimodal one. Its prepare.py exposes only an argparse
-        # `main(args)`; every other prepare benchmark exposes save_data.
+        # apart and adjacent in `sgl-eval list`, but a text 10-choice exam.
         "name": "mmlu_pro",
         "loader": "prepare",
         "save_args": ("test",),

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -7,6 +7,8 @@ no new module. Each entry encodes only the things that genuinely differ:
   (run vendored ``prepare.py:save_data``).
 - ``save_args`` / ``save_kwargs``: signature for ``save_data`` when
   ``loader == "prepare"``.
+- ``argparse_main``: upstream's prepare.py exposes an argparse ``main(args)``
+  rather than ``save_data``; ``save_args[0]`` becomes ``args.split``.
 - ``media_dir`` / ``media_field``: multimodal ``prepare`` benchmarks only --
   the sidecar directory ``save_data`` writes beside its jsonl, and the jsonl
   column holding each row's path into it.
@@ -104,13 +106,29 @@ _TABLE = [
         "description": "GPQA Diamond (graduate-level QA, pass@k + majority@k).",
     },
     {
+        # MMLU-Pro, not to be confused with `mmmu_pro` below -- one letter
+        # apart and adjacent in `sgl-eval list`, but a text 10-choice exam
+        # vs a multimodal one. Its prepare.py exposes only an argparse
+        # `main(args)`; every other prepare benchmark exposes save_data.
+        "name": "mmlu_pro",
+        "loader": "prepare",
+        "save_args": ("test",),
+        "argparse_main": True,
+        # 12032 rows ordered by category, so a small --num-examples would
+        # otherwise score one subject only.
+        "sample_seed": 0,
+        "thinking": False,
+        "default_n_repeats": 1,
+        "description": "MMLU-Pro (12032 questions, 10-choice, reasoning-heavy).",
+    },
+    {
         # SE-own: upstream ships MMMU-Pro's `vision` config only (registered
         # below as `mmmu_pro_vision`), not `standard (10 options)`. So
         # metrics_type + prompt + loader_fn bypass the vendored
         # dataset/__init__.py + prepare path.
         "name": "mmmu_pro",
         "metrics_type": "multichoice",
-        "prompt": "mcq-10choices",
+        "prompt": "mmmu-pro-cot",
         "loader_fn": lambda num_examples: load_mmmu_pro("test", num_examples),
         "thinking": False,
         "default_n_repeats": 1,
@@ -189,6 +207,7 @@ def _build_loader(entry: dict):
             media_dir=entry.get("media_dir"),
             media_field=entry.get("media_field"),
             sample_seed=entry.get("sample_seed"),
+            argparse_main=entry.get("argparse_main", False),
         )
     raise ValueError(f"unknown loader kind: {kind!r}")
 

--- a/sgl_eval/evals/prompts/mmmu-pro-cot.yaml
+++ b/sgl_eval/evals/prompts/mmmu-pro-cot.yaml
@@ -1,5 +1,7 @@
 # sgl-eval prompt for MMMU-Pro (multimodal, variable-choice). SE-own
-# (NeMo-Skills upstream has no MMMU-Pro). Aligns with the official MMMU-Pro
+# (NeMo-Skills upstream has no MMMU-Pro). Named for the benchmark rather than
+# the option count, so it stays distinct from the vendored `mcq-10choices`,
+# which is MMLU-Pro's and does hardcode A-J. Aligns with the official MMMU-Pro
 # cot/standard prompt: "$LETTER ... one of the options" adapts to the
 # variable option count (MMMU-Pro ships 4-10 options per question) instead
 # of hardcoding A-J; "Think step by step" elicits CoT from reasoning models.

--- a/tests/test_mmlu_pro.py
+++ b/tests/test_mmlu_pro.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 import json
 import types
 
-import pytest
-
 from sgl_eval.evals import _loader
 from sgl_eval.evals._prompts import render_prompt, resolve_prompt
 from sgl_eval.registry import get
@@ -82,27 +80,16 @@ def test_default_shape_still_calls_save_data(tmp_path, monkeypatch):
     assert calls == {"save_data": ("test",)}
 
 
-def test_mmlu_pro_is_registered_with_the_argparse_shape():
-    """The loader flag lives in the registry row, so this is the only place
-    the two halves are connected."""
-    from sgl_eval.evals._registry import _TABLE
+def test_registry_wires_mmlu_pro_to_the_argparse_shape(tmp_path, monkeypatch):
+    """Dropping ``argparse_main`` from the row, or forgetting to forward it in
+    ``_build_loader``, leaves mmlu_pro calling a ``save_data`` its prepare.py
+    does not have."""
+    from sgl_eval.evals._registry import _TABLE, _build_loader
+
+    mod, calls = _fake_prepare_module(tmp_path)
+    _install(monkeypatch, tmp_path, mod)
 
     row = next(r for r in _TABLE if r["name"] == "mmlu_pro")
-    assert row["argparse_main"] is True
-    # Rows are ordered by category, so a subject-ordered split needs a seed
-    # for --num-examples to span more than one subject.
-    assert row["sample_seed"] == 0
+    _build_loader(row)(None)
 
-
-@pytest.mark.parametrize("name", ["mmlu_pro", "mmmu_pro"])
-def test_the_two_pro_benchmarks_do_not_share_a_prompt(name):
-    """One letter apart in the registry and adjacent in `sgl-eval list`, but
-    MMLU-Pro is a text 10-choice exam and MMMU-Pro a multimodal variable-choice
-    one. ``resolve_prompt`` prefers vendored, so a shared basename would
-    silently give MMMU-Pro the A-J prompt."""
-    from sgl_eval.evals._registry import _TABLE, _resolve_upstream_metadata
-
-    row = next(r for r in _TABLE if r["name"] == name)
-    basename = row["prompt"] if "prompt" in row else _resolve_upstream_metadata(name)[1]
-    assert basename == ("mcq-10choices" if name == "mmlu_pro" else "mmmu-pro-cot")
-    assert resolve_prompt(basename).exists()
+    assert calls == {"main": "test"}

--- a/tests/test_mmlu_pro.py
+++ b/tests/test_mmlu_pro.py
@@ -1,0 +1,108 @@
+"""MMLU-Pro: upstream metadata, the argparse-``main`` prepare shape, and the
+prompt it must not share with ``mmmu_pro``.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+
+import pytest
+
+from sgl_eval.evals import _loader
+from sgl_eval.evals._prompts import render_prompt, resolve_prompt
+from sgl_eval.registry import get
+
+
+def test_mmlu_pro_registered_from_upstream_metadata():
+    """``metrics_type`` and the prompt basename are derived from the vendored
+    ``dataset/mmlu_pro/__init__.py``, never hand-mirrored -- so an upstream
+    sync that retargets either one has to show up here."""
+    from sgl_eval.evals._registry import _resolve_upstream_metadata
+
+    assert get("mmlu_pro").category == "multichoice"
+    assert _resolve_upstream_metadata("mmlu_pro") == ("multichoice", "mcq-10choices")
+
+
+def test_mmlu_pro_prompt_enumerates_ten_letters():
+    rendered = render_prompt(resolve_prompt("mcq-10choices"), problem="Q?\n\nA) x\nB) y")
+    assert "Answer: A/B/C/D/E/F/G/H/I/J" in rendered
+    assert "Q?" in rendered
+
+
+def _fake_prepare_module(tmp_path, rows=3):
+    """Stands in for a vendored prepare.py: records which entry point ran and
+    writes the jsonl where the real one would."""
+    calls = {}
+
+    def _write():
+        with (tmp_path / "test.jsonl").open("w") as f:
+            for i in range(rows):
+                f.write(json.dumps({"problem": f"q{i}", "expected_answer": "A"}) + "\n")
+
+    def main(args):
+        calls["main"] = args.split
+        _write()
+
+    def save_data(*args, **kwargs):
+        calls["save_data"] = args
+        _write()
+
+    mod = types.SimpleNamespace(
+        __file__=str(tmp_path / "prepare.py"), main=main, save_data=save_data
+    )
+    return mod, calls
+
+
+def _install(monkeypatch, tmp_path, mod):
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _path: mod)
+
+
+def test_argparse_main_shape_calls_main_with_the_split(tmp_path, monkeypatch):
+    """mmlu-pro's prepare.py has no ``save_data``; calling the wrong entry
+    point raises AttributeError only once someone actually runs the benchmark,
+    which needs a 12k-row download."""
+    mod, calls = _fake_prepare_module(tmp_path)
+    _install(monkeypatch, tmp_path, mod)
+
+    examples = _loader.load_via_prepare("mmlu_pro", ["test"], {}, argparse_main=True)(None)
+
+    assert calls == {"main": "test"}
+    assert [e.inputs["problem"] for e in examples] == ["q0", "q1", "q2"]
+
+
+def test_default_shape_still_calls_save_data(tmp_path, monkeypatch):
+    """The flag is opt-in: every other prepare benchmark keeps save_data."""
+    mod, calls = _fake_prepare_module(tmp_path)
+    _install(monkeypatch, tmp_path, mod)
+
+    _loader.load_via_prepare("gpqa", ["test"], {"random_seed": 42})(None)
+
+    assert calls == {"save_data": ("test",)}
+
+
+def test_mmlu_pro_is_registered_with_the_argparse_shape():
+    """The loader flag lives in the registry row, so this is the only place
+    the two halves are connected."""
+    from sgl_eval.evals._registry import _TABLE
+
+    row = next(r for r in _TABLE if r["name"] == "mmlu_pro")
+    assert row["argparse_main"] is True
+    # Rows are ordered by category, so a subject-ordered split needs a seed
+    # for --num-examples to span more than one subject.
+    assert row["sample_seed"] == 0
+
+
+@pytest.mark.parametrize("name", ["mmlu_pro", "mmmu_pro"])
+def test_the_two_pro_benchmarks_do_not_share_a_prompt(name):
+    """One letter apart in the registry and adjacent in `sgl-eval list`, but
+    MMLU-Pro is a text 10-choice exam and MMMU-Pro a multimodal variable-choice
+    one. ``resolve_prompt`` prefers vendored, so a shared basename would
+    silently give MMMU-Pro the A-J prompt."""
+    from sgl_eval.evals._registry import _TABLE, _resolve_upstream_metadata
+
+    row = next(r for r in _TABLE if r["name"] == name)
+    basename = row["prompt"] if "prompt" in row else _resolve_upstream_metadata(name)[1]
+    assert basename == ("mcq-10choices" if name == "mmlu_pro" else "mmmu-pro-cot")
+    assert resolve_prompt(basename).exists()

--- a/tests/test_mmmu_pro.py
+++ b/tests/test_mmmu_pro.py
@@ -222,7 +222,19 @@ def test_mmmu_pro_prompt_packaged():
     run time. A missing file crashes the first MMMU-Pro run, not import."""
     from sgl_eval.evals._prompts import resolve_prompt
 
-    assert resolve_prompt("mcq-10choices").exists()
+    assert resolve_prompt("mmmu-pro-cot").exists()
+
+
+def test_mmmu_pro_prompt_is_not_shadowed_by_the_vendored_10choice():
+    """`mcq-10choices` is MMLU-Pro's vendored prompt and hardcodes A-J;
+    MMMU-Pro ships 4-10 options per question and needs its own. Since
+    ``resolve_prompt`` prefers vendored, sharing the basename would silently
+    swap MMMU-Pro's prompt for MMLU-Pro's."""
+    from sgl_eval.evals._prompts import resolve_prompt
+
+    mmmu = resolve_prompt("mmmu-pro-cot").read_text()
+    assert "$LETTER" in mmmu and "A/B/C/D/E/F/G/H/I/J" not in mmmu
+    assert "A/B/C/D/E/F/G/H/I/J" in resolve_prompt("mcq-10choices").read_text()
 
 
 def test_max_tokens_not_pinned_for_any_benchmark():

--- a/tests/test_mmmu_pro.py
+++ b/tests/test_mmmu_pro.py
@@ -232,9 +232,9 @@ def test_mmmu_pro_prompt_is_not_shadowed_by_the_vendored_10choice():
     swap MMMU-Pro's prompt for MMLU-Pro's."""
     from sgl_eval.evals._prompts import resolve_prompt
 
+    assert resolve_prompt("mmmu-pro-cot") != resolve_prompt("mcq-10choices")
     mmmu = resolve_prompt("mmmu-pro-cot").read_text()
     assert "$LETTER" in mmmu and "A/B/C/D/E/F/G/H/I/J" not in mmmu
-    assert "A/B/C/D/E/F/G/H/I/J" in resolve_prompt("mcq-10choices").read_text()
 
 
 def test_max_tokens_not_pinned_for_any_benchmark():

--- a/tests/test_prompt_override.py
+++ b/tests/test_prompt_override.py
@@ -19,9 +19,9 @@ from sgl_eval.types import Example, GenConfig, Sample
 
 def test_resolve_prompt_prefers_vendored_then_se_own():
     assert resolve_prompt("math") == vendored_prompt("math")
-    # mcq-10choices is sgl-eval's own; upstream ships no such config.
-    assert not vendored_prompt("mcq-10choices").exists()
-    assert resolve_prompt("mcq-10choices") == _SE_PROMPT_DIR / "mcq-10choices.yaml"
+    # mmmu-pro-cot is sgl-eval's own; upstream ships no MMMU-Pro config.
+    assert not vendored_prompt("mmmu-pro-cot").exists()
+    assert resolve_prompt("mmmu-pro-cot") == _SE_PROMPT_DIR / "mmmu-pro-cot.yaml"
 
 
 def test_resolve_prompt_takes_a_path_verbatim(tmp_path):


### PR DESCRIPTION
Vendors upstream's `mmlu-pro` dataset and its `eval/aai/mcq-10choices` prompt. Renames the SE-own `mcq-10choices` to `mmmu-pro-cot` so the vendored copy does not shadow MMMU-Pro's variable-choice prompt.