### PR TITLE
Persist reasoning content in prediction dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ gsm8k:  34%|###4      | 452/1319 [02:11<04:12, 3.4it/s, acc=81.42%]
 Every scored sample is streamed to
 `<out-dir>/sgl_eval_<name>_<stamp>/output-rs*.jsonl` as it lands (disable
 with `--no-dump-predictions`), so the per-sample record survives however the
-run ends.
+run ends. Each record stores the assistant's final response in `generation`
+and separately parsed reasoning in `reasoning_content` when the endpoint
+provides it.
 
 ---
 

--- a/sgl_eval/predictions.py
+++ b/sgl_eval/predictions.py
@@ -83,6 +83,7 @@ class PredictionsWriter:
     ) -> None:
         pred: Dict[str, Any] = {
             "generation": sample.text,
+            "reasoning_content": sample.reasoning_content,
             **sample_to_pred(sample, ex, self._schema),
             "predicted_answer": extracted,
             self._schema.score_field: bool(score) if self._schema.binary_score else score,

--- a/sgl_eval/sampler.py
+++ b/sgl_eval/sampler.py
@@ -162,21 +162,26 @@ class ChatCompletionSampler:
         response: Any, *, start: Optional[float] = None, end: Optional[float] = None
     ) -> Sample:
         choice = response.choices[0]
-        text = choice.message.content or ""
+        message = choice.message
+        text = message.content or ""
+        reasoning_content = getattr(message, "reasoning_content", None)
         usage = getattr(response, "usage", None)
         completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
         prompt_tokens = getattr(usage, "prompt_tokens", None) if usage else None
 
-        # Reasoning models (e.g. OpenAI o-series, sglang thinking-mode)
-        # report split via ``usage.completion_tokens_details.reasoning_tokens``.
+        # OpenAI reports the split under completion_tokens_details. SGLang
+        # historically exposed the same count directly on usage.
         reasoning_tokens = None
         if usage is not None:
             details = getattr(usage, "completion_tokens_details", None)
             if details is not None:
                 reasoning_tokens = getattr(details, "reasoning_tokens", None)
+            if reasoning_tokens is None:
+                reasoning_tokens = getattr(usage, "reasoning_tokens", None)
 
         return Sample(
             text=text,
+            reasoning_content=reasoning_content,
             completion_tokens=completion_tokens,
             prompt_tokens=prompt_tokens,
             reasoning_tokens=reasoning_tokens,

--- a/sgl_eval/types.py
+++ b/sgl_eval/types.py
@@ -50,6 +50,7 @@ class Sample:
     generation_start_time: Optional[float] = None
     generation_end_time: Optional[float] = None
     raw: Any = None
+    reasoning_content: Optional[str] = None
 
 
 @dataclass

--- a/tests/test_predictions_writer.py
+++ b/tests/test_predictions_writer.py
@@ -22,7 +22,13 @@ def _ex(i: int) -> Example:
 
 
 def _sample(text: str = "ans", completion: int = 10) -> Sample:
-    return Sample(text=text, completion_tokens=completion, prompt_tokens=5, finish_reason="stop")
+    return Sample(
+        text=text,
+        reasoning_content="reasoning",
+        completion_tokens=completion,
+        prompt_tokens=5,
+        finish_reason="stop",
+    )
 
 
 def test_writes_ns_shape_record(tmp_path: Path) -> None:
@@ -34,6 +40,7 @@ def test_writes_ns_shape_record(tmp_path: Path) -> None:
     r = rows[0]
     assert r["id"] == "0"
     assert r["generation"] == "response-A"
+    assert r["reasoning_content"] == "reasoning"
     assert r["expected_answer"] == "0"
     assert r["problem"] == "q0"
     assert r["predicted_answer"] == "42"

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -18,14 +18,23 @@ from sgl_eval.sampler import ChatCompletionSampler
 from sgl_eval.types import GenConfig
 
 
-def _stub_response(text: str, completion: int = 7, prompt: int = 11, reasoning: int | None = None):
+def _stub_response(
+    text: str,
+    completion: int = 7,
+    prompt: int = 11,
+    reasoning: int | None = None,
+    reasoning_content: str | None = None,
+    sglang_reasoning: int | None = None,
+):
     usage_kw = {"completion_tokens": completion, "prompt_tokens": prompt}
     if reasoning is not None:
         usage_kw["completion_tokens_details"] = SimpleNamespace(reasoning_tokens=reasoning)
+    if sglang_reasoning is not None:
+        usage_kw["reasoning_tokens"] = sglang_reasoning
     return SimpleNamespace(
         choices=[
             SimpleNamespace(
-                message=SimpleNamespace(content=text),
+                message=SimpleNamespace(content=text, reasoning_content=reasoning_content),
                 finish_reason="stop",
             )
         ],
@@ -101,6 +110,29 @@ def test_reasoning_tokens_extracted(sampler):
     out = sampler([{"role": "user", "content": "hi"}])
     assert out.completion_tokens == 20
     assert out.reasoning_tokens == 15
+
+
+def test_sglang_reasoning_fields_extracted(sampler):
+    """SGLang exposes reasoning text on the message and, in older releases,
+    its token count directly on usage."""
+    sampler.client.chat.completions.create = lambda **_: _stub_response(
+        "answer",
+        completion=20,
+        reasoning_content="thinking",
+        sglang_reasoning=15,
+    )
+    out = sampler([{"role": "user", "content": "hi"}])
+    assert out.text == "answer"
+    assert out.reasoning_content == "thinking"
+    assert out.reasoning_tokens == 15
+
+
+def test_standard_reasoning_token_count_takes_precedence(sampler):
+    sampler.client.chat.completions.create = lambda **_: _stub_response(
+        "answer", reasoning=12, sglang_reasoning=10
+    )
+    out = sampler([{"role": "user", "content": "hi"}])
+    assert out.reasoning_tokens == 12
 
 
 def test_abort_before_call_raises(sampler):


### PR DESCRIPTION
## Summary

- persist `message.reasoning_content` alongside final `generation` text in per-sample JSONL records
- read the legacy SGLang `usage.reasoning_tokens` field when standard `completion_tokens_details.reasoning_tokens` is unavailable
- keep standard OpenAI token accounting authoritative when both fields are present

## Motivation

SGLang can separate model reasoning into `message.reasoning_content`. The existing sampler only preserved `message.content`, so a response that exhausted its token budget before producing final content appeared as an empty generation. Older SGLang releases also put the reasoning-token count directly on `usage`, causing these responses to be recorded with zero reasoning tokens.

Scoring remains based only on final content; this change makes prediction dumps complete and fixes token accounting for analysis.

## Testing

- `pytest` — 242 passed
- `pre-commit run --all-files` — passed