### PR TITLE
Raise nofile limit for high-concurrency evaluation

### DIFF
--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -13,6 +13,11 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
+try:
+    import resource
+except ImportError:  # pragma: no cover - unavailable on Windows
+    resource = None
+
 import httpx
 import openai
 from openai import OpenAI
@@ -26,6 +31,41 @@ LOG = logging.getLogger(__name__)
 # Above any plausible --num-threads; httpx's default 100 would silently cap
 # concurrency below what the runner was told to use.
 _MAX_CONNECTIONS = 3600
+_TARGET_NOFILE = 65_535
+
+
+def _set_nofile_soft_limit(target: int = _TARGET_NOFILE) -> None:
+    """Raise the process file-descriptor limit for high-concurrency runs.
+
+    ``--num-threads`` can legitimately exceed the default Linux soft limit of
+    1024. Each in-flight HTTP request needs a socket, and math scoring also
+    creates a short-lived asyncio selector. Without raising the limit, a run
+    can fail partway through with ``EMFILE`` after requests have already
+    reached the server.
+    """
+    if resource is None:
+        return
+    try:
+        current_soft, current_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    except (OSError, ValueError) as exc:
+        LOG.warning("Could not read RLIMIT_NOFILE: %s", exc)
+        return
+
+    hard_is_infinite = current_hard == getattr(resource, "RLIM_INFINITY", None)
+    desired_soft = target if hard_is_infinite else min(target, current_hard)
+    if current_soft >= desired_soft:
+        return
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (desired_soft, current_hard))
+    except (OSError, ValueError) as exc:
+        LOG.warning(
+            "Could not raise RLIMIT_NOFILE from %d to %d: %s",
+            current_soft,
+            desired_soft,
+            exc,
+        )
+    else:
+        LOG.info("Raised RLIMIT_NOFILE soft limit from %d to %d", current_soft, desired_soft)
 
 
 class _LargeHttpxClient(httpx.Client):
@@ -54,6 +94,7 @@ class ChatCompletionSampler:
         api_key: str = "EMPTY",
         max_retries: int = 6,
     ) -> None:
+        _set_nofile_soft_limit()
         # Hold the httpx client directly so ``abort()`` can close it without
         # reaching into ``OpenAI``'s private ``_client`` attribute.
         self._http = _LargeHttpxClient()

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -8,11 +8,13 @@ the sampler builds the right request kwargs and unpacks responses into a
 
 from __future__ import annotations
 
+import logging
 import threading
 from types import SimpleNamespace
 
 import pytest
 
+from sgl_eval import sampler as sampler_module
 from sgl_eval.runner import WorkerAborted
 from sgl_eval.sampler import ChatCompletionSampler
 from sgl_eval.types import GenConfig
@@ -31,6 +33,88 @@ def _stub_response(text: str, completion: int = 7, prompt: int = 11, reasoning: 
         ],
         usage=SimpleNamespace(**usage_kw),
     )
+
+
+def test_nofile_soft_limit_is_raised(monkeypatch):
+    calls = []
+    fake_resource = SimpleNamespace(
+        RLIMIT_NOFILE=7,
+        getrlimit=lambda _: (1024, 1_048_576),
+        setrlimit=lambda resource_type, limits: calls.append((resource_type, limits)),
+    )
+    monkeypatch.setattr(sampler_module, "resource", fake_resource)
+
+    sampler_module._set_nofile_soft_limit()
+
+    assert calls == [(7, (sampler_module._TARGET_NOFILE, 1_048_576))]
+
+
+def test_nofile_soft_limit_is_capped_by_hard_limit(monkeypatch):
+    calls = []
+    fake_resource = SimpleNamespace(
+        RLIMIT_NOFILE=7,
+        getrlimit=lambda _: (1024, 4096),
+        setrlimit=lambda resource_type, limits: calls.append((resource_type, limits)),
+    )
+    monkeypatch.setattr(sampler_module, "resource", fake_resource)
+
+    sampler_module._set_nofile_soft_limit()
+
+    assert calls == [(7, (4096, 4096))]
+
+
+def test_nofile_soft_limit_handles_negative_infinity_sentinel(monkeypatch):
+    calls = []
+    fake_resource = SimpleNamespace(
+        RLIMIT_NOFILE=7,
+        RLIM_INFINITY=-1,
+        getrlimit=lambda _: (1024, -1),
+        setrlimit=lambda resource_type, limits: calls.append((resource_type, limits)),
+    )
+    monkeypatch.setattr(sampler_module, "resource", fake_resource)
+
+    sampler_module._set_nofile_soft_limit()
+
+    assert calls == [(7, (sampler_module._TARGET_NOFILE, -1))]
+
+
+def test_nofile_soft_limit_is_unchanged_when_already_sufficient(monkeypatch):
+    calls = []
+    fake_resource = SimpleNamespace(
+        RLIMIT_NOFILE=7,
+        getrlimit=lambda _: (131072, 1_048_576),
+        setrlimit=lambda resource_type, limits: calls.append((resource_type, limits)),
+    )
+    monkeypatch.setattr(sampler_module, "resource", fake_resource)
+
+    sampler_module._set_nofile_soft_limit()
+
+    assert calls == []
+
+
+def test_nofile_soft_limit_is_a_noop_without_resource(monkeypatch):
+    monkeypatch.setattr(sampler_module, "resource", None)
+
+    sampler_module._set_nofile_soft_limit()
+
+
+@pytest.mark.parametrize("operation", ["getrlimit", "setrlimit"])
+def test_nofile_soft_limit_logs_and_continues_on_resource_error(monkeypatch, caplog, operation):
+    def raise_oserror(*_args):
+        raise OSError("not permitted")
+
+    fake_resource = SimpleNamespace(
+        RLIMIT_NOFILE=7,
+        getrlimit=raise_oserror if operation == "getrlimit" else lambda _: (1024, 1_048_576),
+        setrlimit=raise_oserror if operation == "setrlimit" else lambda *_: None,
+    )
+    monkeypatch.setattr(sampler_module, "resource", fake_resource)
+
+    with caplog.at_level(logging.WARNING):
+        sampler_module._set_nofile_soft_limit()
+
+    assert "RLIMIT_NOFILE" in caplog.text
+    assert "not permitted" in caplog.text
 
 
 @pytest.fixture


### PR DESCRIPTION
## Motivation

`sgl-eval` allows thousands of HTTP connections, but it does not raise the
process file-descriptor limit. On Linux systems with the common soft limit of
1,024, a high-concurrency run such as `--num-threads 1200` can exhaust file
descriptors while requests are in flight. The sampler then reports connection
errors, and math scoring can fail while creating an asyncio selector with:

```text
OSError: [Errno 24] Too many open files
```

This was found while validating SGLang GLM-5.3-Flash support, but the problem
and fix are model- and backend-independent.

## Changes

- Raise the process soft `RLIMIT_NOFILE` to 65,535 before constructing the
  high-concurrency HTTP client.
- Cap the requested value at the process hard limit; preserve an already-unlimited soft limit.
- Handle platforms without the `resource` module and systems that represent
  an infinite hard limit with a negative sentinel.
- Log and continue if the limit cannot be read or raised.
- Parameterize the existing limit cases and retain the unavailable-platform and syscall-failure checks.

This changes only evaluator process setup; sampling parameters, scoring, and
model behavior are unchanged.

## Reproduction and validation

A one-variable A/B used the same MI355X node, model, container, SGLang source,
server arguments, 1,319 GSM8K examples, and 1,200 evaluator threads:

- Soft limit 1,024: evaluator exited 1 with `Errno 24`, 540 sampler connection
  errors, and zero persisted predictions. The SGLang server stayed healthy and
  recorded no GPU or runtime faults.
- Soft limit 65,536: evaluator exited 0 with 1,281/1,319 = 97.12%, all 1,319
  unique examples present, zero evaluator errors, and a healthy server after
  evaluation. Three responses reached the configured 4,096-token limit.

Patch verification:

- PR head: `244 passed`; synthetic merge with main at `ea8a621`: `259 passed`.
- Full pre-commit suite passed
- Vendored-source audit passed
- `git diff --check` passed
- Real subprocess checks raised the soft limit from 1,024 to 65,535 on both
  macOS and Linux inside the ROCm evaluation container

- Rechecked the real macOS constructor path (1,024 to 65,535 with the hard limit unchanged) and the unlimited-soft-limit guard using an isolated probe.
