### PR TITLE
gsm8k: use the standard 8-shot CoT examples; add --num-shots

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -9,7 +9,7 @@ an endpoint. Most need nothing.
 
 | benchmark | category | notes |
 |---|---|---|
-| `gsm8k` | math | -- |
+| `gsm8k` | math | 8-shot CoT by default (lm-eval `gsm8k-cot` examples); `--num-shots 0` for the zero-shot `generic/math` prompt -- [see below](#gsm8k-few-shot) |
 | `aime24/25/26` | math | one per contest year, same shape |
 | `mmlu` | multichoice | -- |
 | `mmlu_pro` | multichoice | text 10-choice; **not** `mmmu_pro` -- [see below](#mmlu-pro-vs-mmmu-pro) |
@@ -204,3 +204,16 @@ explicitly, e.g. `1048576 - 768` to reserve room to answer), and the same
 `--num-examples` is *not* a substitute for `--ruler2-dataset-size`: it slices
 the generated file (NS's `++max_samples`), it does not change what gets
 generated.
+
+## gsm8k few-shot
+
+`gsm8k` prepends NeMo-Skills' `gsm8k_standard_few_shot` (the 8 CoT-paper
+examples lm-eval's `gsm8k-cot` task uses) inside the `generic/math` prompt.
+The zero-shot wording alone ("put the answer (and only answer) inside
+\boxed{}") makes reasoning models such as Qwen3.5-397B-A17B loop on the
+answer format inside their reasoning until `max_tokens`: on the same server
+(4x GB300, `max_tokens 16384`, T=0.6) it truncates 7-28% of samples and scores
+0.90-0.95, while the 8-shot prompt truncates <=0.5% and scores 0.975-0.985,
+matching sglang's 5-shot `run_eval` number. `--num-shots N` trims the set,
+`--num-shots 0` restores the zero-shot prompt; the value is recorded in
+`metrics.json` because scores are not comparable across it.

--- a/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
+++ b/sgl_eval/_vendored/nemo_skills/SOURCES.yaml
@@ -90,6 +90,10 @@ files:
   - src: nemo_skills/dataset/utils.py
     dst: dataset/_utils.py
 
+  # --- few-shot example sets (gsm8k's default prompt is 8-shot CoT) ---
+  - src: nemo_skills/prompt/few_shot_examples/gsm8k.py
+    dst: prompt/few_shot_examples/gsm8k.py
+
   # --- per-benchmark dataset metadata + bundled data ---
   - src: nemo_skills/dataset/aime25/__init__.py
     dst: dataset/aime25/__init__.py

--- a/sgl_eval/_vendored/nemo_skills/prompt/__init__.py
+++ b/sgl_eval/_vendored/nemo_skills/prompt/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored NeMo-Skills prompt assets (few-shot example sets)."""

--- a/sgl_eval/_vendored/nemo_skills/prompt/few_shot_examples/__init__.py
+++ b/sgl_eval/_vendored/nemo_skills/prompt/few_shot_examples/__init__.py
@@ -1,0 +1,2 @@
+"""Few-shot example sets vendored one module at a time; upstream's
+``__init__`` pulls in every set and is intentionally not vendored."""

--- a/sgl_eval/_vendored/nemo_skills/prompt/few_shot_examples/gsm8k.py
+++ b/sgl_eval/_vendored/nemo_skills/prompt/few_shot_examples/gsm8k.py
@@ -1,0 +1,244 @@
+# Vendored from NVIDIA/NeMo-Skills@645cf567ff08c0ae9cc3fc8e1edbb975b3067816
+# Source: nemo_skills/prompt/few_shot_examples/gsm8k.py
+# DO NOT EDIT directly. To upgrade, edit SOURCES.yaml and rerun
+# `python scripts/sync_vendored.py`.
+
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Source https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/gsm8k/gsm8k-cot.yaml
+# Derived from the CoT paper - https://arxiv.org/pdf/2201.11903 - Table 20
+gsm8k_standard_few_shot = [
+    {
+        "problem": "There are 15 trees in the grove. Grove workers will plant trees in the grove today. After they are done, there will be 21 trees. How many trees did the grove workers plant today?",
+        "solution": "There are 15 trees originally. Then there were 21 trees after some more were planted. So there must have been 21 - 15 = 6. So the answer is \\boxed{6}.",
+    },
+    {
+        "problem": "If there are 3 cars in the parking lot and 2 more cars arrive, how many cars are in the parking lot?",
+        "solution": "There are originally 3 cars. 2 more cars arrive. 3 + 2 = 5. So the answer is \\boxed{5}.",
+    },
+    {
+        "problem": "Leah had 32 chocolates and her sister had 42. If they ate 35, how many pieces do they have left in total?",
+        "solution": "Originally, Leah had 32 chocolates. Her sister had 42. So in total they had 32 + 42 = 74. After eating 35, they had 74 - 35 = 39. So the answer is \\boxed{39}.",
+    },
+    {
+        "problem": "Jason had 20 lollipops. He gave Denny some lollipops. Now Jason has 12 lollipops. How many lollipops did Jason give to Denny?",
+        "solution": "Jason started with 20 lollipops. Then he had 12 after giving some to Denny. So he gave Denny 20 - 12 = 8. So the answer is \\boxed{8}.",
+    },
+    {
+        "problem": "Shawn has five toys. For Christmas, he got two toys each from his mom and dad. How many toys does he have now?",
+        "solution": "Shawn started with 5 toys. If he got 2 toys each from his mom and dad, then that is 4 more toys. 5 + 4 = 9. So the answer is \\boxed{9}.",
+    },
+    {
+        "problem": "There were nine computers in the server room. Five more computers were installed each day, from monday to thursday. How many computers are now in the server room?",
+        "solution": "There were originally 9 computers. For each of 4 days, 5 more computers were added. So 5 * 4 = 20 computers were added. 9 + 20 is 29. So the answer is \\boxed{29}.",
+    },
+    {
+        "problem": "Michael had 58 golf balls. On tuesday, he lost 23 golf balls. On wednesday, he lost 2 more. How many golf balls did he have at the end of wednesday?",
+        "solution": "Michael started with 58 golf balls. After losing 23 on tuesday, he had 58 - 23 = 35. After losing 2 more, he had 35 - 2 = 33 golf balls. So the answer is \\boxed{33}.",
+    },
+    {
+        "problem": "Olivia has $23. She bought five bagels for $3 each. How much money does she have left?",
+        "solution": "Olivia had 23 dollars. 5 bagels for 3 dollars each will be 5 x 3 = 15 dollars. So she has 23 - 15 dollars left. 23 - 15 is 8. So the answer is \\boxed{8}.",
+    },
+]
+
+
+gsm8k_text_with_code = [
+    {
+        "problem": "Missy had a giant piggy bank in her bedroom.  Every day she would search the house for change to put in her bank.  After 4 years, the bank was opened and it contained $450 in change.  If the second, third, and fourth-year she doubled the amount of money she put in the bank from the amount she had put in the previous year, how much money, in dollars, did she put in the bank the first year?",
+        "solution": """
+Missy started with some amount of money in the first year.
+She was then doubling the amount of money every year for 4 years and ended up with $450.
+Let's write down an equation for this problem and solve it using sympy.
+{code_begin}from sympy import solve, symbols
+first_year_money = symbols('first_year_money')
+second_year_money = 2 * first_year_money
+third_year_money = 2 * second_year_money
+fourth_year_money = 2 * third_year_money
+# Solve for first year money given that the combined saving is 450
+result = solve(first_year_money + second_year_money + third_year_money + fourth_year_money - 450, first_year_money)[0]
+result
+{code_end}{code_output_begin}
+30
+{code_output_end}
+Thus Missy put \\boxed{30} dollars in the bank the first year.
+""".strip(),
+    },
+    {
+        "problem": "Pete has to take a 10-minute walk down to the train station and then board a 1hr 20-minute train to LA. When should he leave if he cannot get to LA later than 0900 hours? (24-hr time)",
+        "solution": """
+Since Pete needs to take a 10 minutes walk and then a 1 hour 20 minutes train ride, he will spend a total of 1 hour and 30 minutes.
+This means that he needs to leave 1 hour and 30 minutes earlier than 09:00 hours.
+Subtracting 1 hour and 30 minutes from 09:00 hours we get \\boxed{07:30} hours.
+""".strip(),
+    },
+    {
+        "problem": "Mark deposited $88 in a bank. Bryan deposited $40 less than five times as much as Mark. How much did Bryan deposit in the bank?",
+        "solution": """
+Let's solve this problem using Python code.
+{code_begin}mark_deposit = 88
+five_times_mark_deposit = 5 * mark_deposit
+bryan_deposit = five_times_mark_deposit - 40
+bryan_deposit
+{code_end}{code_output_begin}
+400
+{code_output_end}
+So Bryan deposited \\boxed{400} dollars in the bank.
+""".strip(),
+    },
+    {
+        "problem": "A department store displays a 20% discount on all fixtures. What will be the new price of a 25 cm high bedside lamp that was worth $120?",
+        "solution": """
+Let's solve this problem using Python code.
+{code_begin}discount_percent = 20
+price_before_discount = 120
+discount_portion = discount_percent / 100
+discount_amount = price_before_discount * discount_portion
+price_after_discount = price_before_discount - discount_amount
+price_after_discount
+{code_end}{code_output_begin}
+96.0
+{code_output_end}
+So the new price of the lamp is \\boxed{96} dollars.
+""".strip(),
+    },
+    {
+        "problem": "James opens up a flower shop.  He needs to pay rent of $1200 a week with an additional 20% of rent to pay for utilities and he has 2 employees per shift with the store open 16 hours a day for 5 days a week.  If he pays each employee $12.50 an hour, what are his weekly expenses to run the store?",
+        "solution": """
+The cost consists of rent, utilities, and employee salaries. Let's compute each of them separately and then add them up.
+{code_begin}# rent cost
+rent_per_week = 1200
+# utility cost
+utility_per_week = rent_per_week * 20 / 100
+# employee cost
+employee_work_hours = 16
+work_days_per_week = 5
+employee_work_hours_per_week = work_days_per_week * employee_work_hours
+number_of_employees = 2
+employee_cost_per_hour = 12.5
+employees_cost_per_week = number_of_employees * employee_work_hours_per_week * employee_cost_per_hour
+# add the three to get total cost
+cost_per_week = rent_per_week + utility_per_week + employees_cost_per_week
+cost_per_week
+{code_end}{code_output_begin}
+3440.0
+{code_output_end}
+Thus James's weekly expenses add up to \\boxed{3440} dollars.
+""".strip(),
+    },
+]
+
+
+# Solutions are only in text
+gsm8k_text_detailed = [
+    {
+        "problem": "Missy had a giant piggy bank in her bedroom.  Every day she would search the house for change to put in her bank.  After 4 years, the bank was opened and it contained $450 in change.  If the second, third, and fourth-year she doubled the amount of money she put in the bank from the amount she had put in the previous year, how much money, in dollars, did she put in the bank the first year?",
+        "solution": """
+Let $x$ be the amount of money Missy put in the bank the first year.
+She was then doubling the amount of money every year for 4 years.
+So in the second year she put $2*x$ amount in her bank.
+In the third year she put $2*2*x = 4*x$ amount in her bank.
+And in the fourth year she put $2*4*x = 8*x$ amount in her bank.
+So the total amount she put in the bank is $x + (2*x) + (4*x) + (8*x) = 15*x$.
+As the problem states, this total amounts to $450.
+So $450 = 15*x$ which implies $x = 30$.
+Thus, Missy put \\boxed{30} dollars in the bank the first year.
+""".strip(),
+    },
+    {
+        "problem": "Pete has to take a 10-minute walk down to the train station and then board a 1hr 20-minute train to LA. When should he leave if he cannot get to LA later than 0900 hours? (24-hr time)",
+        "solution": """
+Since Pete needs to take a 10 minutes walk and then a 1 hour 20 minutes train ride, he will spend a total of 1 hour and 30 minutes.
+This means that he needs to leave 1 hour and 30 minutes earlier than 09:00 hours.
+Subtracting 1 hour and 30 minutes from 0900 hours we get \\boxed{07:30} hours.
+""".strip(),
+    },
+    {
+        "problem": "Mark deposited $88 in a bank. Bryan deposited $40 less than five times as much as Mark. How much did Bryan deposit in the bank?",
+        "solution": """
+Five times of what Mark deposited is $88 * 5 = 440$.
+Bryan deposited $440 - 40 = 400$.
+So Bryan deposited \\boxed{400} dollars in the bank.
+""".strip(),
+    },
+    {
+        "problem": "A department store displays a 20% discount on all fixtures. What will be the new price of a 25 cm high bedside lamp that was worth $120?",
+        "solution": """
+The lamp was originally priced at $120.
+A 20% discount amounts to $120 * 20 / 100 = 24$.
+So the discount reduces the price of the lamp to $120 - 24 = 96$.
+So the new price of the lamp is \\boxed{96} dollars.
+""".strip(),
+    },
+    {
+        "problem": "James opens up a flower shop.  He needs to pay rent of $1200 a week with an additional 20% of rent to pay for utilities and he has 2 employees per shift with the store open 16 hours a day for 5 days a week.  If he pays each employee $12.50 an hour, what are his weekly expenses to run the store?",
+        "solution": """
+The store expense consist of rent, utilities, and employee salaries.
+Let's compute each of these expenses separately at a week timescale and then add them up.
+The expense due to rent is $1200.
+The expense due to utilities is 20% of rent expense. Thus, it is $1200 * 20 / 100 = 240$.
+Now we calculate the expense due to employee salaries.
+Each employee works 16*5=80 hours per week.
+For each employee the cost per week based on hourly wage of $12.5/hr is $12.5 * 80 = 1000$ per week.
+For two employees, this amounts to $2 * 1000 = 2000$.
+Adding the cost of rent, utilities, and employee salaries amounts to $1200 + 240 + 2000 = 3440$.
+Thus James's weekly expenses to run the store add up to \\boxed{3440} dollars.
+""".strip(),
+    },
+]
+
+gsm8k_problem_augmentation = [
+    {
+        "problem": "Olivia has $23. She bought five bagels for $3 each. How much money does she have left?",
+        "augmented_problem": "Aiden has $35. He purchased eight pencils for $2 each and a notebook for $5. How much money does he have remaining?",
+    },
+    {
+        "problem": "Michael had 58 golf balls. On tuesday, he lost 23 golf balls. On wednesday, he lost 2 more. How many golf balls did he have at the end of wednesday?",
+        "augmented_problem": "Sarah collected 72 seashells during her beach vacation. On Thursday, she gave 15 seashells to her friend as a souvenir. On Friday, she found 8 more seashells while exploring the shore. How many seashells did Sarah have at the end of Friday?",
+    },
+    {
+        "problem": "Angelo and Melanie want to plan how many hours over the next week they should study together for their test next week. They have 2 chapters of their textbook to study and 4 worksheets to memorize. They figure out that they should dedicate 3 hours to each chapter of their textbook and 1.5 hours for each worksheet. If they plan to study no more than 4 hours each day, how many days should they plan to study total over the next week if they take a 10-minute break every hour, include 3 10-minute snack breaks each day, and 30 minutes for lunch each day?",
+        "augmented_problem": "Samantha and David are preparing for their upcoming science fair project. They have four different experiments to conduct and a research paper to write. Each experiment is estimated to take 2 hours, and the research paper will require 8 hours to complete. To stay focused and productive, they plan to take a 15-minute break for every 1.5 hours of work and have three 20-minute snack breaks each day. Additionally, they allocate 45 minutes for lunch each day. If they want to limit their daily study time to 5 hours, how many days should they plan to work on their project over the next two weeks?",
+    },
+    {
+        "problem": "Leah had 32 chocolates and her sister had 42. If they ate 35, how many pieces do they have left in total?",
+        "augmented_problem": "Tom has 50 marbles, and his friend Jerry has 65 marbles. If they decide to play a game and bet 20 marbles each, how many marbles will they have left in total after the game?",
+    },
+    {
+        "problem": "There were nine computers in the server room. Five more computers were installed each day, from monday to thursday. How many computers are now in the server room?",
+        "augmented_problem": "In a garden, there were 12 flowers. Every morning for a week (from Monday to Sunday), 3 more flowers were planted. How many flowers are there in the garden now?",
+    },
+    {
+        "problem": "Jason had 20 lollipops. He gave Denny some lollipops. Now Jason has 12 lollipops. How many lollipops did Jason give to Denny?",
+        "augmented_problem": "Sarah had 35 marbles. She gave some marbles to her friend Emma. Now Sarah has 18 marbles left. How many marbles did Sarah give to Emma?",
+    },
+    {
+        "problem": "Sam bought a dozen boxes, each with 30 highlighter pens inside, for $10 each box. He rearranged five of these boxes into packages of six highlighters each and sold them for $3 per package. He sold the rest of the highlighters separately at the rate of three pens for $2. How much profit did he make in total, in dollars?",
+        "augmented_problem": "Amy purchased 8 crates, each containing 24 colorful markers, for $12 per crate. She decided to create sets of 4 markers each and sell them for $2 per set. The remaining markers she sold individually at a rate of 5 markers for $3. Calculate the total profit Amy made, in dollars.",
+    },
+    {
+        "problem": "There are 15 trees in the grove. Grove workers will plant trees in the grove today. After they are done, there will be 21 trees. How many trees did the grove workers plant today?",
+        "augmented_problem": "In a garden, there are 25 rose bushes. The gardener plans to plant some more rose bushes today. After planting, there will be a total of 40 rose bushes in the garden. How many rose bushes will the gardener plant today?",
+    },
+]
+
+
+examples_map = {
+    "gsm8k_standard_few_shot": gsm8k_standard_few_shot,
+    "gsm8k_text_with_code": gsm8k_text_with_code,
+    "gsm8k_problem_augmentation": gsm8k_problem_augmentation,
+    "gsm8k_text_detailed": gsm8k_text_detailed,
+}

--- a/sgl_eval/cli.py
+++ b/sgl_eval/cli.py
@@ -132,6 +132,16 @@ def build_parser() -> argparse.ArgumentParser:
         "scores are not comparable across prompts -- the choice is recorded in "
         "metrics.json.",
     )
+    p_run.add_argument(
+        "--num-shots",
+        type=int,
+        default=None,
+        metavar="N",
+        help="number of few-shot examples to prepend for benchmarks that ship them "
+        "(gsm8k: 8 by default, the lm-eval gsm8k-cot set). 0 runs zero-shot. "
+        "Changes what the model is asked, so scores are not comparable across "
+        "values -- the choice is recorded in metrics.json.",
+    )
     p_run.set_defaults(func=cmd_run, dump_predictions=True)
 
     # Benchmarks contribute their own options, so argparse -- not a hand-rolled

--- a/sgl_eval/evals/_math.py
+++ b/sgl_eval/evals/_math.py
@@ -34,9 +34,14 @@ def _eval_single_sync(evaluator: MathEvaluator, data_point: Dict[str, Any]) -> D
     return asyncio.run(evaluator.eval_single(data_point))
 
 
-def make_sample_fn(sampler: ChatCompletionSampler, gen: GenConfig, prompt_yaml: Path) -> SampleFn:
+def make_sample_fn(
+    sampler: ChatCompletionSampler,
+    gen: GenConfig,
+    prompt_yaml: Path,
+    few_shot_examples: Optional[list] = None,
+) -> SampleFn:
     def sample_fn(ex: Example, _rep_idx: int) -> Sample:
-        prompt = render_math_prompt(prompt_yaml, ex.inputs["problem"])
+        prompt = render_math_prompt(prompt_yaml, ex.inputs["problem"], few_shot_examples)
         return sampler([{"role": "user", "content": prompt}], gen)
 
     return sample_fn
@@ -103,12 +108,13 @@ def run_math_benchmark(
     num_threads: int,
     load_examples: Callable[[Optional[int]], List[Example]],
     prompt_yaml: Path,
+    few_shot_examples: Optional[list] = None,
     evaluator_config: Optional[Dict[str, Any]] = None,
     predictions_writer: Optional[PredictionsWriter] = None,
 ) -> RunResult:
     examples = load_examples(num_examples)
     evaluator = MathEvaluator(config=evaluator_config or {})
-    sample_fn = make_sample_fn(sampler, gen, prompt_yaml)
+    sample_fn = make_sample_fn(sampler, gen, prompt_yaml, few_shot_examples)
     score_one_fn = make_score_one_fn(evaluator)
     aggregator = (
         (lambda results: aggregate_with_math_metrics(results, n_repeats)) if n_repeats > 1 else None

--- a/sgl_eval/evals/_prompts.py
+++ b/sgl_eval/evals/_prompts.py
@@ -19,6 +19,21 @@ _VENDORED_PROMPT_DIR = (
 _SE_PROMPT_DIR = Path(__file__).resolve().parent / "prompts"
 
 
+def load_few_shot_examples(spec: str) -> list:
+    """Resolve ``"<module>:<name>"`` (relative to the vendored
+    ``nemo_skills.prompt.few_shot_examples`` package) to its list of
+    ``{"problem", "solution"}`` dicts."""
+    import importlib
+
+    module_name, _, attr = spec.partition(":")
+    if not module_name or not attr:
+        raise ValueError(f"few_shot_examples spec must be '<module>:<name>', got {spec!r}")
+    module = importlib.import_module(
+        f"sgl_eval._vendored.nemo_skills.prompt.few_shot_examples.{module_name}"
+    )
+    return list(getattr(module, attr))
+
+
 def vendored_prompt(name: str) -> Path:
     """Return the path to a vendored prompt yaml by basename (no extension)."""
     return _VENDORED_PROMPT_DIR / f"{name}.yaml"

--- a/sgl_eval/evals/_registry.py
+++ b/sgl_eval/evals/_registry.py
@@ -18,6 +18,9 @@ no new module. Each entry encodes only the things that genuinely differ:
   split, for benchmarks whose jsonl is grouped rather than shuffled.
 - ``thinking``: whether to set ``chat_template_kwargs={"thinking": True}``
   by default. True for reasoning benchmarks (aime / gpqa); off otherwise.
+- ``few_shot_examples``: ``"<module>:<name>"`` under the vendored
+  ``nemo_skills.prompt.few_shot_examples``; rendered into the prompt yaml's
+  ``{examples}`` slot. ``--num-shots`` trims or disables it per run.
 - ``default_n_repeats``: per-example repeat count (sgl-eval choice; NS
   also leaves this to CLI via ``--benchmarks=name:N``).
 - ``default_num_threads``: concurrency ceiling, defaulting to 64. Long-context
@@ -43,13 +46,13 @@ ships no dataset metadata -- its subtasks only exist once generated).
 from __future__ import annotations
 
 import importlib
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from sgl_eval.evals._loader import load_bundled, load_via_prepare
 from sgl_eval.evals._math import run_math_benchmark
 from sgl_eval.evals._mmmu_pro import load_mmmu_pro
 from sgl_eval.evals._multichoice import run_multichoice_benchmark
-from sgl_eval.evals._prompts import resolve_prompt
+from sgl_eval.evals._prompts import load_few_shot_examples, resolve_prompt
 from sgl_eval.evals._ruler2 import PRED_SCHEMA as _RULER2_PRED_SCHEMA
 from sgl_eval.evals._ruler2 import add_arguments as _add_ruler2_arguments
 from sgl_eval.evals._ruler2 import run_ruler2_benchmark
@@ -68,7 +71,12 @@ _TABLE = [
         "save_args": ("test",),
         "thinking": False,
         "default_n_repeats": 1,
-        "description": "GSM8K grade-school math (single-shot, mean accuracy).",
+        # The standard 8-shot CoT prompt (lm-eval gsm8k-cot / CoT paper). The
+        # zero-shot generic/math wording makes reasoning models (Qwen3.5) loop
+        # on the answer-format instruction until max_tokens: 7-28% truncated,
+        # score 0.90-0.95 vs 0.985 with these examples on the same server.
+        "few_shot_examples": "gsm8k:gsm8k_standard_few_shot",
+        "description": "GSM8K grade-school math (8-shot CoT, mean accuracy).",
     },
     {
         "name": "aime24",
@@ -227,8 +235,11 @@ def _build_loader(entry: dict):
 # Per-category behavior, in one place. Every factory takes the same arguments so
 # the registration loop below stays free of benchmark names; a new category is a
 # new row here plus its runner module.
-def _math_run(name: str, prompt_basename: str, loader: Callable):
+def _math_run(
+    name: str, prompt_basename: str, loader: Callable, few_shot_examples: Optional[str] = None
+):
     default_prompt_yaml = resolve_prompt(prompt_basename)
+    default_examples = load_few_shot_examples(few_shot_examples) if few_shot_examples else []
 
     def run(
         *,
@@ -241,7 +252,18 @@ def _math_run(name: str, prompt_basename: str, loader: Callable):
         load_examples=None,
         bench_args=None,
         prompt_yaml=None,
+        num_shots=None,
     ):
+        examples = default_examples
+        if num_shots is not None:
+            if num_shots and not default_examples:
+                raise ValueError(f"{name} ships no few-shot examples; --num-shots is not supported")
+            if num_shots > len(default_examples):
+                raise ValueError(
+                    f"{name}: --num-shots {num_shots} exceeds the {len(default_examples)} "
+                    "vendored examples"
+                )
+            examples = default_examples[:num_shots]
         return run_math_benchmark(
             name=name,
             sampler=sampler,
@@ -251,6 +273,7 @@ def _math_run(name: str, prompt_basename: str, loader: Callable):
             num_threads=num_threads,
             load_examples=load_examples or loader,
             prompt_yaml=prompt_yaml or default_prompt_yaml,
+            few_shot_examples=examples or None,
             predictions_writer=predictions_writer,
         )
 
@@ -271,7 +294,10 @@ def _mcq_run(name: str, prompt_basename: str, loader: Callable):
         load_examples=None,
         bench_args=None,
         prompt_yaml=None,
+        num_shots=None,
     ):
+        if num_shots:
+            raise ValueError(f"{name} ships no few-shot examples; --num-shots is not supported")
         return run_multichoice_benchmark(
             name=name,
             sampler=sampler,
@@ -299,7 +325,10 @@ def _ruler2_run(name: str, _prompt_basename: str, _loader: Callable):
         load_examples=None,
         bench_args=None,
         prompt_yaml=None,
+        num_shots=None,
     ):
+        if num_shots:
+            raise ValueError(f"{name} ships no few-shot examples; --num-shots is not supported")
         if prompt_yaml is not None:
             raise ValueError(
                 f"{name} does not take a prompt override: its prompt is a pure "
@@ -349,7 +378,12 @@ for _entry in _TABLE:
             description=_entry["description"],
             default_gen=_build_default_gen(_entry["thinking"]),
             default_n_repeats=_entry["default_n_repeats"],
-            run=_category["make_run"](_name, _prompt_basename, _build_loader(_entry)),
+            run=_category["make_run"](
+                _name,
+                _prompt_basename,
+                _build_loader(_entry),
+                **({"few_shot_examples": _entry["few_shot_examples"]} if "few_shot_examples" in _entry else {}),
+            ),
             default_num_threads=_entry.get("default_num_threads", 64),
             pred_schema=_category.get("pred_schema") or PredSchema(),
             add_arguments=_category.get("add_arguments"),

--- a/sgl_eval/pipeline/report.py
+++ b/sgl_eval/pipeline/report.py
@@ -72,6 +72,11 @@ def _build_run_meta(ctx: RunContext) -> Dict[str, Any]:
     # not comparable with one that does not.
     if ctx.prompt_yaml is not None:
         meta["prompt"] = {"spec": ctx.args.prompt, "path": str(ctx.prompt_yaml)}
+    # Same reasoning: a different number of in-context examples is a different
+    # question. Only recorded when overridden; the benchmark default is implied.
+    num_shots = getattr(ctx, "num_shots", None)
+    if num_shots is not None:
+        meta["num_shots"] = num_shots
     model_preset_block = make_model_preset_meta_block(ctx.inputs.model_preset)
     if model_preset_block:
         meta["model_preset"] = model_preset_block

--- a/sgl_eval/pipeline/run.py
+++ b/sgl_eval/pipeline/run.py
@@ -20,6 +20,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             load_examples=ctx.load_examples,
             bench_args=ctx.bench_args,
             prompt_yaml=ctx.prompt_yaml,
+            num_shots=ctx.num_shots,
         )
     finally:
         setup.teardown(ctx)

--- a/sgl_eval/pipeline/setup.py
+++ b/sgl_eval/pipeline/setup.py
@@ -37,6 +37,8 @@ class RunContext:
     bench_args: Dict[str, Any]
     # None means "the benchmark's registered prompt"; set only by --prompt.
     prompt_yaml: Optional[Path]
+    # None means "the benchmark's registered example count"; set only by --num-shots.
+    num_shots: Optional[int]
     _prev_sigint_handler: Any
 
 
@@ -64,6 +66,9 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
 
     num_threads = args.num_threads if args.num_threads is not None else spec.default_num_threads
     prompt_yaml = _resolve_prompt_override(getattr(args, "prompt", None))
+    num_shots = getattr(args, "num_shots", None)
+    if num_shots is not None and num_shots < 0:
+        raise ValueError(f"--num-shots must be >= 0, got {num_shots}")
 
     return RunContext(
         inputs=inputs,
@@ -77,6 +82,7 @@ def prepare_run(args: argparse.Namespace) -> RunContext:
         load_examples=load_examples,
         bench_args=_collect_bench_args(args, spec.name),
         prompt_yaml=prompt_yaml,
+        num_shots=num_shots,
         _prev_sigint_handler=prev_sigint,
     )
 

--- a/tests/test_gsm8k_few_shot.py
+++ b/tests/test_gsm8k_few_shot.py
@@ -1,0 +1,83 @@
+"""``gsm8k`` ships the standard 8-shot CoT examples and ``--num-shots`` trims them.
+
+The zero-shot ``generic/math`` wording ("put the answer (and only answer)
+inside \\boxed{}") makes reasoning models loop on the answer format until
+``max_tokens``; the vendored lm-eval ``gsm8k-cot`` examples are what the
+benchmark is normally run with.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sgl_eval.evals._prompts import load_few_shot_examples
+from sgl_eval.registry import get
+from sgl_eval.types import Example, GenConfig, Sample
+
+
+class _PromptCapturingSampler:
+    def __init__(self):
+        self.prompts = []
+
+    def __call__(self, messages, gen):
+        self.prompts.append(messages[0]["content"])
+        return Sample(text="\\boxed{42}", completion_tokens=3, finish_reason="stop")
+
+
+def _one_example_loader(_num_examples):
+    return [Example(id="p1", inputs={"problem": "Find n."}, target="42")]
+
+
+def _render(num_shots=None, benchmark="gsm8k"):
+    sampler = _PromptCapturingSampler()
+    kwargs = {} if num_shots is None else {"num_shots": num_shots}
+    get(benchmark).run(
+        sampler=sampler,
+        gen=GenConfig(),
+        n_repeats=1,
+        num_examples=1,
+        num_threads=1,
+        load_examples=_one_example_loader,
+        **kwargs,
+    )
+    assert len(sampler.prompts) == 1
+    return sampler.prompts[0]
+
+
+def test_vendored_set_is_the_lm_eval_cot_eight():
+    examples = load_few_shot_examples("gsm8k:gsm8k_standard_few_shot")
+    assert len(examples) == 8
+    assert examples[0]["problem"].startswith("There are 15 trees in the grove.")
+    assert all(set(ex) >= {"problem", "solution"} for ex in examples)
+    assert all("\\boxed{" in ex["solution"] for ex in examples)
+
+
+def test_gsm8k_default_prompt_is_eight_shot():
+    prompt = _render()
+    assert prompt.count("Problem:\n") == 8
+    assert "There are 15 trees in the grove." in prompt
+    # The examples block sits between the instruction and the query, as in NS.
+    assert prompt.index("inside \\boxed{}") < prompt.index("There are 15 trees")
+    assert prompt.rstrip().endswith("Here is the problem you need to solve:\nFind n.")
+
+
+def test_num_shots_trims_or_disables_the_examples():
+    assert _render(num_shots=3).count("Problem:\n") == 3
+    zero = _render(num_shots=0)
+    assert "Problem:\n" not in zero
+    assert "Here are some examples" not in zero
+    assert zero.rstrip().endswith("\\boxed{}.\n\nFind n.")
+
+
+def test_num_shots_beyond_vendored_set_fails_loudly():
+    with pytest.raises(ValueError, match="exceeds the 8"):
+        _render(num_shots=9)
+
+
+def test_benchmarks_without_examples_reject_num_shots():
+    with pytest.raises(ValueError, match="no few-shot examples"):
+        _render(num_shots=5, benchmark="aime25")
+
+
+def test_aime_stays_zero_shot():
+    assert "Problem:\n" not in _render(benchmark="aime25")


### PR DESCRIPTION
## Motivation

`gsm8k` currently renders the vendored `generic/math` prompt with no in-context examples:

> Solve the following math problem. Make sure to put the answer (and only answer) inside \boxed{}.

GSM8K is normally reported few-shot (the CoT paper and lm-eval's `gsm8k-cot` task use the same 8 worked examples), and on reasoning models the zero-shot wording is unstable: the model reaches the correct `\boxed{}` answer inside its reasoning and then keeps re-checking the answer format until `max_tokens`. Measured on Qwen3.5-397B-A17B-NVFP4-V2 (sglang, 4x GB300, TP4/EP4/DP4), 200 examples, `max_tokens=16384`, temperature 0.6 / top-p 0.95 / top-k 20 (from `generation_config.json`), same server and same scorer for every row:

| prompt | thinking | score | truncated | wrong among completed |
|---|---|---|---|---|
| zero-shot `generic/math` (current default) | on | 0.945 | 7.0% | 5 / 186 |
| zero-shot `generic/math`, greedy | on | 0.905 | 21.0% | -- |
| zero-shot `generic/math` | off | 0.890 | 0.0% | 22 / 200 |
| zero-shot, "(and only answer)" removed | on | 0.965 | 6.0% | 3 / 188 |
| `generic/math` + `gsm8k_standard_few_shot` (8-shot) in `{examples}` | on | 0.975 | 2.0% | -- |
| `generic/math` + `gsm8k_standard_few_shot` (8-shot) in `{examples}` | off | 0.985 | 0.0% | -- |

About 90% of the truncated samples already contain the correct `\boxed{}` answer; the score loss is the truncation itself. With the standard examples, thinking and non-thinking modes converge to 0.975-0.985, which also matches sglang's 5-shot chat `run_eval --eval-name gsm8k` on the same server (0.985). NeMo-Skills ships this example set (`nemo_skills/prompt/few_shot_examples/gsm8k.py`, `gsm8k_standard_few_shot`), and `generic/math` already has the `{examples}` slot for it; sgl-eval simply did not vendor or use it.

## Modifications

- Vendor `nemo_skills/prompt/few_shot_examples/gsm8k.py` at the pinned SHA (new `SOURCES.yaml` entry). Only that module is vendored; upstream's package `__init__` imports every example set, so it is replaced by a minimal local one.
- `_registry.py`: new per-row key `few_shot_examples` (`"<module>:<name>"`). `gsm8k` uses `gsm8k:gsm8k_standard_few_shot`. `_math_run` loads the set once and passes it through `run_math_benchmark` to `render_prompt`, which fills `generic/math`'s `{examples}` slot using the yaml's `few_shot_examples` template.
- `--num-shots N`: trims the set; `0` restores the zero-shot prompt. Recorded in `metrics.json` because, like `--prompt`, a different value is a different question. Benchmarks that ship no examples reject the flag.
- `benchmarks.md`: row note and a short section with the numbers above.
- `tests/test_gsm8k_few_shot.py`.

## Validation

- Unit tests: 50 passed (`test_gsm8k_few_shot`, `test_prompt_override`, `test_vendor_audit`, `test_preset`, `test_cli_partial`).
- End-to-end with this branch (default 8-shot, no `--prompt`), same server as above: thinking on 0.970 / 2.5% truncated; thinking off 0.985 / 0.0% truncated (zero-shot: 0.945 / 7.0% and 0.890 / 0.0%).
- Related sglang fix for the `chat_template_kwargs.thinking` vs `enable_thinking` mismatch that makes `--no-thinking` a no-op against Qwen templates: sgl-project/sglang#38053.
