### PR TITLE
Add `mindcube` (MindCube tinybench, raw-QA setting)

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -16,6 +16,7 @@ an endpoint. Most need nothing.
 | `gpqa` | multichoice | Diamond split |
 | `mmmu_pro` | multichoice | VLM endpoint; MMMU-Pro `standard (10 options)` -- [see below](#mmmu-pro-variants) |
 | `mmmu_pro_vision` | multichoice | VLM endpoint; MMMU-Pro `vision` -- [see below](#mmmu-pro-variants) |
+| `mindcube` | multichoice | VLM endpoint; MindCube tinybench, raw-QA setting -- [see below](#mindcube) |
 | `ruler2` | ruler2 | extra install, a required flag, generated data -- [see below](#ruler2) |
 
 All scoring behavior (prompt, answer extraction, grading, pass@k /
@@ -204,3 +205,40 @@ explicitly, e.g. `1048576 - 768` to reserve room to answer), and the same
 `--num-examples` is *not* a substitute for `--ruler2-dataset-size`: it slices
 the generated file (NS's `++max_samples`), it does not change what gets
 generated.
+
+---
+
+## MindCube
+
+[MindCube](https://github.com/mll-lab-nu/MindCube) (Yin et al., 2025) asks
+whether a VLM can build a spatial mental model from a few views: 2-4 images of
+a scene plus a multiple-choice question about positions, orientations, or
+"what-if" movements. `mindcube` runs the paper's evaluation split
+(`MindCube_tinybench.jsonl`, 1,050 questions: 600 `among`, 250 `around`,
+200 `rotation`) in the **raw QA** setting -- views + question, answer directly.
+The cognitive-map settings (`aug_cgmap_*`, `plain_cgmap_*`, `ff_rsn`) need
+scaffold data and a map-parsing evaluator and are not registered.
+
+sgl-eval-own, like `mmmu_pro`: NeMo-Skills has no MindCube module. What is
+sgl-eval's and what is the official protocol's:
+
+| | source |
+|---|---|
+| prompt | official `RAW_QA` template (`[Task] ... [Answer Instruction] ... [Question]`), verbatim |
+| image placement | views before the text, in dataset order (image 1..N as the question refers to them), original bytes |
+| answer extraction | official `extract_answer` regex cascade, ported verbatim |
+| correctness | extracted letter == `gt_answer` |
+| overall | official filtered accuracy (`translation` tracked under `task.translation` but excluded from `score`; tinybench has none) |
+| per-setting | `task.among` / `task.around` / `task.rotation` |
+| `no_answer` | share of responses the official extractor could not parse |
+| `--n-repeats k` | `pass@1[avg-of-k]` / `pass@k` / `majority@k` via the vendored `MathMetrics` |
+
+Data: `MLL-Lab/MindCube` `data.zip` (~640 MB) is downloaded from the Hub and
+extracted once into `~/.cache/sgl_eval/mindcube/`. Set `SGL_EVAL_MINDCUBE_DIR`
+to a directory that already contains the extracted `data/` to skip that.
+
+The official prompt asks for the answer only, so the default is
+`thinking=False`; pass `--thinking` for reasoning models. The extractor reads
+the model's final `content`, not its reasoning stream. `--num-examples N`
+takes a setting-balanced sample. `--from-dataset` is not supported (image
+inputs are required).

--- a/sgl_eval/evals/_mindcube.py
+++ b/sgl_eval/evals/_mindcube.py
@@ -1,0 +1,371 @@
+"""MindCube spatial-reasoning benchmark (sgl-eval-own; NeMo-Skills has no MindCube).
+
+Dataset: ``MLL-Lab/MindCube`` -- ``data.zip`` on the HuggingFace Hub, holding
+``data/raw/MindCube_tinybench.jsonl`` (1,050 questions, the paper's evaluation
+split) and the referenced images (2-4 views per question, ``among`` /
+``around`` / ``rotation`` settings). The zip is downloaded and extracted once
+into ``~/.cache/sgl_eval/mindcube/`` (or ``$SGL_EVAL_MINDCUBE_DIR``), then each
+question's views are attached as ``MediaItem``\\s so the sample path is the same
+``build_user_content`` transport the other vision benchmarks use.
+
+This registers the paper's **raw QA** setting only: the frozen-VLM protocol
+where the model sees the views and the question and answers directly. The
+cognitive-map settings (``aug_cgmap_*`` / ``plain_cgmap_*`` / ``ff_rsn``) need
+scaffold data and a map-parsing evaluator and are out of scope here.
+
+Scoring follows the official evaluator (``src/evaluation``): the answer letter
+is pulled from the response by the official ``extract_answer`` regex cascade
+(ported verbatim) and compared to ``gt_answer``; the headline accuracy is the
+official filtered overall (``translation`` questions are tracked but excluded
+from the overall, exactly as upstream's ``base_metrics`` does), plus a
+per-setting breakdown via the standard ``task.*`` metric keys.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import warnings
+import zipfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from sgl_eval.evals._vision import build_user_content
+from sgl_eval.predictions import PredictionsWriter
+from sgl_eval.registry import EvalSpec, register
+from sgl_eval.runner import SampleFn, ScoreOneFn, run_examples
+from sgl_eval.sampler import ChatCompletionSampler
+from sgl_eval.types import Example, ExampleResult, GenConfig, MediaItem, RunResult, Sample
+
+DATASET_REPO = "MLL-Lab/MindCube"
+DATASET_FILE = "data.zip"
+BENCH_JSONL = "data/raw/MindCube_tinybench.jsonl"
+_CACHE_DIR = Path.home() / ".cache" / "sgl_eval" / "mindcube"
+_ENV_DIR = "SGL_EVAL_MINDCUBE_DIR"
+
+# Official raw-QA prompt, verbatim from MindCube
+# ``src/prompt_generation/templates.py`` (RAW_QA_BACKGROUND_INSTRUCTION,
+# QUESTION_HEADER, RawQATemplate.generate_prompt).
+RAW_QA_INSTRUCTION = """[Task]
+Your task is to analyze the spatial arrangement of objects in the scene by examining the provided images, which show the scene from different viewpoints.
+[Answer Instruction]
+You only need to provide *ONE* correct answer selecting from the options listed below. For example, if you think the correct answer is 'A. Above' from 'A. Above B. Under C. Front D. Behind', your response should **only** be '<answer>A. Above</answer>'.
+"""
+QUESTION_HEADER = "[Question]\n"
+
+# Official aggregation: which settings count toward the overall accuracy
+# (``src/evaluation/core/base_metrics.py``). ``translation`` is tracked but
+# excluded from the overall; the tinybench split ships no translation rows.
+SETTINGS = ("around", "rotation", "translation", "among", "other")
+INCLUDE_IN_OVERALL = {
+    "around": True,
+    "rotation": True,
+    "translation": False,
+    "among": True,
+    "other": True,
+}
+
+_MIME = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg"}
+
+
+# ---------- official scoring (ported verbatim from src/evaluation/core/extractors.py) ----------
+
+
+def extract_answer(text: str) -> str | None:
+    """Official MindCube answer extractor: the last letter A-E found by the
+    highest-priority matching pattern, or ``None``."""
+    if not text:
+        return None
+
+    simple_pattern_matches = list(re.finditer(r"([A-E])\.", text))
+    if simple_pattern_matches:
+        return simple_pattern_matches[-1].group(1)
+
+    answer_section_match = re.search(r"<Answer>(.*?)(?:<|$)", text, re.DOTALL)
+    if answer_section_match:
+        answer_section = answer_section_match.group(1)
+        for pattern in [
+            r"[Mm]y answer is ([A-E])",
+            r"[Mm]y answer is ([A-E])\.",
+            r"[Tt]he answer is ([A-E])",
+            r"(?:Answer: )?([A-E])\.",
+            r"\b([A-E])\b",
+        ]:
+            matches = list(re.finditer(pattern, answer_section))
+            if matches:
+                return matches[-1].group(1)
+
+    patterns = [
+        r"(?:Answer: )?([A-E])\. [A-Za-z0-9 \-\(\)\'\",]+(?=(?:\n|$|\.|\"))",
+        r"(?:Answer: )?([A-E])\. [A-Za-z0-9 \-\(\)\'\"]+",
+        r"(?:^|\n)(?:Answer: )?([A-E])(?:\.|$|\s)",
+        r"[\*\"]([A-E])[\*\"]",
+        r"\bAnswer:?\s*([A-E])\b",
+        r"[Mm]y answer is ([A-E])",
+        r"[Mm]y answer is ([A-E])\.",
+        r"answer is ([A-E])",
+    ]
+    for pattern in patterns:
+        matches = list(re.finditer(pattern, text))
+        if matches:
+            return matches[-1].group(1)
+
+    lines = text.split("\n")
+    line_matches = []
+    for i, line in enumerate(lines):
+        match = re.search(r"([A-E])\. [A-Za-z0-9 \-\(\)\'\",]+", line)
+        if match:
+            line_matches.append((i, match.group(1)))
+    if line_matches:
+        return line_matches[-1][1]
+
+    for i in reversed(range(len(lines))):
+        match = re.search(r"\b([A-E])\b", lines[i])
+        if match:
+            return match.group(1)
+
+    return None
+
+
+def setting_of(item_id: str) -> str:
+    """Official ``get_setting_from_id``: the setting is encoded in the id."""
+    if not item_id:
+        return "other"
+    lowered = item_id.lower()
+    for setting in ("around", "rotation", "translation", "among"):
+        if setting in lowered:
+            return setting
+    return "other"
+
+
+def build_prompt(question: str) -> str:
+    """Official ``RawQATemplate.generate_prompt``: instruction + question."""
+    return "\n".join([RAW_QA_INSTRUCTION, QUESTION_HEADER + question])
+
+
+# ---------- dataset ----------
+
+
+def _data_root() -> Path:
+    """Directory holding ``data/raw/...`` and ``data/other_all_image/...``.
+
+    ``$SGL_EVAL_MINDCUBE_DIR`` may point at an already-extracted copy (the
+    directory that *contains* ``data/``); otherwise the zip is fetched from the
+    Hub and extracted once into the sgl-eval cache.
+    """
+    override = os.environ.get(_ENV_DIR)
+    if override:
+        root = Path(override).expanduser()
+        if not (root / BENCH_JSONL).exists():
+            sys.exit(f"error: {_ENV_DIR}={override} does not contain {BENCH_JSONL}")
+        return root
+    if (_CACHE_DIR / BENCH_JSONL).exists():
+        return _CACHE_DIR
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as e:  # pragma: no cover - datasets pulls it in
+        raise SystemExit(f"error: mindcube needs huggingface_hub ({e})")
+    zip_path = hf_hub_download(repo_id=DATASET_REPO, filename=DATASET_FILE, repo_type="dataset")
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(_CACHE_DIR)
+    if not (_CACHE_DIR / BENCH_JSONL).exists():
+        sys.exit(f"error: extracted {DATASET_FILE} but {BENCH_JSONL} is missing")
+    return _CACHE_DIR
+
+
+def _read_rows(root: Path) -> list[dict[str, Any]]:
+    with (root / BENCH_JSONL).open() as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _interleave_rows_by_setting(rows: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    """Cap the row count while keeping settings balanced: the jsonl is grouped
+    by setting, so a plain head-slice would smoke-test only one of them."""
+    queues: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        queues.setdefault(setting_of(row.get("id", "")), []).append(row)
+    picked: list[dict[str, Any]] = []
+    depth = 0
+    setting_queues = list(queues.values())
+    while len(picked) < limit and any(depth < len(q) for q in setting_queues):
+        for q in setting_queues:
+            if depth < len(q):
+                picked.append(q[depth])
+                if len(picked) >= limit:
+                    break
+        depth += 1
+    return picked
+
+
+def _image_media(root: Path, rel_paths: list[str]) -> list[MediaItem]:
+    """Attach the views in dataset order (image 1..N as the question refers to
+    them), as their original bytes -- no re-encode, no resize."""
+    media: list[MediaItem] = []
+    for rel in rel_paths:
+        path = root / "data" / rel
+        if not path.exists():
+            raise ValueError(f"missing image {rel}")
+        mime = _MIME.get(path.suffix.lower())
+        if mime is None:
+            raise ValueError(f"unsupported image type {path.suffix!r} for {rel}")
+        media.append(MediaItem(kind="image", data=path.read_bytes(), mime=mime))
+    if not media:
+        raise ValueError("no images")
+    return media
+
+
+def _build_example(root: Path, row: dict[str, Any], idx: int) -> Example:
+    item_id = str(row.get("id") or f"mindcube-{idx}")
+    answer = str(row["gt_answer"]).strip().upper()
+    if not answer:
+        raise ValueError("empty gt_answer")
+    return Example(
+        id=item_id,
+        inputs={"problem": build_prompt(row["question"])},
+        target=answer,
+        meta={
+            "setting": setting_of(item_id),
+            "type": str(row.get("type")),
+            "category": row.get("category"),
+        },
+        media=_image_media(root, list(row.get("images") or [])),
+    )
+
+
+def load_mindcube_examples(num_examples: int | None) -> list[Example]:
+    root = _data_root()
+    rows = _read_rows(root)
+    if num_examples is not None:
+        rows = _interleave_rows_by_setting(rows, num_examples)
+    examples: list[Example] = []
+    for i, row in enumerate(rows):
+        try:
+            examples.append(_build_example(root, row, i))
+        except (ValueError, KeyError) as e:
+            # One bad row must not abort the whole load, but it must be visible.
+            warnings.warn(f"skipping MindCube row {row.get('id') or i}: {e}")
+    return examples
+
+
+# ---------- sample / score ----------
+
+
+def make_sample_fn(sampler: ChatCompletionSampler, gen: GenConfig) -> SampleFn:
+    def sample_fn(ex: Example, _rep_idx: int) -> Sample:
+        # Official inference puts the views before the text prompt.
+        content = build_user_content(ex.inputs["problem"], ex.media, image_position="before")
+        return sampler([{"role": "user", "content": content}], gen)
+
+    return sample_fn
+
+
+def make_score_one_fn() -> ScoreOneFn:
+    def score_one(ex: Example, sample: Sample) -> tuple[float, str | None]:
+        letter = extract_answer(sample.text)
+        correct = letter is not None and letter == str(ex.target)
+        return (1.0 if correct else 0.0), letter
+
+    return score_one
+
+
+# ---------- aggregate ----------
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def aggregate_mindcube(results: list[ExampleResult], n_repeats: int) -> dict[str, float]:
+    """Official filtered overall (settings with ``include_in_overall``) as
+    ``score``/``pass@1``, per-setting means as ``task.<setting>``, and the
+    no-answer rate (responses the official extractor could not parse)."""
+    if not results:
+        return {"score": 0.0}
+    counted = [r for r in results if INCLUDE_IN_OVERALL.get(r.example.meta.get("setting"), True)]
+    if n_repeats > 1:
+        # pass@1[avg-of-k] (+ std/SEM), pass@k and majority@k via the vendored
+        # MathMetrics, over the official filtered set.
+        from sgl_eval.evals._multichoice import aggregate_with_math_metrics
+
+        flat = aggregate_with_math_metrics(counted, n_repeats) if counted else {"score": 0.0}
+    else:
+        flat = {"score": _mean([_mean(r.scores) for r in counted if r.scores])}
+    by_setting: dict[str, list[float]] = {}
+    for r in results:
+        if r.scores:
+            by_setting.setdefault(r.example.meta.get("setting", "other"), []).append(
+                _mean(r.scores)
+            )
+    for setting, vals in sorted(by_setting.items()):
+        flat[f"task.{setting}"] = _mean(vals)
+    total = sum(len(r.extracted) for r in results)
+    missing = sum(1 for r in results for letter in r.extracted if letter is None)
+    flat["no_answer"] = missing / total if total else 0.0
+    return flat
+
+
+# ---------- registration ----------
+
+
+def run_mindcube_benchmark(
+    *,
+    name: str,
+    sampler: ChatCompletionSampler,
+    gen: GenConfig,
+    n_repeats: int,
+    num_examples: int | None,
+    num_threads: int,
+    predictions_writer: PredictionsWriter | None = None,
+) -> RunResult:
+    examples = load_mindcube_examples(num_examples)
+    return run_examples(
+        name=name,
+        examples=examples,
+        sample_fn=make_sample_fn(sampler, gen),
+        score_one_fn=make_score_one_fn(),
+        num_threads=num_threads,
+        n_repeats=n_repeats,
+        aggregate_fn=lambda results: aggregate_mindcube(results, n_repeats),
+        on_sample_scored=predictions_writer,
+    )
+
+
+def _run(
+    *,
+    sampler: ChatCompletionSampler,
+    gen: GenConfig,
+    n_repeats: int,
+    num_examples: int | None,
+    num_threads: int,
+    predictions_writer: PredictionsWriter | None = None,
+    load_examples: Callable[[int | None], list[Example]] | None = None,
+    bench_args: Any | None = None,
+    **_unused: Any,
+) -> RunResult:
+    if load_examples is not None:
+        sys.exit("error: --from-dataset is not supported for mindcube (image inputs required)")
+    return run_mindcube_benchmark(
+        name="mindcube",
+        sampler=sampler,
+        gen=gen,
+        n_repeats=n_repeats,
+        num_examples=num_examples,
+        num_threads=num_threads,
+        predictions_writer=predictions_writer,
+    )
+
+
+register(
+    EvalSpec(
+        name="mindcube",
+        category="multichoice",
+        description="MindCube tinybench (1050 multi-view spatial MCQs; raw-QA setting, official scorer).",
+        default_gen=GenConfig(),
+        default_n_repeats=1,
+        run=_run,
+    )
+)

--- a/tests/test_mindcube.py
+++ b/tests/test_mindcube.py
@@ -1,0 +1,230 @@
+"""Tests for the MindCube benchmark (SE-own; dataset on disk mocked, no network)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sgl_eval.evals._mindcube import (
+    QUESTION_HEADER,
+    RAW_QA_INSTRUCTION,
+    _interleave_rows_by_setting,
+    aggregate_mindcube,
+    build_prompt,
+    extract_answer,
+    load_mindcube_examples,
+    make_sample_fn,
+    make_score_one_fn,
+    setting_of,
+)
+from sgl_eval.types import Example, ExampleResult, GenConfig, Sample
+
+# ---------- official extractor ----------
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("<answer>C. Light purple sofa</answer>", "C"),
+        (
+            "I think A. TV is wrong, so <answer>B. Wooden dining table</answer>",
+            "B",
+        ),  # last "X." wins
+        ("Answer: D", "D"),
+        ("The answer is B", "B"),
+        ("My answer is A.", "A"),
+        ("**C**", "C"),
+        ("<Answer>My answer is D</Answer>", "D"),
+        ("Some reasoning\nB\n", "B"),
+        ("no option letter here", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_extract_answer(text, expected):
+    assert extract_answer(text) == expected
+
+
+def test_setting_of():
+    assert setting_of("among_group693_q1_5_2") == "among"
+    assert setting_of("around_group12_q3") == "around"
+    assert setting_of("rotation_group1_q0") == "rotation"
+    assert setting_of("translation_x") == "translation"
+    assert setting_of("weird") == "other"
+    assert setting_of("") == "other"
+
+
+# ---------- prompt ----------
+
+
+def test_build_prompt_is_official_raw_qa():
+    q = "Based on these images ... A. TV B. Sofa C. Table D. Curtains"
+    prompt = build_prompt(q)
+    assert prompt == RAW_QA_INSTRUCTION + "\n" + QUESTION_HEADER + q
+    assert prompt.startswith("[Task]\n")
+    assert "<answer>A. Above</answer>" in prompt
+    assert prompt.endswith("[Question]\n" + q)
+
+
+# ---------- loader ----------
+
+
+def _write_fake_dataset(root, rows):
+    from PIL import Image
+
+    raw = root / "data" / "raw"
+    raw.mkdir(parents=True)
+    with (raw / "MindCube_tinybench.jsonl").open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+    for row in rows:
+        for rel in row["images"]:
+            p = root / "data" / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            Image.new("RGB", (8, 6)).save(p, format="PNG" if p.suffix == ".png" else "JPEG")
+
+
+def _row(idx, setting, n_images, answer="B"):
+    return {
+        "id": f"{setting}_group{idx}_q0",
+        "category": ["x"],
+        "type": "1_frame",
+        "meta_info": [],
+        "question": f"Q{idx}? A. one B. two C. three D. four",
+        "images": [
+            f"other_all_image/{setting}/g{idx}/view{k}.{'jpg' if k % 2 else 'png'}"
+            for k in range(n_images)
+        ],
+        "gt_answer": answer,
+    }
+
+
+def test_load_from_env_dir(tmp_path, monkeypatch):
+    rows = [_row(0, "among", 4), _row(1, "around", 2, "A"), _row(2, "rotation", 3)]
+    _write_fake_dataset(tmp_path, rows)
+    monkeypatch.setenv("SGL_EVAL_MINDCUBE_DIR", str(tmp_path))
+    examples = load_mindcube_examples(None)
+    assert [e.id for e in examples] == [r["id"] for r in rows]
+    ex = examples[0]
+    assert ex.target == "B"
+    assert ex.meta["setting"] == "among"
+    assert len(ex.media) == 4
+    assert ex.media[0].kind == "image" and ex.media[0].mime == "image/png"
+    assert ex.media[1].mime == "image/jpeg"
+    assert ex.media[0].data[:8] == b"\x89PNG\r\n\x1a\n"
+    assert ex.inputs["problem"].endswith(rows[0]["question"])
+
+
+def test_load_skips_row_with_missing_image(tmp_path, monkeypatch):
+    rows = [_row(0, "among", 2), _row(1, "around", 2)]
+    _write_fake_dataset(tmp_path, rows)
+    (tmp_path / "data" / rows[1]["images"][0]).unlink()
+    monkeypatch.setenv("SGL_EVAL_MINDCUBE_DIR", str(tmp_path))
+    with pytest.warns(UserWarning, match="missing image"):
+        examples = load_mindcube_examples(None)
+    assert [e.id for e in examples] == [rows[0]["id"]]
+
+
+def test_env_dir_without_bench_jsonl_exits(tmp_path, monkeypatch):
+    monkeypatch.setenv("SGL_EVAL_MINDCUBE_DIR", str(tmp_path))
+    with pytest.raises(SystemExit):
+        load_mindcube_examples(None)
+
+
+def test_num_examples_interleaves_settings():
+    rows = [_row(i, "among", 1) for i in range(5)] + [_row(i, "around", 1) for i in range(5)]
+    picked = _interleave_rows_by_setting(rows, 4)
+    assert [setting_of(r["id"]) for r in picked] == ["among", "around", "among", "around"]
+
+
+# ---------- sample / score ----------
+
+
+class _FakeSampler:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, messages, gen):
+        self.calls.append(messages)
+        return Sample(text="<answer>B. two</answer>")
+
+
+def test_sample_fn_puts_images_before_text():
+    from sgl_eval.types import MediaItem
+
+    ex = Example(
+        id="among_g0_q0",
+        inputs={"problem": build_prompt("Q? A. one B. two")},
+        target="B",
+        meta={"setting": "among"},
+        media=[MediaItem(kind="image", data=b"\x89PNG", mime="image/png")] * 2,
+    )
+    sampler = _FakeSampler()
+    make_sample_fn(sampler, GenConfig())(ex, 0)
+    content = sampler.calls[0][0]["content"]
+    assert [c["type"] for c in content] == ["image_url", "image_url", "text"]
+    assert content[-1]["text"] == ex.inputs["problem"]
+
+
+def test_score_one_official_rule():
+    score_one = make_score_one_fn()
+    ex = Example(id="among_g0_q0", inputs={"problem": ""}, target="B", meta={})
+    assert score_one(ex, Sample(text="<answer>B. two</answer>")) == (1.0, "B")
+    assert score_one(ex, Sample(text="<answer>A. one</answer>")) == (0.0, "A")
+    assert score_one(ex, Sample(text="no idea")) == (0.0, None)
+
+
+# ---------- aggregate ----------
+
+
+def _result(setting, scores, extracted=None):
+    ex = Example(id=f"{setting}_g_q", inputs={"problem": ""}, target="A", meta={"setting": setting})
+    samples = [Sample(text="x") for _ in scores]
+    return ExampleResult(
+        example=ex, samples=samples, scores=scores, extracted=extracted or ["A"] * len(scores)
+    )
+
+
+def test_aggregate_excludes_translation_from_overall_but_reports_it():
+    results = [
+        _result("among", [1.0]),
+        _result("around", [0.0]),
+        _result("rotation", [1.0]),
+        _result("translation", [0.0]),
+    ]
+    agg = aggregate_mindcube(results, n_repeats=1)
+    assert agg["score"] == pytest.approx(2 / 3)  # translation excluded (official)
+    assert agg["task.translation"] == 0.0
+    assert agg["task.among"] == 1.0 and agg["task.around"] == 0.0
+    assert agg["no_answer"] == 0.0
+
+
+def test_aggregate_no_answer_rate():
+    results = [_result("among", [0.0], extracted=[None]), _result("among", [1.0])]
+    agg = aggregate_mindcube(results, n_repeats=1)
+    assert agg["no_answer"] == 0.5
+
+
+def test_aggregate_repeats_uses_pass_at_k_keys():
+    results = [_result("among", [1.0, 0.0]), _result("around", [1.0, 1.0])]
+    agg = aggregate_mindcube(results, n_repeats=2)
+    assert agg["score"] == pytest.approx(0.75)
+    assert "pass@2" in agg and "majority@2" in agg
+    assert agg["task.among"] == 0.5 and agg["task.around"] == 1.0
+
+
+def test_aggregate_empty():
+    assert aggregate_mindcube([], 1) == {"score": 0.0}
+
+
+# ---------- registration ----------
+
+
+def test_registered():
+    from sgl_eval import registry
+
+    spec = registry.get("mindcube")
+    assert spec.category == "multichoice"
+    assert spec.default_n_repeats == 1
+    assert spec.default_gen.chat_template_kwargs is None


### PR DESCRIPTION
## Summary

Add [MindCube](https://github.com/mll-lab-nu/MindCube) (Yin et al., 2025, "Spatial Mental Modeling from Limited Views") as a new sgl-eval-own multimodal multichoice benchmark: the paper's evaluation split `MindCube_tinybench.jsonl` -- 1,050 questions, each with 2-4 views of a scene (600 `among`, 250 `around`, 200 `rotation`) -- in the frozen-VLM **raw QA** setting. Dataset/eval only; the cognitive-map settings (`aug_cgmap_*`, `plain_cgmap_*`, `ff_rsn`) are out of scope.

- `sgl_eval/evals/_mindcube.py`: downloads `MLL-Lab/MindCube` `data.zip` (~640 MB) from the Hub and extracts it once into `~/.cache/sgl_eval/mindcube/` (`$SGL_EVAL_MINDCUBE_DIR` points at an existing extracted copy). Official `RAW_QA` prompt verbatim; views attached before the text in dataset order as their original bytes (same `MediaItem` + `build_user_content` transport as `mmmu_pro`). Scoring is the official evaluator's: `extract_answer` regex cascade ported verbatim, letter == `gt_answer`, overall = official filtered accuracy (`translation` tracked under `task.translation` but excluded from `score`, as upstream's `base_metrics` does), per-setting `task.among/around/rotation`, `no_answer` rate, and `pass@1[avg-of-k]` / `pass@k` / `majority@k` via the vendored `MathMetrics` for `--n-repeats > 1`. `--num-examples N` samples settings in a balanced way.
- `tests/test_mindcube.py`: 24 tests -- extractor cases, setting parsing, prompt shape, loader on a fake on-disk dataset (env override, missing-image skip, balanced sampling), image-before-text layout, scoring rule, aggregation (translation exclusion, `no_answer`, repeats), registration.
- `benchmarks.md`: row + section.

No new dependencies (`pillow` and `huggingface_hub` are already pulled in).

## Validation

- `pytest`: 264 passed (24 new); `ruff` / `black` / `codespell` clean; `scripts/audit_vendored.py` OK.
- Loader on the real dataset: 1,050 examples, settings `{among: 600, rotation: 200, around: 250}`, images per question `{2: 274, 3: 345, 4: 431}`, 0 missing files.
- 100-question setting-balanced sample (`--num-examples 100`), 16 repeats, temperature 1.0, top-p 0.95, thinking, 64 threads, same endpoint (SGLang v0.5.18, long-context serving ceiling): **pass@1 82.63%** (pass@16 100%, majority@16 87.0%), per setting among 77.94% / around 79.36% / rotation 90.72%, `no_answer` 0%, truncation 0%, errors 0%; 1,600/1,600 samples in 3,121 s, 6.53M completion tokens (per response: median 2,647, p95 12,871, max 56,858 -- the tail is the model's reasoning, still far inside the context). A partial full-split run (2,095 samples before it was stopped) also showed 0 truncation / 0 unparseable answers.

## Notes for review

- The official inference engine inserts each image at position 0 of the content list, which reverses the view order; this module keeps dataset order (image 1..N as the question text refers to them). Flagging in case reviewers prefer byte-for-byte parity with that quirk.
- The official prompt asks for the answer only, so the registered default is `thinking=False`; pass `--thinking` for reasoning models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TV8PRYZcMdeXMh8ySTuVSS


