### PR TITLE
Add MMAU audio-understanding benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ run ends.
 
 `sgl-eval list` for the registered set, `sgl-eval list -v` for each one's
 defaults. See [`benchmarks.md`](benchmarks.md) for the ones that need more
-than an endpoint (today: `ruler2`), and for how to match a NeMo-Skills run.
+than an endpoint (today: `ruler2`, `mmau`), and for how to match a NeMo-Skills run.
 
 ## Presets
 

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -17,10 +17,12 @@ an endpoint. Most need nothing.
 | `mmmu_pro` | multichoice | VLM endpoint; MMMU-Pro `standard (10 options)` -- [see below](#mmmu-pro-variants) |
 | `mmmu_pro_vision` | multichoice | VLM endpoint; MMMU-Pro `vision` -- [see below](#mmmu-pro-variants) |
 | `ruler2` | ruler2 | extra install, a required flag, generated data -- [see below](#ruler2) |
+| `mmau` | audio | audio-capable endpoint, extra install -- [see below](#mmau) |
 
 All scoring behavior (prompt, answer extraction, grading, pass@k /
-majority@k aggregation) comes from the vendored NeMo-Skills slice, whatever
-the benchmark.
+majority@k aggregation) comes from the vendored NeMo-Skills slice, with one
+exception: `mmau` has no NeMo-Skills upstream, so its (official-protocol)
+scorer lives in `sgl_eval/evals/_mmau.py`.
 
 ---
 
@@ -204,3 +206,27 @@ explicitly, e.g. `1048576 - 768` to reserve room to answer), and the same
 `--num-examples` is *not* a substitute for `--ruler2-dataset-size`: it slices
 the generated file (NS's `++max_samples`), it does not change what gets
 generated.
+
+---
+
+## mmau
+
+MMAU v05.15.25 test-mini: 1000 audio multiple-choice questions across sound
+/ music / speech, fetched from `gamma-lab-umd/MMAU-test-mini` and served to
+an audio-capable endpoint as 16 kHz mono WAV data URLs.
+
+```bash
+pip install 'sgl-eval[audio]'      # librosa, soundfile
+
+sgl-eval run mmau --base-url http://localhost:30000/v1
+# stochastic 32-repeat protocol (mean +/- std):
+sgl-eval run mmau --base-url http://localhost:30000/v1 --n-repeats 32 --temperature 1.0
+```
+
+The summary prints the overall accuracy plus a per-task breakdown
+(`sound` / `music` / `speech`), rendered the same way as ruler2's subtasks.
+
+`--num-examples N` round-robins across the three tasks (the parquet is
+grouped by task, so a head-slice would smoke-test only one). Two flags do
+not apply: `--prompt` (the instruction is fixed by the official MMAU
+protocol) and `--from-dataset` (NS-shape rows carry no audio).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ keywords = [
     "gpqa",
     "mmlu",
     "gsm8k",
+    "mmau",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -55,6 +56,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+audio = [
+    # mmau audio preprocessing (lazy-imported by sgl_eval.evals._mmau)
+    "librosa>=0.10,<1",
+    "soundfile>=0.12,<1",
+]
 dev = [
     "pytest>=7.0,<9",
     "pytest-asyncio>=0.23,<2",

--- a/sgl_eval/evals/_mmau.py
+++ b/sgl_eval/evals/_mmau.py
@@ -1,0 +1,296 @@
+"""MMAU audio-understanding benchmark (sgl-eval-own; NeMo-Skills has no MMAU).
+
+Dataset: ``gamma-lab-umd/MMAU-test-mini`` -- 1000 audio multiple-choice
+questions across sound / music / speech. Each clip is decoded and re-encoded
+once at load time to 16 kHz mono WAV, then attached as a ``MediaItem`` so the
+sample path is the same ``build_user_content`` transport the vision
+benchmarks use.
+
+Scoring follows the official MMAU protocol (v05.15.25): a prediction is
+correct when its tokens contain the gold answer's tokens while staying
+disjoint from the tokens unique to the wrong choices. Aggregation reports
+the overall accuracy plus a per-task breakdown via the standard ``task.*``
+metric keys.
+
+Heavy deps (``librosa`` / ``soundfile`` / ``pyarrow`` / ``huggingface_hub``)
+are imported lazily inside functions: ``registry._autoload`` swallows import
+errors, so a module-level import failure would silently drop the benchmark.
+Install them via ``pip install sgl-eval[audio]``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import sys
+import warnings
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from sgl_eval.evals._vision import build_user_content
+from sgl_eval.predictions import PredictionsWriter
+from sgl_eval.registry import EvalSpec, register
+from sgl_eval.runner import SampleFn, ScoreOneFn, run_examples
+from sgl_eval.sampler import ChatCompletionSampler
+from sgl_eval.types import Example, ExampleResult, GenConfig, MediaItem, RunResult, Sample
+
+SAMPLE_RATE = 16000
+DATASET_REPO = "gamma-lab-umd/MMAU-test-mini"
+DATASET_FILE = "test_mini.parquet"
+
+_AUDIO_DEP_HINT = (
+    "error: mmau requires audio dependencies; install them with `pip install sgl-eval[audio]`"
+)
+
+
+# ---------- scoring ----------
+
+
+def _tokens(text: str) -> set:
+    return set(re.findall(r"\b\w+\b", text.lower()))
+
+
+def mmau_string_match(answer: str, prediction: str, choices: List[str]) -> bool:
+    """Official MMAU correctness rule: the prediction must contain the
+    gold answer's tokens and none of the tokens unique to wrong choices."""
+    pred_tokens = _tokens(prediction)
+    gold_tokens = _tokens(answer)
+    if not pred_tokens:
+        return False
+    wrong_tokens: set = set()
+    for choice in choices:
+        choice_tokens = _tokens(choice)
+        if choice_tokens != gold_tokens:
+            wrong_tokens |= choice_tokens - gold_tokens
+    return gold_tokens <= pred_tokens and not (pred_tokens & wrong_tokens)
+
+
+def _strip_choice_letter(text: str) -> str:
+    """Drop a leading ``"(A) "``-style letter prefix from a choice/answer."""
+    if len(text) >= 4 and text[0] == "(" and text[2] == ")" and text[3] == " ":
+        if text[1].isalpha():
+            return text[4:]
+    return text
+
+
+def _format_question(question: str, choices: List[str]) -> str:
+    """Render the MMAU multiple-choice instruction for one sample."""
+    lines = [question, "", "Choice: ", *choices]
+    lines.append(
+        f"Choose a choices from the given {len(choices)} choices. Do not provide any "
+        "additional explanations or content. Output must match exactly one of the listed choices."
+    )
+    return "\n".join(lines)
+
+
+# ---------- audio preprocessing ----------
+
+
+def _encode_mono_16k_wav(raw_bytes: bytes) -> bytes:
+    """Decode an audio clip and re-encode it as 16 kHz mono PCM16 WAV."""
+    try:
+        import numpy as np
+        import soundfile as sf
+    except ImportError as e:
+        raise SystemExit(f"{_AUDIO_DEP_HINT} ({e})")
+
+    audio_array, sample_rate = sf.read(io.BytesIO(raw_bytes), dtype="float32")
+    if audio_array.ndim > 1:
+        audio_array = audio_array.mean(axis=1)
+    if sample_rate != SAMPLE_RATE:
+        try:
+            import librosa
+        except ImportError as e:
+            raise SystemExit(f"{_AUDIO_DEP_HINT} ({e})")
+        audio_array = librosa.resample(audio_array, orig_sr=sample_rate, target_sr=SAMPLE_RATE)
+    buf = io.BytesIO()
+    sf.write(
+        buf, np.asarray(audio_array, dtype=np.float32), SAMPLE_RATE, format="WAV", subtype="PCM_16"
+    )
+    return buf.getvalue()
+
+
+# ---------- dataset ----------
+
+
+def _fetch_dataset_rows() -> List[Dict[str, Any]]:
+    try:
+        import pyarrow.parquet as pq
+        from huggingface_hub import hf_hub_download
+    except ImportError as e:
+        raise SystemExit(f"{_AUDIO_DEP_HINT} ({e})")
+
+    parquet_path = hf_hub_download(repo_id=DATASET_REPO, filename=DATASET_FILE, repo_type="dataset")
+    return pq.ParquetFile(parquet_path).read().to_pylist()
+
+
+def _task_of(row: Dict[str, Any]) -> str:
+    return json.loads(row["other_attributes"])["task"]
+
+
+def _interleave_rows_by_task(rows: List[Dict[str, Any]], limit: int) -> List[Dict[str, Any]]:
+    """Cap the row count while keeping tasks balanced: the parquet is grouped
+    by task, so a plain head-slice would smoke-test only one task. Selection
+    happens before the (expensive) audio re-encode."""
+    queues: Dict[str, List[Dict[str, Any]]] = {}
+    for row in rows:
+        queues.setdefault(_task_of(row), []).append(row)
+    picked: List[Dict[str, Any]] = []
+    depth = 0
+    task_queues = list(queues.values())
+    while len(picked) < limit and any(depth < len(q) for q in task_queues):
+        for q in task_queues:
+            if depth < len(q):
+                picked.append(q[depth])
+                if len(picked) >= limit:
+                    break
+        depth += 1
+    return picked
+
+
+def _build_example(row: Dict[str, Any], idx: int) -> Example:
+    choices = [_strip_choice_letter(c) for c in row["choices"]]
+    wav_bytes = _encode_mono_16k_wav(row["context"]["bytes"])
+    return Example(
+        id=str(row.get("id") or f"mmau-{idx}"),
+        inputs={"problem": _format_question(row["instruction"], choices)},
+        target=_strip_choice_letter(row["answer"]),
+        meta={"task": _task_of(row), "choices": choices},
+        media=[MediaItem(kind="audio", data=wav_bytes, mime="audio/wav")],
+    )
+
+
+def load_mmau_examples(num_examples: Optional[int]) -> List[Example]:
+    rows = _fetch_dataset_rows()
+    if num_examples is not None:
+        rows = _interleave_rows_by_task(rows, num_examples)
+    examples: List[Example] = []
+    for i, row in enumerate(rows):
+        try:
+            examples.append(_build_example(row, i))
+        except SystemExit:
+            raise
+        except Exception as e:
+            # One undecodable clip must not abort the whole load.
+            warnings.warn(f"skipping MMAU row {row.get('id') or i}: {e}")
+    return examples
+
+
+# ---------- sample / score ----------
+
+
+def make_sample_fn(sampler: ChatCompletionSampler, gen: GenConfig) -> SampleFn:
+    def sample_fn(ex: Example, _rep_idx: int) -> Sample:
+        content = build_user_content(ex.inputs["problem"], ex.media)
+        return sampler([{"role": "user", "content": content}], gen)
+
+    return sample_fn
+
+
+def make_score_one_fn() -> ScoreOneFn:
+    def score_one(ex: Example, sample: Sample) -> Tuple[float, Optional[str]]:
+        correct = mmau_string_match(str(ex.target), sample.text, ex.meta["choices"])
+        return (1.0 if correct else 0.0), None
+
+    return score_one
+
+
+# ---------- aggregate ----------
+
+
+def _per_task_scores(results: List[ExampleResult]) -> Dict[str, float]:
+    """Per-task means, published under the standard ``task.<name>`` keys the
+    summary renderer already knows how to print (same idiom as ruler2)."""
+    by_task: Dict[str, List[float]] = {}
+    for r in results:
+        task = r.example.meta.get("task")
+        if task is None or not r.scores:
+            continue
+        by_task.setdefault(task, []).append(sum(r.scores) / len(r.scores))
+    return {f"task.{task}": sum(vals) / len(vals) for task, vals in sorted(by_task.items())}
+
+
+def aggregate_mmau(results: List[ExampleResult], n_repeats: int) -> Dict[str, float]:
+    if not results:
+        return {"score": 0.0}
+    if n_repeats > 1:
+        # Overall pass@1[avg-of-k] (+ std/SEM) via the vendored MathMetrics,
+        # same as math/multichoice; per-task keys are plain means.
+        from sgl_eval.evals._multichoice import aggregate_with_math_metrics
+
+        flat = aggregate_with_math_metrics(results, n_repeats)
+    else:
+        means = [sum(r.scores) / len(r.scores) for r in results if r.scores]
+        flat = {"score": sum(means) / len(means) if means else 0.0}
+    flat.update(_per_task_scores(results))
+    return flat
+
+
+# ---------- registration ----------
+
+
+def run_mmau_benchmark(
+    *,
+    name: str,
+    sampler: ChatCompletionSampler,
+    gen: GenConfig,
+    n_repeats: int,
+    num_examples: Optional[int],
+    num_threads: int,
+    load_examples: Optional[Callable[[Optional[int]], List[Example]]] = None,
+    predictions_writer: Optional[PredictionsWriter] = None,
+) -> RunResult:
+    examples = load_mmau_examples(num_examples)
+    return run_examples(
+        name=name,
+        examples=examples,
+        sample_fn=make_sample_fn(sampler, gen),
+        score_one_fn=make_score_one_fn(),
+        num_threads=num_threads,
+        n_repeats=n_repeats,
+        aggregate_fn=lambda results: aggregate_mmau(results, n_repeats),
+        on_sample_scored=predictions_writer,
+    )
+
+
+def _run(
+    *,
+    sampler: ChatCompletionSampler,
+    gen: GenConfig,
+    n_repeats: int,
+    num_examples: Optional[int],
+    num_threads: int,
+    predictions_writer: Optional[PredictionsWriter] = None,
+    load_examples: Optional[Callable[[Optional[int]], List[Example]]] = None,
+    bench_args: Optional[Any] = None,
+    prompt_yaml: Optional[Any] = None,
+) -> RunResult:
+    if prompt_yaml is not None:
+        raise ValueError(
+            "mmau does not take a prompt override: its instruction is fixed by "
+            "the official MMAU eval protocol."
+        )
+    if load_examples is not None:
+        sys.exit("error: --from-dataset is not supported for mmau (audio inputs required)")
+    return run_mmau_benchmark(
+        name="mmau",
+        sampler=sampler,
+        gen=gen,
+        n_repeats=n_repeats,
+        num_examples=num_examples,
+        num_threads=num_threads,
+        load_examples=load_examples,
+        predictions_writer=predictions_writer,
+    )
+
+
+register(
+    EvalSpec(
+        name="mmau",
+        category="audio",
+        description="MMAU v05.15.25 test-mini (1000 audio MCQs: sound/music/speech).",
+        default_gen=GenConfig(),
+        default_n_repeats=1,
+        run=_run,
+    )
+)

--- a/sgl_eval/evals/_vision.py
+++ b/sgl_eval/evals/_vision.py
@@ -1,9 +1,10 @@
-"""Vision-aware message construction shared by multimodal benchmarks.
+"""Media-aware message construction shared by multimodal benchmarks.
 
 ``build_user_content`` turns a prompt + ``Example.media`` list into an
 OpenAI-style ``content``: a plain string when there is no media (so text
 benchmarks stay byte-for-byte compatible), or a list of text / image_url /
-video_url blocks otherwise. The sampler passes it through unchanged.
+video_url / audio_url blocks otherwise. The sampler passes it through
+unchanged.
 
 Image placement: if the prompt contains ``[image]`` placeholders (left by
 the MMMU-Pro loader after stripping ``<image n>``), images are inserted at
@@ -65,7 +66,7 @@ def build_user_content(
     else:
         content.append({"type": "text", "text": prompt})
 
-    # Append media not consumed above (video, and images with no placeholder).
+    # Append media not consumed above (video/audio, and images with no placeholder).
     inserted_images = image_idx
     for m in media:
         if m.kind == "image":
@@ -77,6 +78,8 @@ def build_user_content(
             if not m.url:
                 raise ValueError("video MediaItem requires a url (too large to base64-inline)")
             content.append({"type": "video_url", "video_url": {"url": m.url}})
+        elif m.kind == "audio":
+            content.append(_audio_block(m))
         else:
             raise ValueError(f"unsupported media kind: {m.kind!r}")
     return content
@@ -85,6 +88,11 @@ def build_user_content(
 def _image_block(m: MediaItem) -> dict:
     url = m.url or _data_url(m.data, m.mime or "image/png")
     return {"type": "image_url", "image_url": {"url": url}}
+
+
+def _audio_block(m: MediaItem) -> dict:
+    url = m.url or _data_url(m.data, m.mime or "audio/wav")
+    return {"type": "audio_url", "audio_url": {"url": url}}
 
 
 def _data_url(data: bytes, mime: str) -> str:

--- a/sgl_eval/types.py
+++ b/sgl_eval/types.py
@@ -54,14 +54,14 @@ class Sample:
 
 @dataclass
 class MediaItem:
-    """One input media attachment (image/video). ``kind`` selects the message
-    block; ``data`` (raw bytes) is used for images via base64 data URL, ``url``
-    for video (too large to inline) or pre-hosted images."""
+    """One input media attachment (image/video/audio). ``kind`` selects the
+    message block; ``data`` (raw bytes) is used for images/audio via base64
+    data URL, ``url`` for video (too large to inline) or pre-hosted media."""
 
-    kind: str  # "image" | "video"
+    kind: str  # "image" | "video" | "audio"
     data: bytes = b""
     url: str = ""
-    mime: str = ""  # "image/png" | "video/mp4" | ...
+    mime: str = ""  # "image/png" | "video/mp4" | "audio/wav" | ...
 
 
 @dataclass

--- a/tests/test_mmau.py
+++ b/tests/test_mmau.py
@@ -1,0 +1,177 @@
+"""Unit tests for the mmau benchmark glue. No live endpoint, no audio deps:
+the WAV re-encode and dataset fetch are monkeypatched, rows are synthetic."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from sgl_eval.evals import _mmau
+from sgl_eval.metrics import format_summary
+from sgl_eval.types import Example, ExampleResult, GenConfig, MediaItem, RunResult, Sample
+
+
+def _row(task: str = "sound", row_id: str = "abc") -> dict:
+    return {
+        "id": row_id,
+        "instruction": "What do you hear?",
+        "choices": ["(A) cat", "(B) dog"],
+        "answer": "(A) cat",
+        "context": {"bytes": b"audio"},
+        "other_attributes": f'{{"task": "{task}"}}',
+    }
+
+
+def _example(task: str = "sound", target: str = "cat", choices=("cat", "dog")) -> Example:
+    return Example(
+        id=f"{task}-0",
+        inputs={"problem": "What sound is this?"},
+        target=target,
+        meta={"task": task, "choices": list(choices)},
+        media=[MediaItem(kind="audio", data=b"wav-bytes", mime="audio/wav")],
+    )
+
+
+# ---------- scoring ----------
+
+
+def test_mmau_string_match_exact():
+    assert _mmau.mmau_string_match("Yes", "Yes", ["Yes", "No"])
+
+
+def test_mmau_string_match_empty_prediction():
+    assert not _mmau.mmau_string_match("Yes", "", ["Yes", "No"])
+
+
+def test_mmau_string_match_answer_embedded_in_sentence():
+    assert _mmau.mmau_string_match("a dog", "It is clearly a dog.", ["a dog", "a cat"])
+
+
+def test_mmau_string_match_wrong_choice_tokens_pollute():
+    assert not _mmau.mmau_string_match("a dog", "a dog and a cat", ["a dog", "a cat"])
+
+
+def test_mmau_string_match_missing_answer():
+    assert not _mmau.mmau_string_match("a dog", "a cat", ["a dog", "a cat"])
+
+
+def test_strip_choice_letter():
+    assert _mmau._strip_choice_letter("(A) barking") == "barking"
+    assert _mmau._strip_choice_letter("barking") == "barking"
+    assert _mmau._strip_choice_letter("(AB) barking") == "(AB) barking"
+
+
+def test_format_question_shape():
+    prompt = _mmau._format_question("What do you hear?", ["cat", "dog"])
+    assert prompt.startswith("What do you hear?\n\nChoice: \ncat\ndog\n")
+    assert "2 choices" in prompt
+
+
+# ---------- dataset shaping ----------
+
+
+def test_build_example(monkeypatch):
+    monkeypatch.setattr(_mmau, "_encode_mono_16k_wav", lambda b: b"wav")
+    ex = _mmau._build_example(_row(), 0)
+    assert ex.id == "abc"
+    assert ex.target == "cat"
+    assert ex.meta == {"task": "sound", "choices": ["cat", "dog"]}
+    assert ex.media == [MediaItem(kind="audio", data=b"wav", mime="audio/wav")]
+    assert "cat\ndog" in ex.inputs["problem"]
+
+
+def test_interleave_rows_by_task_balances_tasks():
+    rows = [_row(task=t, row_id=f"{t}-{i}") for t, n in [("sound", 4), ("music", 2), ("speech", 2)] for i in range(n)]
+    picked = _mmau._interleave_rows_by_task(rows, 6)
+    assert len(picked) == 6
+    tasks = [_mmau._task_of(r) for r in picked]
+    assert tasks.count("sound") == 2
+    assert tasks.count("music") == 2
+    assert tasks.count("speech") == 2
+
+
+def test_load_skips_undecodable_rows(monkeypatch):
+    rows = [_row(row_id="ok"), _row(row_id="bad")]
+    rows[1]["context"] = {"bytes": b"corrupt"}
+    monkeypatch.setattr(_mmau, "_fetch_dataset_rows", lambda: rows)
+
+    def _encode(raw):
+        if raw == b"audio":
+            return b"wav"
+        raise ValueError("bad audio")
+
+    monkeypatch.setattr(_mmau, "_encode_mono_16k_wav", _encode)
+    with pytest.warns(UserWarning, match="skipping MMAU row bad"):
+        examples = _mmau.load_mmau_examples(None)
+    assert [ex.id for ex in examples] == ["ok"]
+
+
+# ---------- sample / score ----------
+
+
+class _RecordingSampler:
+    def __init__(self, text: str = "cat"):
+        self.messages = None
+        self.text = text
+
+    def __call__(self, messages, gen):
+        self.messages = messages
+        return Sample(text=self.text, finish_reason="stop")
+
+
+def test_sample_fn_builds_multipart_message():
+    sampler = _RecordingSampler()
+    sample_fn = _mmau.make_sample_fn(sampler, GenConfig())
+    sample = sample_fn(_example(), 0)
+    assert sample.text == "cat"
+    content = sampler.messages[0]["content"]
+    assert content[0] == {"type": "text", "text": "What sound is this?"}
+    expected_url = "data:audio/wav;base64," + base64.b64encode(b"wav-bytes").decode()
+    assert content[1] == {"type": "audio_url", "audio_url": {"url": expected_url}}
+
+
+def test_score_one():
+    score_one = _mmau.make_score_one_fn()
+    assert score_one(_example(), Sample(text="cat")) == (1.0, None)
+    assert score_one(_example(), Sample(text="dog")) == (0.0, None)
+
+
+# ---------- aggregate ----------
+
+
+def _result(task: str, score: float) -> ExampleResult:
+    return ExampleResult(
+        example=_example(task=task),
+        samples=[Sample(text="x")],
+        scores=[score],
+        extracted=[None],
+    )
+
+
+def test_aggregate_mmau_single_shot_with_per_task():
+    results = [_result("sound", 1.0), _result("sound", 0.0), _result("music", 1.0)]
+    agg = _mmau.aggregate_mmau(results, n_repeats=1)
+    assert agg["score"] == pytest.approx(2 / 3)
+    assert agg["task.sound"] == pytest.approx(0.5)
+    assert agg["task.music"] == pytest.approx(1.0)
+    assert "task.speech" not in agg
+
+
+def test_aggregate_mmau_empty():
+    assert _mmau.aggregate_mmau([], n_repeats=1) == {"score": 0.0}
+
+
+def test_summary_renders_per_task_rows():
+    result = RunResult(
+        name="mmau",
+        per_example=[],
+        aggregate={"score": 0.75, "task.music": 0.8, "task.sound": 0.7},
+        latency=1.0,
+        num_examples=10,
+        n_repeats=1,
+    )
+    summary = format_summary(result)
+    assert "* score" in summary
+    assert "music" in summary
+    assert "sound" in summary

--- a/tests/test_mmau.py
+++ b/tests/test_mmau.py
@@ -82,7 +82,11 @@ def test_build_example(monkeypatch):
 
 
 def test_interleave_rows_by_task_balances_tasks():
-    rows = [_row(task=t, row_id=f"{t}-{i}") for t, n in [("sound", 4), ("music", 2), ("speech", 2)] for i in range(n)]
+    rows = [
+        _row(task=t, row_id=f"{t}-{i}")
+        for t, n in [("sound", 4), ("music", 2), ("speech", 2)]
+        for i in range(n)
+    ]
     picked = _mmau._interleave_rows_by_task(rows, 6)
     assert len(picked) == 6
     tasks = [_mmau._task_of(r) for r in picked]

--- a/tests/test_vision_message.py
+++ b/tests/test_vision_message.py
@@ -64,9 +64,22 @@ def test_mixed_image_and_video():
     assert [b["type"] for b in content] == ["text", "image_url", "video_url"]
 
 
+def test_audio_appended_as_audio_url_block():
+    media = [MediaItem(kind="audio", data=b"a", mime="audio/wav")]
+    content = build_user_content("q", media)
+    assert [b["type"] for b in content] == ["text", "audio_url"]
+    assert content[1]["audio_url"]["url"].startswith("data:audio/wav;base64,")
+
+
+def test_audio_url_passthrough():
+    media = [MediaItem(kind="audio", url="https://x/a.wav")]
+    content = build_user_content("q", media)
+    assert content[1] == {"type": "audio_url", "audio_url": {"url": "https://x/a.wav"}}
+
+
 def test_unsupported_kind_raises():
     with pytest.raises(ValueError, match="unsupported media kind"):
-        build_user_content("q", [MediaItem(kind="audio", data=b"x")])
+        build_user_content("q", [MediaItem(kind="file", data=b"x")])
 
 
 def test_image_inserted_at_placeholder_preserves_order():


### PR DESCRIPTION
## Summary

Add MMAU v05.15.25 (test-mini) as a new `audio`-category benchmark: 1,000 audio multiple-choice questions across sound, music, and speech, scored by the official string-match rule.

- `sgl_eval/evals/_mmau.py`: dataset load from `gamma-lab-umd/MMAU-test-mini` (parquet), one-time 16 kHz mono WAV re-encode per clip, task-balanced `--num-examples` sampling, per-task `task.*` metric keys, pass@1[avg-of-k] aggregation via the shared MathMetrics when `--n-repeats > 1`
- Audio goes through the same `MediaItem` + `build_user_content` transport as vision (`audio_url` base64 data-URI blocks)
- Heavy deps (`librosa`/`soundfile`/`pyarrow`) are lazy-imported behind a new `sgl-eval[audio]` extra so the base install is unaffected
- `tests/test_mmau.py` covers the scoring rule, choice-letter stripping, task balancing, aggregation, and registration; `tests/test_vision_message.py` extended for audio content blocks

## Validation

- `pytest tests/test_mmau.py tests/test_vision_message.py`: 35 passed
- End-to-end against a omni model: overall 74.40% (speech 79.88% / music 72.16% / sound 71.17%), 1000/1000 samples, zero API errors