### PR TITLE
Retry and mirror the vendored dataset downloads

### DIFF
--- a/sgl_eval/evals/_fetch.py
+++ b/sgl_eval/evals/_fetch.py
@@ -1,0 +1,97 @@
+"""Make the vendored `prepare.py` downloads survive a flaky origin.
+
+Upstream's prepare scripts call `urllib.request.urlretrieve(URL, path)` with a
+hard-coded URL, no timeout and no retry, so one unreachable host ends the run
+with a bare `Errno 110`. Those files are synced verbatim from NeMo-Skills and
+carry a DO-NOT-EDIT banner, so the retry/mirror policy lives here and is
+installed around the call instead.
+
+MMLU is the case that actually bites: its archive is served from a personal
+faculty web space that has had repeated outages (sgl-project/sgl-eval#33), while
+every other benchmark here loads from HuggingFace or GitHub.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from typing import Dict, List
+
+# Same archive as the primary, pinned to a commit so the bytes cannot move under
+# us. Verified to produce the expected 14042 MMLU test rows.
+_MMLU_PRIMARY = "https://people.eecs.berkeley.edu/~hendrycks/data.tar"
+_MMLU_HF_MIRROR = (
+    "https://huggingface.co/datasets/cais/mmlu/resolve/"
+    "c30699e8356da336a370243923dbaf21066bb9fe/data.tar"
+)
+
+MIRRORS: Dict[str, List[str]] = {_MMLU_PRIMARY: [_MMLU_HF_MIRROR]}
+
+# Override the whole chain for one dataset, e.g. an internal mirror or a
+# file:// path in an air-gapped environment.
+_OVERRIDE_ENV = {_MMLU_PRIMARY: "SGL_EVAL_MMLU_URL"}
+
+# Two tries, not more: a host that refuses twice with a 30s socket timeout is
+# down, not busy, and the mirror is one hop away. Worst case before falling
+# through is 2 * 30s + one backoff, which a cold-cache CI job can absorb.
+_ATTEMPTS_PER_URL = 2
+_BACKOFF_SECONDS = 2.0
+# Per socket operation, not per download -- a 166 MB body reads in many chunks,
+# each with its own budget, so this does not cap a slow but working transfer.
+_TIMEOUT_SECONDS = 30.0
+
+
+def _candidates(url: str) -> List[str]:
+    override = os.environ.get(_OVERRIDE_ENV.get(url, ""))
+    if override:
+        return [override]
+    return [url, *MIRRORS.get(url, [])]
+
+
+def _download(url: str, filename: str) -> None:
+    """One attempt, with a socket timeout urlretrieve does not offer."""
+    with urllib.request.urlopen(url, timeout=_TIMEOUT_SECONDS) as response:
+        with open(filename, "wb") as out:
+            while chunk := response.read(1 << 20):
+                out.write(chunk)
+
+
+def retrieve(url: str, filename: str) -> str:
+    """Try each candidate `_ATTEMPTS_PER_URL` times before moving to the next."""
+    errors = []
+    for candidate in _candidates(url):
+        for attempt in range(_ATTEMPTS_PER_URL):
+            try:
+                _download(candidate, filename)
+                return candidate
+            except (urllib.error.URLError, OSError) as exc:
+                errors.append(f"{candidate}: {exc}")
+                if attempt + 1 < _ATTEMPTS_PER_URL:
+                    time.sleep(_BACKOFF_SECONDS * (attempt + 1))
+    raise RuntimeError("could not download " + url + " from any source:\n  " + "\n  ".join(errors))
+
+
+@contextmanager
+def resilient_downloads():
+    """Point `urllib.request.urlretrieve` at `retrieve` for the duration.
+
+    Patching the module the vendored script imports is what keeps the policy out
+    of the vendored file; the original is restored on the way out so nothing
+    else in the process inherits it.
+    """
+    original = urllib.request.urlretrieve
+
+    def patched(url, filename=None, reporthook=None, data=None):
+        if filename is None:  # only the caching form is used by prepare scripts
+            return original(url, filename, reporthook, data)
+        retrieve(url, filename)
+        return filename, None
+
+    urllib.request.urlretrieve = patched
+    try:
+        yield
+    finally:
+        urllib.request.urlretrieve = original

--- a/sgl_eval/evals/_loader.py
+++ b/sgl_eval/evals/_loader.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from sgl_eval import VENDORED_NS_ROOT
+from sgl_eval.evals._fetch import resilient_downloads
 from sgl_eval.types import Example, MediaItem
 
 _CACHE_ROOT = Path.home() / ".cache" / "sgl_eval"
@@ -181,10 +182,11 @@ def load_via_prepare(
         if not cache_path.exists():
             mod = importlib.import_module(f"sgl_eval._vendored.nemo_skills.dataset.{name}.prepare")
             vendored_dir = Path(mod.__file__).resolve().parent
-            if argparse_main:
-                mod.main(argparse.Namespace(split=save_args[0], **save_kwargs))
-            else:
-                mod.save_data(*save_args, **save_kwargs)
+            with resilient_downloads():
+                if argparse_main:
+                    mod.main(argparse.Namespace(split=save_args[0], **save_kwargs))
+                else:
+                    mod.save_data(*save_args, **save_kwargs)
             cache_dir.mkdir(parents=True, exist_ok=True)
             shutil.move(str(vendored_dir / output_basename), str(cache_path))
             # save_data's data_dir is `Path(__file__).parent`, i.e. inside

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,116 @@
+"""Download fallback for the vendored prepare scripts.
+
+The failure this guards is a cold-cache run dying on one unreachable host
+(sgl-project/sgl-eval#33). Nothing here touches the network: the point is the
+ordering and the restore, not the transfer.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+
+import pytest
+
+from sgl_eval.evals import _fetch
+
+PRIMARY = _fetch._MMLU_PRIMARY
+
+
+def test_mmlu_falls_back_to_a_mirror():
+    assert _fetch._candidates(PRIMARY)[0] == PRIMARY, "primary must stay first"
+    assert len(_fetch._candidates(PRIMARY)) > 1, "mmlu needs a mirror"
+
+
+def test_an_unmirrored_url_is_left_alone():
+    """Only URLs in the table get alternates -- a typo'd host must not
+    silently resolve to someone else's data."""
+    assert _fetch._candidates("https://other.example/x.tar") == ["https://other.example/x.tar"]
+
+
+def test_override_replaces_the_whole_chain(monkeypatch):
+    """An air-gapped or internal-mirror run must not still reach for the
+    public hosts, so the override is exclusive rather than prepended."""
+    monkeypatch.setenv("SGL_EVAL_MMLU_URL", "file:///data/mmlu.tar")
+    assert _fetch._candidates(PRIMARY) == ["file:///data/mmlu.tar"]
+
+
+def test_retrieve_moves_on_after_the_primary_fails(monkeypatch):
+    seen = []
+
+    def fake(url, filename):
+        seen.append(url)
+        if url == PRIMARY:
+            raise urllib.error.URLError("timed out")
+
+    monkeypatch.setattr(_fetch, "_download", fake)
+    monkeypatch.setattr(_fetch, "_BACKOFF_SECONDS", 0)
+
+    used = _fetch.retrieve(PRIMARY, "/tmp/x.tar")
+    assert used != PRIMARY
+    assert seen.count(PRIMARY) == _fetch._ATTEMPTS_PER_URL, "primary retried before moving on"
+
+
+def test_retrieve_reports_every_source_it_tried(monkeypatch):
+    """A bare 'Errno 110' was the original complaint -- the error has to name
+    what was attempted, or the next person cannot tell a dead mirror from a
+    dead network."""
+    monkeypatch.setattr(
+        _fetch, "_download", lambda url, filename: (_ for _ in ()).throw(OSError("nope"))
+    )
+    monkeypatch.setattr(_fetch, "_BACKOFF_SECONDS", 0)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _fetch.retrieve(PRIMARY, "/tmp/x.tar")
+    for candidate in _fetch._candidates(PRIMARY):
+        assert candidate in str(excinfo.value)
+
+
+def test_patch_is_scoped_to_the_block(monkeypatch):
+    """The vendored scripts are called inside this context; leaking the patch
+    would change urlretrieve for everything else in the process."""
+    monkeypatch.setattr(_fetch, "_download", lambda url, filename: None)
+    original = urllib.request.urlretrieve
+
+    with _fetch.resilient_downloads():
+        assert urllib.request.urlretrieve is not original
+        path, headers = urllib.request.urlretrieve(PRIMARY, "/tmp/x.tar")
+        assert path == "/tmp/x.tar"
+
+    assert urllib.request.urlretrieve is original
+
+
+def test_patch_restores_on_exception(monkeypatch):
+    original = urllib.request.urlretrieve
+    with pytest.raises(ValueError):
+        with _fetch.resilient_downloads():
+            raise ValueError("prepare blew up")
+    assert urllib.request.urlretrieve is original
+
+
+def test_loader_installs_the_fallback_around_prepare(tmp_path, monkeypatch):
+    """The wrapper only matters at the one call site. Dropping it from
+    `load_via_prepare` breaks nothing until a cold cache meets a dead host, so
+    assert the vendored script really runs under the patch."""
+    import json
+    import types
+
+    from sgl_eval.evals import _loader
+
+    original = urllib.request.urlretrieve
+    seen = {}
+
+    def save_data(split):
+        seen["patched"] = urllib.request.urlretrieve is not original
+        (tmp_path / f"{split}.jsonl").write_text(
+            json.dumps({"problem": "q", "expected_answer": "A"}) + "\n"
+        )
+
+    mod = types.SimpleNamespace(__file__=str(tmp_path / "prepare.py"), save_data=save_data)
+    monkeypatch.setattr(_loader, "_CACHE_ROOT", tmp_path / "cache")
+    monkeypatch.setattr(_loader.importlib, "import_module", lambda _p: mod)
+
+    _loader.load_via_prepare("mmlu", ["test"], {})(None)
+
+    assert seen["patched"], "prepare ran with the stock urlretrieve"
+    assert urllib.request.urlretrieve is original, "patch leaked past the loader"


### PR DESCRIPTION
Fixes #33.

The vendored `prepare.py` scripts call `urllib.request.urlretrieve` with a hard-coded URL, no timeout and no retry, so an unreachable host ends a cold-cache run with a bare `Errno 110`. MMLU is the one that bites: its archive is served from a personal faculty web space, which is unreachable as of this writing, while every other benchmark loads from HuggingFace or GitHub.

Those files are synced verbatim from NeMo-Skills, so the policy lives in a new `sgl_eval/evals/_fetch.py` and is installed around the call in `load_via_prepare` instead of edited into the vendored script. `gsm8k`, which uses the same `urlretrieve`, gets the retries too.

- Primary URL retried twice with a 30s socket timeout, then a commit-pinned `cais/mmlu` mirror.
- `SGL_EVAL_MMLU_URL` overrides the whole chain for internal mirrors or `file://` paths.
- Failure names every source tried, instead of surfacing one `Errno 110`.

Verified against the live outage: falls through in 65s and fetches the full 166 MB, and a cold-cache `load_via_prepare("mmlu", ["test"])` produces the expected 14042 rows.