### PR TITLE
Add `video_mme` (Video-MME, official scorer, server-side frame sampling)

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -16,6 +16,7 @@ an endpoint. Most need nothing.
 | `gpqa` | multichoice | Diamond split |
 | `mmmu_pro` | multichoice | VLM endpoint; MMMU-Pro `standard (10 options)` -- [see below](#mmmu-pro-variants) |
 | `mmmu_pro_vision` | multichoice | VLM endpoint; MMMU-Pro `vision` -- [see below](#mmmu-pro-variants) |
+| `video_mme` | multichoice | video-capable endpoint; Video-MME, server-side frame sampling, ~101 GB of videos -- [see below](#video-mme) |
 | `ruler2` | ruler2 | extra install, a required flag, generated data -- [see below](#ruler2) |
 
 All scoring behavior (prompt, answer extraction, grading, pass@k /
@@ -204,3 +205,51 @@ explicitly, e.g. `1048576 - 768` to reserve room to answer), and the same
 `--num-examples` is *not* a substitute for `--ruler2-dataset-size`: it slices
 the generated file (NS's `++max_samples`), it does not change what gets
 generated.
+
+---
+
+## Video-MME
+
+[Video-MME](https://github.com/MME-Benchmarks/Video-MME) (Fu et al., 2024): 2,700
+four-way multiple-choice questions over 900 videos, 300 per duration bucket
+(`short` < 2 min, `medium` 4-15 min, `long` 30-60 min), with `.srt` subtitles
+for 744 videos. `video_mme` sends each question as one `video_url` block plus
+the official prompt and lets the **served model sample frames itself** -- there
+is no client-side frame extraction, so the frame budget is whatever the
+endpoint's video processor applies (report it with your numbers).
+
+sgl-eval-own, like `mmmu_pro`: NeMo-Skills has no Video-MME module.
+
+| | source |
+|---|---|
+| prompt | official README template: `Select the best answer ... based on the video.` / `Respond with only the letter (A, B, C, or D) of the correct option.` / question / options / `The best answer is:` |
+| with subtitles (`--video-mme-subtitles`) | official header `This video's subtitles are listed below:` + caption text from the `.srt` (white `<font>` spans, one per line); videos without a subtitle file use the plain prompt |
+| answer extraction | official `extract_characters_regex` from `evaluation/eval_your_results.py` (repo @ `4e7566d36f`, the last commit that shipped it), ported verbatim including its quirks |
+| `score` | official accuracy: correct / **answered** (the official script drops unparsable responses from the denominator) |
+| `score_all` | correct / all samples (unparsable counted wrong) |
+| per duration | `task.short` / `task.medium` / `task.long` (official rule) |
+| `no_answer` | share of unparsable responses |
+| `--n-repeats k` | `pass@1[avg-of-k]` / `pass@k` / `majority@k` via the vendored `MathMetrics` (unparsable counted wrong) |
+
+**Video transport.** Videos are 2 MB - 915 MB, so the default (inline
+`data:video/mp4;base64,...`, read per request) is only practical for small
+deployments. Prefer `--video-mme-video-url TEMPLATE` to tell the *server* how
+to reach each file, with `{videoID}` / `{filename}` placeholders:
+
+```bash
+# server co-located with the data (SGLang accepts file:// and plain paths)
+sgl-eval run video_mme --base-url ... --video-mme-video-url 'file:///mnt/video-mme/data/{videoID}.mp4'
+# hosted copy
+sgl-eval run video_mme --base-url ... --video-mme-video-url 'https://files.example.org/vmme/{filename}'
+```
+
+**Data.** `SGL_EVAL_VIDEO_MME_DIR` should point at a directory holding
+`data/<videoID>.mp4` (and optionally `subtitle/<videoID>.srt`) -- the layout
+inside the Hub zips. Without it the benchmark downloads the 20
+`videos_chunked_*.zip` (~101 GB) plus `subtitle.zip` from `lmms-lab/Video-MME`
+and extracts them once into `~/.cache/sgl_eval/video_mme/`. Questions come from
+the repo's parquet via `datasets`.
+
+`--num-examples N` takes a duration-balanced sample. Default `--num-threads` is
+16: every request makes the server decode and sample a video of up to an hour.
+`--from-dataset` is not supported (video inputs required).

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -250,6 +250,8 @@ inside the Hub zips. Without it the benchmark downloads the 20
 and extracts them once into `~/.cache/sgl_eval/video_mme/`. Questions come from
 the repo's parquet via `datasets`.
 
-`--num-examples N` takes a duration-balanced sample. Default `--num-threads` is
+`--video-mme-duration short|medium|long` scores one bucket on its own (900
+questions), like the official `--video_duration_type`. `--num-examples N` takes
+a duration-balanced sample (within the bucket, if one is selected). Default `--num-threads` is
 16: every request makes the server decode and sample a video of up to an hour.
 `--from-dataset` is not supported (video inputs required).

--- a/sgl_eval/evals/_video_mme.py
+++ b/sgl_eval/evals/_video_mme.py
@@ -208,9 +208,15 @@ def _build_example(root: Path, row: dict[str, Any], use_subtitles: bool) -> Exam
     )
 
 
-def load_video_mme_examples(num_examples: int | None, use_subtitles: bool = False) -> list[Example]:
+def load_video_mme_examples(
+    num_examples: int | None, use_subtitles: bool = False, duration: str | None = None
+) -> list[Example]:
     root = _data_root()
     rows = _read_rows()
+    if duration:
+        # Official ``eval_your_results.py --video_duration_type``: score one
+        # bucket (900 questions: 300 videos x 3) on its own.
+        rows = [row for row in rows if row["duration"] == duration]
     if num_examples is not None:
         rows = _interleave_rows_by_duration(rows, num_examples)
     examples: list[Example] = []
@@ -312,6 +318,11 @@ def add_arguments(group: Any) -> None:
         ),
     )
     group.add_argument(
+        "--video-mme-duration",
+        choices=list(DURATIONS),
+        help="evaluate one duration bucket only (900 questions), like the official --video_duration_type",
+    )
+    group.add_argument(
         "--video-mme-subtitles",
         action="store_true",
         default=None,  # None keeps it out of bench_args when not passed
@@ -332,9 +343,10 @@ def run_video_mme_benchmark(
     num_threads: int,
     video_url_template: str | None = None,
     use_subtitles: bool = False,
+    duration: str | None = None,
     predictions_writer: PredictionsWriter | None = None,
 ) -> RunResult:
-    examples = load_video_mme_examples(num_examples, use_subtitles=use_subtitles)
+    examples = load_video_mme_examples(num_examples, use_subtitles=use_subtitles, duration=duration)
     return run_examples(
         name=name,
         examples=examples,
@@ -371,6 +383,7 @@ def _run(
         num_threads=num_threads,
         video_url_template=args.get("video_url"),
         use_subtitles=bool(args.get("subtitles")),
+        duration=args.get("duration"),
         predictions_writer=predictions_writer,
     )
 

--- a/sgl_eval/evals/_video_mme.py
+++ b/sgl_eval/evals/_video_mme.py
@@ -1,0 +1,391 @@
+"""Video-MME video-understanding benchmark (sgl-eval-own; NeMo-Skills has no Video-MME).
+
+Dataset: ``lmms-lab/Video-MME`` -- 2,700 multiple-choice questions (A-D) over 900
+videos, 300 videos per duration bucket (``short`` < 2 min, ``medium`` 4-15 min,
+``long`` 30-60 min), plus ``.srt`` subtitles for 744 of them. Each question is
+sent as one ``video_url`` content block followed by the official prompt, so the
+served model does its own frame sampling -- there is no client-side frame
+extraction. Scoring is the official ``eval_your_results.py`` (MME-Benchmarks/
+Video-MME @ 4e7566d36f, the last commit that shipped it): ``extract_characters_regex``
+ported verbatim, letter == ``answer``, and accuracy over *answered* questions
+(the official script drops unparsable responses from the denominator; the
+stricter all-questions accuracy is reported alongside as ``score_all``).
+
+Video transport. The videos are 2 MB - 915 MB, so inlining them as base64 is
+only practical for small deployments. ``--video-mme-video-url TEMPLATE`` tells
+the benchmark how the *server* reaches each video instead: a template with
+``{videoID}`` (and optionally ``{filename}``), e.g.
+``file:///mnt/video-mme/data/{videoID}.mp4`` for a co-located server or
+``https://files.example.org/video-mme/{filename}`` for a hosted copy. Without
+it, each request inlines the file as a ``data:video/mp4;base64,...`` URL, read
+at request time (never all at once).
+
+Data. ``$SGL_EVAL_VIDEO_MME_DIR`` may point at a directory holding
+``data/<videoID>.mp4`` (and optionally ``subtitle/<videoID>.srt``); otherwise
+the parquet, ``subtitle.zip`` and the 20 ``videos_chunked_*.zip`` (~101 GB) are
+fetched from the Hub and extracted once into ``~/.cache/sgl_eval/video_mme/``.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+import sys
+import warnings
+import zipfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from sgl_eval.evals._vision import build_user_content
+from sgl_eval.predictions import PredictionsWriter
+from sgl_eval.registry import EvalSpec, register
+from sgl_eval.runner import SampleFn, ScoreOneFn, run_examples
+from sgl_eval.sampler import ChatCompletionSampler
+from sgl_eval.types import Example, ExampleResult, GenConfig, MediaItem, RunResult, Sample
+
+DATASET_REPO = "lmms-lab/Video-MME"
+PARQUET_FILE = "videomme/test-00000-of-00001.parquet"
+SUBTITLE_ZIP = "subtitle.zip"
+VIDEO_ZIP_GLOB = "videos_chunked_*.zip"
+_CACHE_DIR = Path.home() / ".cache" / "sgl_eval" / "video_mme"
+_ENV_DIR = "SGL_EVAL_VIDEO_MME_DIR"
+
+DURATIONS = ("short", "medium", "long")
+CHOICES = ("A", "B", "C", "D")
+
+# Official prompt (Video-MME README, "Evaluation").
+PROMPT_INSTRUCTION = (
+    "Select the best answer to the following multiple-choice question based on the video.\n"
+    "Respond with only the letter (A, B, C, or D) of the correct option."
+)
+PROMPT_SUBTITLE_HEADER = "This video's subtitles are listed below:"
+PROMPT_SUFFIX = "The best answer is:"
+_SRT_TEXT_RE = re.compile(r'<font color="white" size=".72c">(.*?)</font>')
+
+
+# ---------- official scoring (ported verbatim from evaluation/eval_your_results.py) ----------
+
+
+def extract_characters_regex(s: str) -> str:
+    """Official Video-MME extractor. Returns the first A-D letter left after
+    stripping the answer prefixes, or ``""``. (The prefix list is reproduced
+    as published, including its two missing commas.)"""
+    s = s.strip()
+    answer_prefixes = [
+        "The best answer is",
+        "The correct answer is",
+        "The answer is",
+        "The answer",
+        # (the two missing commas are in the published script; the parentheses
+        # keep the identical concatenated strings while satisfying the linter)
+        ("The best option is" "The correct option is"),
+        ("Best answer:" "Best option:"),
+    ]
+    for answer_prefix in answer_prefixes:
+        s = s.replace(answer_prefix, "")
+
+    if len(s.split()) > 10 and not re.search("[ABCD]", s):
+        return ""
+    matches = re.search(r"[ABCD]", s)
+    if matches is None:
+        return ""
+    return matches[0]
+
+
+# ---------- prompt ----------
+
+
+def subtitle_text(srt: str) -> str:
+    """Official subtitle cleaning: keep the caption text inside the white
+    ``<font>`` spans, one caption per line."""
+    return "\n".join(m.strip() for m in _SRT_TEXT_RE.findall(srt) if m.strip())
+
+
+def build_prompt(question: str, options: list[str], subtitles: str | None = None) -> str:
+    parts: list[str] = []
+    if subtitles:
+        parts += [PROMPT_SUBTITLE_HEADER, subtitles]
+    parts += [PROMPT_INSTRUCTION, question, *options, PROMPT_SUFFIX]
+    return "\n".join(parts)
+
+
+# ---------- dataset ----------
+
+
+def _has_videos(root: Path) -> bool:
+    return (root / "data").is_dir() and any((root / "data").glob("*.mp4"))
+
+
+def _data_root() -> Path:
+    override = os.environ.get(_ENV_DIR)
+    if override:
+        root = Path(override).expanduser()
+        if not _has_videos(root):
+            sys.exit(f"error: {_ENV_DIR}={override} has no data/*.mp4")
+        return root
+    if _has_videos(_CACHE_DIR):
+        return _CACHE_DIR
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as e:  # pragma: no cover - datasets pulls it in
+        raise SystemExit(f"error: video_mme needs huggingface_hub ({e})")
+    warnings.warn(
+        f"Video-MME videos not found; downloading ~101 GB of {VIDEO_ZIP_GLOB} from {DATASET_REPO} "
+        f"into {_CACHE_DIR} (set {_ENV_DIR} to reuse an existing copy)"
+    )
+    snap = Path(
+        snapshot_download(
+            DATASET_REPO, repo_type="dataset", allow_patterns=[VIDEO_ZIP_GLOB, SUBTITLE_ZIP]
+        )
+    )
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    for zpath in sorted(snap.glob(VIDEO_ZIP_GLOB)) + [snap / SUBTITLE_ZIP]:
+        with zipfile.ZipFile(zpath) as zf:
+            zf.extractall(_CACHE_DIR)  # zips carry data/<videoID>.mp4 and subtitle/<videoID>.srt
+    if not _has_videos(_CACHE_DIR):
+        sys.exit(f"error: extracted {VIDEO_ZIP_GLOB} but found no data/*.mp4 under {_CACHE_DIR}")
+    return _CACHE_DIR
+
+
+def _read_rows() -> list[dict[str, Any]]:
+    from datasets import load_dataset  # lazy: heavy import
+
+    ds = load_dataset(DATASET_REPO, "videomme", split="test")
+    return [dict(row) for row in ds]
+
+
+def _interleave_rows_by_duration(rows: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    """Cap the row count while keeping duration buckets balanced: the parquet
+    is ordered short -> medium -> long, so a head-slice would be all short."""
+    queues: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        queues.setdefault(row["duration"], []).append(row)
+    picked: list[dict[str, Any]] = []
+    depth = 0
+    dq = list(queues.values())
+    while len(picked) < limit and any(depth < len(q) for q in dq):
+        for q in dq:
+            if depth < len(q):
+                picked.append(q[depth])
+                if len(picked) >= limit:
+                    break
+        depth += 1
+    return picked
+
+
+def _load_subtitle(root: Path, video_id: str) -> str | None:
+    path = root / "subtitle" / f"{video_id}.srt"
+    if not path.exists():
+        return None
+    text = subtitle_text(path.read_text(encoding="utf-8", errors="replace"))
+    return text or None
+
+
+def _build_example(root: Path, row: dict[str, Any], use_subtitles: bool) -> Example:
+    video_id = str(row["videoID"])
+    video_path = root / "data" / f"{video_id}.mp4"
+    if not video_path.exists():
+        raise ValueError(f"missing video data/{video_id}.mp4")
+    subtitles = _load_subtitle(root, video_id) if use_subtitles else None
+    options = [str(o) for o in row["options"]]
+    return Example(
+        id=str(row["question_id"]),
+        inputs={"problem": build_prompt(str(row["question"]), options, subtitles)},
+        target=str(row["answer"]).strip().upper(),
+        meta={
+            "video_id": video_id,
+            "duration": row["duration"],
+            "domain": row.get("domain"),
+            "sub_category": row.get("sub_category"),
+            "task_type": row.get("task_type"),
+            "has_subtitles": subtitles is not None,
+        },
+        # ``url`` holds the local path; the sample fn turns it into the URL the
+        # server will actually fetch (template) or an inline data URL.
+        media=[MediaItem(kind="video", url=str(video_path), mime="video/mp4")],
+    )
+
+
+def load_video_mme_examples(num_examples: int | None, use_subtitles: bool = False) -> list[Example]:
+    root = _data_root()
+    rows = _read_rows()
+    if num_examples is not None:
+        rows = _interleave_rows_by_duration(rows, num_examples)
+    examples: list[Example] = []
+    for row in rows:
+        try:
+            examples.append(_build_example(root, row, use_subtitles))
+        except (ValueError, KeyError) as e:
+            warnings.warn(f"skipping Video-MME row {row.get('question_id')}: {e}")
+    return examples
+
+
+# ---------- sample / score ----------
+
+
+def video_url_for(local_path: str, template: str | None) -> str:
+    """Resolve how the server reaches the video: substitute the template, or
+    inline the file as a base64 data URL (read now, per request)."""
+    path = Path(local_path)
+    if template:
+        return template.format(videoID=path.stem, filename=path.name)
+    data = base64.b64encode(path.read_bytes()).decode()
+    return f"data:video/mp4;base64,{data}"
+
+
+def make_sample_fn(
+    sampler: ChatCompletionSampler, gen: GenConfig, video_url_template: str | None
+) -> SampleFn:
+    def sample_fn(ex: Example, _rep_idx: int) -> Sample:
+        media = [
+            MediaItem(kind="video", url=video_url_for(m.url, video_url_template), mime=m.mime)
+            for m in ex.media
+        ]
+        # Video first, then the prompt (build_user_content appends video blocks
+        # after the text, so assemble explicitly).
+        text_content = build_user_content(ex.inputs["problem"], [])
+        content = [{"type": "video_url", "video_url": {"url": m.url}} for m in media]
+        content.append({"type": "text", "text": text_content})
+        return sampler([{"role": "user", "content": content}], gen)
+
+    return sample_fn
+
+
+def make_score_one_fn() -> ScoreOneFn:
+    def score_one(ex: Example, sample: Sample) -> tuple[float, str | None]:
+        letter = extract_characters_regex(sample.text or "")
+        correct = letter != "" and letter == str(ex.target)
+        return (1.0 if correct else 0.0), (letter or None)
+
+    return score_one
+
+
+# ---------- aggregate ----------
+
+
+def _acc(pairs: list[tuple[float, str | None]], answered_only: bool) -> float:
+    if answered_only:
+        pairs = [p for p in pairs if p[1] is not None]
+    return sum(s for s, _ in pairs) / len(pairs) if pairs else 0.0
+
+
+def aggregate_video_mme(results: list[ExampleResult], n_repeats: int) -> dict[str, float]:
+    """``score`` = official accuracy over answered samples; ``score_all`` counts
+    unparsable responses as wrong; ``task.<duration>`` per bucket (official
+    rule); ``no_answer`` = share of unparsable responses. With repeats, the
+    vendored MathMetrics adds pass@1[avg-of-k] / pass@k / majority@k (unparsable
+    counted wrong)."""
+    if not results:
+        return {"score": 0.0}
+    pairs = [(s, e) for r in results for s, e in zip(r.scores, r.extracted)]
+    flat: dict[str, float] = {}
+    if n_repeats > 1:
+        from sgl_eval.evals._multichoice import aggregate_with_math_metrics
+
+        flat.update(aggregate_with_math_metrics(results, n_repeats))
+    flat["score"] = _acc(pairs, answered_only=True)
+    flat["score_all"] = _acc(pairs, answered_only=False)
+    by_dur: dict[str, list[tuple[float, str | None]]] = {}
+    for r in results:
+        by_dur.setdefault(r.example.meta.get("duration", "other"), []).extend(
+            zip(r.scores, r.extracted)
+        )
+    for dur in sorted(by_dur, key=lambda d: DURATIONS.index(d) if d in DURATIONS else 99):
+        flat[f"task.{dur}"] = _acc(by_dur[dur], answered_only=True)
+    flat["no_answer"] = sum(1 for _, e in pairs if e is None) / len(pairs) if pairs else 0.0
+    return flat
+
+
+# ---------- CLI surface ----------
+
+
+def add_arguments(group: Any) -> None:
+    group.add_argument(
+        "--video-mme-video-url",
+        metavar="TEMPLATE",
+        help=(
+            "how the SERVER reaches each video, with {videoID} / {filename} placeholders, "
+            "e.g. file:///mnt/video-mme/data/{videoID}.mp4 or https://host/vmme/{filename}; "
+            "default: inline each file as a base64 data URL (only practical for small setups)"
+        ),
+    )
+    group.add_argument(
+        "--video-mme-subtitles",
+        action="store_true",
+        default=None,  # None keeps it out of bench_args when not passed
+        help="use the official with-subtitles prompt (videos without a subtitle file fall back to the plain prompt)",
+    )
+
+
+# ---------- registration ----------
+
+
+def run_video_mme_benchmark(
+    *,
+    name: str,
+    sampler: ChatCompletionSampler,
+    gen: GenConfig,
+    n_repeats: int,
+    num_examples: int | None,
+    num_threads: int,
+    video_url_template: str | None = None,
+    use_subtitles: bool = False,
+    predictions_writer: PredictionsWriter | None = None,
+) -> RunResult:
+    examples = load_video_mme_examples(num_examples, use_subtitles=use_subtitles)
+    return run_examples(
+        name=name,
+        examples=examples,
+        sample_fn=make_sample_fn(sampler, gen, video_url_template),
+        score_one_fn=make_score_one_fn(),
+        num_threads=num_threads,
+        n_repeats=n_repeats,
+        aggregate_fn=lambda results: aggregate_video_mme(results, n_repeats),
+        on_sample_scored=predictions_writer,
+    )
+
+
+def _run(
+    *,
+    sampler: ChatCompletionSampler,
+    gen: GenConfig,
+    n_repeats: int,
+    num_examples: int | None,
+    num_threads: int,
+    predictions_writer: PredictionsWriter | None = None,
+    load_examples: Callable[[int | None], list[Example]] | None = None,
+    bench_args: dict[str, Any] | None = None,
+    **_unused: Any,
+) -> RunResult:
+    if load_examples is not None:
+        sys.exit("error: --from-dataset is not supported for video_mme (video inputs required)")
+    args = dict(bench_args or {})
+    return run_video_mme_benchmark(
+        name="video_mme",
+        sampler=sampler,
+        gen=gen,
+        n_repeats=n_repeats,
+        num_examples=num_examples,
+        num_threads=num_threads,
+        video_url_template=args.get("video_url"),
+        use_subtitles=bool(args.get("subtitles")),
+        predictions_writer=predictions_writer,
+    )
+
+
+register(
+    EvalSpec(
+        name="video_mme",
+        category="multichoice",
+        description="Video-MME (2700 video MCQs, short/medium/long; official scorer, server-side frame sampling).",
+        default_gen=GenConfig(),
+        default_n_repeats=1,
+        run=_run,
+        # Each request makes the server decode and sample a video of up to an
+        # hour; 64 concurrent decodes is a lot of CPU and RAM on one box.
+        default_num_threads=16,
+        add_arguments=add_arguments,
+    )
+)

--- a/tests/test_video_mme.py
+++ b/tests/test_video_mme.py
@@ -146,6 +146,20 @@ def test_load_skips_missing_video(tmp_path, monkeypatch):
     assert [e.id for e in examples] == ["001-1"]
 
 
+def test_duration_filter(tmp_path, monkeypatch):
+    rows = [
+        _row("001-1", "vidA", "short"),
+        _row("301-1", "vidB", "medium"),
+        _row("601-1", "vidC", "long"),
+    ]
+    _write_fake_dataset(tmp_path, rows)
+    monkeypatch.setenv("SGL_EVAL_VIDEO_MME_DIR", str(tmp_path))
+    monkeypatch.setattr("sgl_eval.evals._video_mme._read_rows", lambda: rows)
+    assert [e.id for e in load_video_mme_examples(None, duration="short")] == ["001-1"]
+    assert [e.id for e in load_video_mme_examples(None, duration="long")] == ["601-1"]
+    assert [e.id for e in load_video_mme_examples(1, duration="medium")] == ["301-1"]
+
+
 def test_env_dir_without_videos_exits(tmp_path, monkeypatch):
     monkeypatch.setenv("SGL_EVAL_VIDEO_MME_DIR", str(tmp_path))
     with pytest.raises(SystemExit):
@@ -266,8 +280,15 @@ def test_registered_with_cli_args():
     parser = argparse.ArgumentParser()
     spec.add_arguments(parser.add_argument_group("video_mme"))
     ns = parser.parse_args(
-        ["--video-mme-video-url", "file:///x/{videoID}.mp4", "--video-mme-subtitles"]
+        [
+            "--video-mme-video-url",
+            "file:///x/{videoID}.mp4",
+            "--video-mme-subtitles",
+            "--video-mme-duration",
+            "short",
+        ]
     )
     assert ns.video_mme_video_url == "file:///x/{videoID}.mp4"
+    assert ns.video_mme_duration == "short"
     assert ns.video_mme_subtitles is True
     assert parser.parse_args([]).video_mme_subtitles is None

--- a/tests/test_video_mme.py
+++ b/tests/test_video_mme.py
@@ -1,0 +1,273 @@
+"""Tests for the Video-MME benchmark (SE-own; dataset on disk mocked, no network)."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from sgl_eval.evals._video_mme import (
+    PROMPT_INSTRUCTION,
+    PROMPT_SUFFIX,
+    _interleave_rows_by_duration,
+    aggregate_video_mme,
+    build_prompt,
+    extract_characters_regex,
+    load_video_mme_examples,
+    make_sample_fn,
+    make_score_one_fn,
+    subtitle_text,
+    video_url_for,
+)
+from sgl_eval.types import Example, ExampleResult, GenConfig, Sample
+
+# ---------- official extractor ----------
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("C", "C"),
+        ("The best answer is: C.", "C"),
+        ("The correct answer is B", "B"),
+        ("(D)", "D"),
+        ("b", ""),  # official regex is case-sensitive
+        ("", ""),
+        ("no letters here at all in this long long sentence with many words indeed ok", ""),
+        # official quirk, reproduced: only listed prefixes are stripped, so the
+        # "A" in "Answer:" is the first match
+        ("Answer: D", "A"),
+    ],
+)
+def test_extract_characters_regex(text, expected):
+    assert extract_characters_regex(text) == expected
+
+
+# ---------- prompt ----------
+
+
+def test_build_prompt_without_subtitles():
+    p = build_prompt("Q?", ["A. x", "B. y", "C. z", "D. w"])
+    assert p == PROMPT_INSTRUCTION + "\nQ?\nA. x\nB. y\nC. z\nD. w\n" + PROMPT_SUFFIX
+    assert "subtitles" not in p
+
+
+def test_build_prompt_with_subtitles():
+    p = build_prompt("Q?", ["A. x", "B. y"], subtitles="hello\nworld")
+    assert p.startswith(
+        "This video's subtitles are listed below:\nhello\nworld\n" + PROMPT_INSTRUCTION
+    )
+    assert p.endswith(PROMPT_SUFFIX)
+
+
+def test_subtitle_text_cleaning():
+    srt = (
+        "1\n00:00:01,520 --> 00:00:05,040\n"
+        '<font color="white" size=".72c">next track final</font>\n\n'
+        "2\n00:00:03,520 --> 00:00:06,000\n"
+        '<font color="white" size=".72c">is the</font>\n'
+    )
+    assert subtitle_text(srt) == "next track final\nis the"
+    assert subtitle_text("garbage without fonts") == ""
+
+
+# ---------- loader ----------
+
+
+def _row(qid, video_id, duration, answer="B"):
+    return {
+        "video_id": qid.split("-")[0],
+        "duration": duration,
+        "domain": "Knowledge",
+        "sub_category": "Astronomy",
+        "url": "https://example.invalid",
+        "videoID": video_id,
+        "question_id": qid,
+        "task_type": "Counting Problem",
+        "question": f"Question {qid}?",
+        "options": ["A. one", "B. two", "C. three", "D. four"],
+        "answer": answer,
+    }
+
+
+def _write_fake_dataset(root, rows, subtitles=None):
+    (root / "data").mkdir(parents=True)
+    for row in rows:
+        (root / "data" / f"{row['videoID']}.mp4").write_bytes(
+            b"\x00\x00\x00\x18ftypmp42" + row["videoID"].encode()
+        )
+    if subtitles:
+        (root / "subtitle").mkdir()
+        for vid, text in subtitles.items():
+            (root / "subtitle" / f"{vid}.srt").write_text(text)
+
+
+def test_load_from_env_dir(tmp_path, monkeypatch):
+    rows = [
+        _row("001-1", "vidA", "short"),
+        _row("001-2", "vidA", "short", "D"),
+        _row("301-1", "vidB", "medium"),
+    ]
+    _write_fake_dataset(tmp_path, rows)
+    monkeypatch.setenv("SGL_EVAL_VIDEO_MME_DIR", str(tmp_path))
+    monkeypatch.setattr("sgl_eval.evals._video_mme._read_rows", lambda: rows)
+    examples = load_video_mme_examples(None)
+    assert [e.id for e in examples] == ["001-1", "001-2", "301-1"]
+    ex = examples[1]
+    assert ex.target == "D"
+    assert ex.meta["duration"] == "short" and ex.meta["video_id"] == "vidA"
+    assert ex.meta["has_subtitles"] is False
+    assert len(ex.media) == 1 and ex.media[0].kind == "video"
+    assert ex.media[0].url == str(tmp_path / "data" / "vidA.mp4")
+    assert ex.inputs["problem"].endswith("D. four\n" + PROMPT_SUFFIX)
+
+
+def test_load_with_subtitles_and_fallback(tmp_path, monkeypatch):
+    rows = [_row("001-1", "vidA", "short"), _row("301-1", "vidB", "medium")]
+    srt = '1\n00:00:01,000 --> 00:00:02,000\n<font color="white" size=".72c">hi there</font>\n'
+    _write_fake_dataset(tmp_path, rows, subtitles={"vidA": srt})
+    monkeypatch.setenv("SGL_EVAL_VIDEO_MME_DIR", str(tmp_path))
+    monkeypatch.setattr("sgl_eval.evals._video_mme._read_rows", lambda: rows)
+    examples = load_video_mme_examples(None, use_subtitles=True)
+    assert examples[0].meta["has_subtitles"] is True
+    assert "This video's subtitles are listed below:\nhi there\n" in examples[0].inputs["problem"]
+    assert examples[1].meta["has_subtitles"] is False  # no .srt -> plain prompt
+    assert "subtitles are listed" not in examples[1].inputs["problem"]
+
+
+def test_load_skips_missing_video(tmp_path, monkeypatch):
+    rows = [_row("001-1", "vidA", "short"), _row("301-1", "vidB", "medium")]
+    _write_fake_dataset(tmp_path, rows)
+    (tmp_path / "data" / "vidB.mp4").unlink()
+    monkeypatch.setenv("SGL_EVAL_VIDEO_MME_DIR", str(tmp_path))
+    monkeypatch.setattr("sgl_eval.evals._video_mme._read_rows", lambda: rows)
+    with pytest.warns(UserWarning, match="missing video"):
+        examples = load_video_mme_examples(None)
+    assert [e.id for e in examples] == ["001-1"]
+
+
+def test_env_dir_without_videos_exits(tmp_path, monkeypatch):
+    monkeypatch.setenv("SGL_EVAL_VIDEO_MME_DIR", str(tmp_path))
+    with pytest.raises(SystemExit):
+        load_video_mme_examples(None)
+
+
+def test_num_examples_interleaves_durations():
+    rows = [_row(f"{i:03d}-1", f"s{i}", "short") for i in range(4)]
+    rows += [_row(f"{300+i:03d}-1", f"m{i}", "medium") for i in range(4)]
+    rows += [_row(f"{600+i:03d}-1", f"l{i}", "long") for i in range(4)]
+    picked = _interleave_rows_by_duration(rows, 5)
+    assert [r["duration"] for r in picked] == ["short", "medium", "long", "short", "medium"]
+
+
+# ---------- video transport ----------
+
+
+def test_video_url_template_and_inline(tmp_path):
+    p = tmp_path / "abc.mp4"
+    p.write_bytes(b"\x00\x01video")
+    assert (
+        video_url_for(str(p), "file:///srv/vmme/data/{videoID}.mp4")
+        == "file:///srv/vmme/data/abc.mp4"
+    )
+    assert video_url_for(str(p), "https://h/{filename}") == "https://h/abc.mp4"
+    inline = video_url_for(str(p), None)
+    assert inline == "data:video/mp4;base64," + base64.b64encode(b"\x00\x01video").decode()
+
+
+class _FakeSampler:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, messages, gen):
+        self.calls.append(messages)
+        return Sample(text="B")
+
+
+def test_sample_fn_video_before_text(tmp_path):
+    from sgl_eval.types import MediaItem
+
+    p = tmp_path / "vid.mp4"
+    p.write_bytes(b"x")
+    ex = Example(
+        id="001-1",
+        inputs={"problem": build_prompt("Q?", ["A. one", "B. two"])},
+        target="B",
+        meta={"duration": "short"},
+        media=[MediaItem(kind="video", url=str(p), mime="video/mp4")],
+    )
+    sampler = _FakeSampler()
+    make_sample_fn(sampler, GenConfig(), "file:///mnt/{videoID}.mp4")(ex, 0)
+    content = sampler.calls[0][0]["content"]
+    assert [c["type"] for c in content] == ["video_url", "text"]
+    assert content[0]["video_url"]["url"] == "file:///mnt/vid.mp4"
+    assert content[1]["text"] == ex.inputs["problem"]
+
+
+def test_score_one_official_rule():
+    score_one = make_score_one_fn()
+    ex = Example(id="001-1", inputs={"problem": ""}, target="B", meta={})
+    assert score_one(ex, Sample(text="The best answer is: B")) == (1.0, "B")
+    assert score_one(ex, Sample(text="C")) == (0.0, "C")
+    assert score_one(ex, Sample(text="")) == (0.0, None)
+
+
+# ---------- aggregate ----------
+
+
+def _result(duration, scores, extracted):
+    ex = Example(id="q", inputs={"problem": ""}, target="A", meta={"duration": duration})
+    return ExampleResult(
+        example=ex, samples=[Sample(text="x") for _ in scores], scores=scores, extracted=extracted
+    )
+
+
+def test_aggregate_official_answered_only_vs_all():
+    results = [
+        _result("short", [1.0], ["A"]),
+        _result("short", [0.0], [None]),  # unparsable: dropped by official rule
+        _result("medium", [0.0], ["B"]),
+        _result("long", [1.0], ["A"]),
+    ]
+    agg = aggregate_video_mme(results, n_repeats=1)
+    assert agg["score"] == pytest.approx(2 / 3)  # official: 3 answered, 2 correct
+    assert agg["score_all"] == pytest.approx(2 / 4)
+    assert agg["task.short"] == 1.0 and agg["task.medium"] == 0.0 and agg["task.long"] == 1.0
+    assert agg["no_answer"] == 0.25
+    assert [k for k in agg if k.startswith("task.")] == [
+        "task.short",
+        "task.medium",
+        "task.long",
+    ]
+
+
+def test_aggregate_repeats_adds_pass_at_k():
+    results = [_result("short", [1.0, 0.0], ["A", "B"]), _result("long", [1.0, 1.0], ["A", "A"])]
+    agg = aggregate_video_mme(results, n_repeats=2)
+    assert "pass@2" in agg and "majority@2" in agg
+    assert agg["score"] == pytest.approx(0.75)
+
+
+def test_aggregate_empty():
+    assert aggregate_video_mme([], 1) == {"score": 0.0}
+
+
+# ---------- registration ----------
+
+
+def test_registered_with_cli_args():
+    import argparse
+
+    from sgl_eval import registry
+
+    spec = registry.get("video_mme")
+    assert spec.category == "multichoice"
+    assert spec.default_num_threads == 16
+    parser = argparse.ArgumentParser()
+    spec.add_arguments(parser.add_argument_group("video_mme"))
+    ns = parser.parse_args(
+        ["--video-mme-video-url", "file:///x/{videoID}.mp4", "--video-mme-subtitles"]
+    )
+    assert ns.video_mme_video_url == "file:///x/{videoID}.mp4"
+    assert ns.video_mme_subtitles is True
+    assert parser.parse_args([]).video_mme_subtitles is None


### PR DESCRIPTION
## Summary

Add [Video-MME](https://github.com/MME-Benchmarks/Video-MME) (Fu et al., 2024) as a new sgl-eval-own multimodal multichoice benchmark: 2,700 four-way multiple-choice questions over 900 videos, 300 per duration bucket (`short` < 2 min, `medium` 4-15 min, `long` 30-60 min), with `.srt` subtitles for 744 videos.

- `sgl_eval/evals/_video_mme.py`: questions from the `lmms-lab/Video-MME` parquet. Each question is one `video_url` content block plus the official prompt, so the **served model samples frames itself** (no client-side frame extraction). `--video-mme-video-url TEMPLATE` (`{videoID}` / `{filename}`) tells the server how to reach each file -- `file://` for a co-located server, `https://` for a hosted copy; without it each file is inlined as a base64 data URL read per request (videos are 2 MB - 915 MB, so that is only for small setups). `--video-mme-subtitles` switches to the official with-subtitles prompt (caption text from the `.srt` white `<font>` spans; videos without a subtitle file fall back to the plain prompt). Scoring is the official `evaluation/eval_your_results.py` (repo @ `4e7566d36f`, the last commit that shipped it): `extract_characters_regex` ported verbatim including its quirks, `score` = official accuracy over *answered* samples (the official script drops unparsable responses from the denominator), `score_all` counting them wrong, `task.short/medium/long`, `no_answer`, and pass@k via the vendored `MathMetrics` for repeats. `--video-mme-duration short|medium|long` scores one bucket on its own (900 questions), like the official `--video_duration_type`; `--num-examples N` is duration-balanced. Default `--num-threads` 16, since every request is a server-side video decode.
- Data: `$SGL_EVAL_VIDEO_MME_DIR` pointing at `data/<videoID>.mp4` (+ optional `subtitle/`), the Hub zips' layout; otherwise a one-time ~101 GB download + extract into `~/.cache/sgl_eval/video_mme/`.
- `tests/test_video_mme.py`: 24 tests -- extractor incl. quirks, prompt shapes, subtitle cleaning, loader on a fake on-disk dataset (env override, subtitle fallback, missing-video skip, balanced sampling), URL template / inline transport, video-before-text message layout, scoring, aggregation (answered-only vs all, per duration, repeats), registration and CLI args.
- `benchmarks.md`: row + section.

No new dependencies.

## Validation

- `pytest`: 264 passed (24 new); `ruff` / `black` / `codespell` clean.
- End-to-end against an SGLang-served video-capable endpoint, 100 duration-balanced questions (`--num-examples 100`) x 16 repeats, temperature 1.0, top-p 0.95, thinking, 16 threads, `--video-mme-video-url 'file:///.../{videoID}.mp4'` (server co-located with the data): **official score 77.13%** (`score_all` identical: `no_answer` 0%), pass@16 89.0%, majority@16 77.0%, short 75.74% / medium 73.67% / long 82.01%, truncation 0%, errors 0%; 1,600/1,600 samples in 4,714 s, 1.18M completion tokens (median 433, p95 2,466, max 9,975 per response).
- Practical note from that run: the endpoint's video processor decoded every frame before sampling, so full-length 30-60 min files cost minutes of CPU each and ~200 GB of resident memory per long video. The numbers above were produced from a pre-sampled copy of the videos (each rewritten to the 96 uniformly spaced frames that processor selects anyway, at 96/duration fps so its timestamps are preserved; identical prompt-token counts confirmed). That is a property of the endpoint, not of this benchmark; the loader sends the files it is pointed at.

## Notes for review

- The official extractor has two missing commas in its prefix list (two pairs of strings concatenate) and strips only listed prefixes, so e.g. `Answer: D` extracts `A`. Ported as published for parity with the leaderboard script; flagged in case reviewers prefer a corrected variant behind a flag.
- Frame count / resolution is a property of the endpoint's video processor, not of this benchmark; runs should report it alongside the score, as the Video-MME leaderboard does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TV8PRYZcMdeXMh8ySTuVSS


