### PR TITLE
Add PyPI release workflow and bump version to 0.1.0

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,69 @@
+name: release-pypi
+
+# Publishes sgl-eval to PyPI via trusted publishing (OIDC): no API token is
+# stored in the repo. PyPI trusts this exact workflow file in the `pypi`
+# environment of sgl-project/sgl-eval.
+#
+# Release flow: bump `version` in pyproject.toml and sgl_eval/__init__.py,
+# merge, then push a matching tag (`git tag v0.1.0 && git push origin v0.1.0`).
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: github.repository == 'sgl-project/sgl-eval'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          ver="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          if [ "$tag" != "$ver" ]; then
+            echo "tag v$tag does not match pyproject version $ver" >&2
+            exit 1
+          fi
+          init_ver="$(python -c 'import re; print(re.search(r"__version__ = \"(.*)\"", open("sgl_eval/__init__.py").read()).group(1))')"
+          if [ "$init_ver" != "$ver" ]; then
+            echo "sgl_eval/__init__.py __version__ $init_ver does not match pyproject version $ver" >&2
+            exit 1
+          fi
+
+      - name: Run tests
+        run: |
+          pip install -e ".[dev]"
+          pytest -q
+
+      - name: Build sdist and wheel
+        run: |
+          pip install build
+          python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -2,14 +2,17 @@ name: release-pypi
 
 on:
   push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+    branches: [main]
+    paths: [pyproject.toml]
   workflow_dispatch:
 
 jobs:
-  build:
+  check:
     if: github.repository == 'sgl-project/sgl-eval'
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      publish: ${{ steps.version.outputs.publish }}
     steps:
       - uses: actions/checkout@v4
 
@@ -17,20 +20,51 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Check tag matches package version
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Read version and decide whether it is already released
+        id: version
         run: |
-          tag="${GITHUB_REF_NAME#v}"
           ver="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          if [ "$tag" != "$ver" ]; then
-            echo "tag v$tag does not match pyproject version $ver" >&2
-            exit 1
-          fi
           init_ver="$(python -c 'import re; print(re.search(r"__version__ = \"(.*)\"", open("sgl_eval/__init__.py").read()).group(1))')"
           if [ "$init_ver" != "$ver" ]; then
             echo "sgl_eval/__init__.py __version__ $init_ver does not match pyproject version $ver" >&2
             exit 1
           fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          pip install -q packaging
+          tags="$(git ls-remote --tags origin 'refs/tags/v*' | sed 's|.*refs/tags/v||; s|\^{}$||' | sort -u)"
+          decision="$(python - "$ver" $tags <<'PY'
+          import sys
+          from packaging.version import Version
+          new, *released = map(Version, sys.argv[1:])
+          if new in released:
+              print("skip")
+          elif released and new < max(released):
+              print(f"fail {max(released)}")
+          else:
+              print("publish")
+          PY
+          )"
+          case "$decision" in
+            skip)
+              echo "v$ver already released; nothing to publish"
+              echo "publish=false" >> "$GITHUB_OUTPUT" ;;
+            fail*)
+              echo "version $ver is not newer than latest release ${decision#fail }" >&2
+              exit 1 ;;
+            publish)
+              echo "publish=true" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+  build:
+    needs: check
+    if: needs.check.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       - name: Run tests
         run: |
@@ -48,17 +82,27 @@ jobs:
           path: dist/
 
   publish:
-    needs: build
+    needs: [check, build]
     runs-on: ubuntu-latest
     # PyPI's trusted-publisher entry is keyed on this workflow's file name and
     # this environment name; renaming either breaks publishing.
     environment: pypi
     permissions:
       id-token: write
+      contents: write
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Tag and create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.check.outputs.version }}" dist/* \
+            --target "$GITHUB_SHA" --generate-notes

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,12 +1,5 @@
 name: release-pypi
 
-# Publishes sgl-eval to PyPI via trusted publishing (OIDC): no API token is
-# stored in the repo. PyPI trusts this exact workflow file in the `pypi`
-# environment of sgl-project/sgl-eval.
-#
-# Release flow: bump `version` in pyproject.toml and sgl_eval/__init__.py,
-# merge, then push a matching tag (`git tag v0.1.0 && git push origin v0.1.0`).
-
 on:
   push:
     tags:
@@ -57,6 +50,8 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    # PyPI's trusted-publisher entry is keyed on this workflow's file name and
+    # this environment name; renaming either breaks publishing.
     environment: pypi
     permissions:
       id-token: write

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sgl-eval contributes the transport, runner, and benchmark wiring.
 ## Quick start
 
 ```bash
-pip install git+https://github.com/sgl-project/sgl-eval
+pip install sgl-eval
 
 sgl-eval ping --base-url http://localhost:30000/v1
 sgl-eval run gsm8k --base-url http://localhost:30000/v1 --num-examples 50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sgl-eval"
-version = "0.0.1"
+version = "0.1.0"
 description = "One-click accuracy evaluation harness for SGLang."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sgl_eval/__init__.py
+++ b/sgl_eval/__init__.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 
 # Single source of truth for the vendored NeMo-Skills slice path. Used by
 # the dataset loader, the CLI's run-meta provenance reader, and any future


### PR DESCRIPTION
Trusted-publishing (OIDC) workflow triggered by `v*` tags; first public release as 0.1.0.