### PR TITLE
Reject duplicate example IDs before evaluation

### DIFF
--- a/sgl_eval/runner/__init__.py
+++ b/sgl_eval/runner/__init__.py
@@ -53,6 +53,15 @@ def run_examples(
     progress: bool = True,
     on_sample_scored: Optional[OnSampleScoredFn] = None,
 ) -> RunResult:
+    seen_ids: dict[str, int] = {}
+    for index, ex in enumerate(examples):
+        if ex.id in seen_ids:
+            raise ValueError(
+                f"duplicate example id {ex.id!r} at positions "
+                f"{seen_ids[ex.id]} and {index}; ids must be unique within a run"
+            )
+        seen_ids[ex.id] = index
+
     debug_serial = os.getenv("SGL_EVAL_DEBUG") == "1"
     total_samples = len(examples) * max(n_repeats, 1)
     workers = 1 if debug_serial else min(num_threads, max(total_samples, 1))

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -47,6 +47,38 @@ def test_runner_basic():
     assert result.output_throughput > 0
 
 
+@pytest.mark.parametrize("num_threads", [1, 4])
+def test_runner_rejects_duplicate_ids_before_sampling(num_threads):
+    """IDs key the runner's per-example storage, so duplicates would make
+    one example overwrite another's samples and scores."""
+    examples = [
+        Example(id="dup", inputs={}, target="a"),
+        Example(id="unique", inputs={}, target="b"),
+        Example(id="dup", inputs={}, target="c"),
+    ]
+    sampled = []
+
+    def sample_fn(ex, rep_idx):
+        sampled.append((ex.id, rep_idx))
+        return Sample(text=str(ex.target), completion_tokens=1, finish_reason="stop")
+
+    with pytest.raises(
+        ValueError,
+        match=r"duplicate example id 'dup' at positions 0 and 2; ids must be unique within a run",
+    ):
+        run_examples(
+            "duplicate-ids",
+            examples,
+            sample_fn,
+            _all_correct_score_one_fn,
+            num_threads=num_threads,
+            n_repeats=2,
+            progress=False,
+        )
+
+    assert sampled == []
+
+
 def test_runner_partial_correct():
     examples = [Example(id=str(i), inputs={}, target="ok") for i in range(10)]
     result = run_examples(


### PR DESCRIPTION
## Summary

- reject duplicate `Example.id` values before the runner builds ID-keyed state
- report the duplicate ID and both input positions
- cover serial and threaded execution, multiple repeats, and the no-sampling failure boundary

## Problem

The runner stores samples, scores, extracted answers, and examples in dictionaries keyed by `Example.id`. If two examples share an ID, those dictionaries alias the rows. In a direct current-main reproduction, two examples with different targets but `id="dup"` both returned the second example's sample and score, and the aggregate was reported as 1.0 instead of 0.5.

Duplicate IDs are therefore not a valid input that can be evaluated faithfully. This change fails before any generation task is submitted instead of returning plausible but corrupted results.

## Validation

- `pytest -q tests/test_runner.py` — 12 passed
- `pytest -q` — 239 passed
- `pre-commit run --all-files` — passed
- `python scripts/audit_vendored.py` — passed
- `python -m compileall -q sgl_eval tests` — passed
- package sdist and wheel build — passed
- adversarial matrix across serial/threaded execution, zero/one/multiple repeats, empty/unique IDs, and every duplicate-position pair — passed
- mutation removing the duplicate check — regression fails as expected

Signed-off-by: Chuyue Wang <stevenwang0805@outlook.com>
